### PR TITLE
Add hotkey manager

### DIFF
--- a/src/main/preload/ipc.ts
+++ b/src/main/preload/ipc.ts
@@ -4,6 +4,11 @@ const removeAllListeners = (channel: string) => {
   ipcRenderer.removeAllListeners(channel);
 };
 
+const send = (channel: string, ...args: any[]) => {
+  ipcRenderer.send(channel, ...args);
+};
+
 export const ipc = {
   removeAllListeners,
+  send,
 };

--- a/src/main/preload/mpv-player.ts
+++ b/src/main/preload/mpv-player.ts
@@ -1,6 +1,10 @@
 import { ipcRenderer, IpcRendererEvent } from 'electron';
 import { PlayerData } from '/@/renderer/store';
 
+const initialize = (data: { extraParameters?: string[]; properties?: Record<string, any> }) => {
+  ipcRenderer.send('player-initialize', data);
+};
+
 const restart = (data: { extraParameters?: string[]; properties?: Record<string, any> }) => {
   ipcRenderer.send('player-restart', data);
 };
@@ -98,6 +102,34 @@ const rendererStop = (cb: (event: IpcRendererEvent, data: PlayerData) => void) =
   ipcRenderer.on('renderer-player-stop', cb);
 };
 
+const rendererSkipForward = (cb: (event: IpcRendererEvent, data: PlayerData) => void) => {
+  ipcRenderer.on('renderer-player-skip-forward', cb);
+};
+
+const rendererSkipBackward = (cb: (event: IpcRendererEvent, data: PlayerData) => void) => {
+  ipcRenderer.on('renderer-player-skip-backward', cb);
+};
+
+const rendererVolumeUp = (cb: (event: IpcRendererEvent, data: PlayerData) => void) => {
+  ipcRenderer.on('renderer-player-volume-up', cb);
+};
+
+const rendererVolumeDown = (cb: (event: IpcRendererEvent, data: PlayerData) => void) => {
+  ipcRenderer.on('renderer-player-volume-down', cb);
+};
+
+const rendererVolumeMute = (cb: (event: IpcRendererEvent, data: PlayerData) => void) => {
+  ipcRenderer.on('renderer-player-volume-mute', cb);
+};
+
+const rendererToggleRepeat = (cb: (event: IpcRendererEvent, data: PlayerData) => void) => {
+  ipcRenderer.on('renderer-player-toggle-repeat', cb);
+};
+
+const rendererToggleShuffle = (cb: (event: IpcRendererEvent, data: PlayerData) => void) => {
+  ipcRenderer.on('renderer-player-toggle-shuffle', cb);
+};
+
 const rendererQuit = (cb: (event: IpcRendererEvent) => void) => {
   ipcRenderer.on('renderer-player-quit', cb);
 };
@@ -105,6 +137,7 @@ const rendererQuit = (cb: (event: IpcRendererEvent) => void) => {
 export const mpvPlayer = {
   autoNext,
   currentTime,
+  initialize,
   mute,
   next,
   pause,
@@ -130,5 +163,12 @@ export const mpvPlayerListener = {
   rendererPlayPause,
   rendererPrevious,
   rendererQuit,
+  rendererSkipBackward,
+  rendererSkipForward,
   rendererStop,
+  rendererToggleRepeat,
+  rendererToggleShuffle,
+  rendererVolumeDown,
+  rendererVolumeMute,
+  rendererVolumeUp,
 };

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -29,3 +29,24 @@ export const isWindows = () => {
 export const isLinux = () => {
   return process.platform === 'linux';
 };
+
+export const hotkeyToElectronAccelerator = (hotkey: string) => {
+  let accelerator = hotkey;
+
+  const replacements = {
+    mod: 'CmdOrCtrl',
+    numpad: 'num',
+    numpadadd: 'numadd',
+    numpaddecimal: 'numdec',
+    numpaddivide: 'numdiv',
+    numpadenter: 'numenter',
+    numpadmultiply: 'nummult',
+    numpadsubtract: 'numsub',
+  };
+
+  Object.keys(replacements).forEach((key) => {
+    accelerator = accelerator.replace(key, replacements[key as keyof typeof replacements]);
+  });
+
+  return accelerator;
+};

--- a/src/renderer/components/search-input/index.tsx
+++ b/src/renderer/components/search-input/index.tsx
@@ -3,6 +3,8 @@ import { TextInputProps } from '@mantine/core';
 import { useFocusWithin, useHotkeys, useMergedRef } from '@mantine/hooks';
 import { RiSearchLine } from 'react-icons/ri';
 import { TextInput } from '/@/renderer/components/input';
+import { useSettingsStore } from '/@/renderer/store';
+import { shallow } from 'zustand/shallow';
 
 interface SearchInputProps extends TextInputProps {
   initialWidth?: number;
@@ -18,18 +20,12 @@ export const SearchInput = ({
 }: SearchInputProps) => {
   const { ref, focused } = useFocusWithin();
   const mergedRef = useMergedRef<HTMLInputElement>(ref);
+  const binding = useSettingsStore((state) => state.hotkeys.bindings.localSearch, shallow);
 
   const isOpened = focused || ref.current?.value;
   const showIcon = !isOpened || (openedWidth || 100) > 100;
 
-  useHotkeys([
-    [
-      'ctrl+F',
-      () => {
-        ref.current.select();
-      },
-    ],
-  ]);
+  useHotkeys([[binding.hotkey, () => ref.current.select()]]);
 
   const handleEscape = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.code === 'Escape') {

--- a/src/renderer/features/player/components/center-controls.tsx
+++ b/src/renderer/features/player/components/center-controls.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useHotkeys } from '@mantine/hooks';
 import formatDuration from 'format-duration';
 import isElectron from 'is-electron';
 import { IoIosPause } from 'react-icons/io';
@@ -25,7 +26,11 @@ import {
   useShuffleStatus,
   useCurrentTime,
 } from '/@/renderer/store';
-import { usePlayerType, useSettingsStore } from '/@/renderer/store/settings.store';
+import {
+  useHotkeySettings,
+  usePlayerType,
+  useSettingsStore,
+} from '/@/renderer/store/settings.store';
 import { PlayerStatus, PlaybackType, PlayerShuffle, PlayerRepeat } from '/@/renderer/types';
 import { PlayerbarSlider } from '/@/renderer/features/player/components/playerbar-slider';
 
@@ -78,6 +83,7 @@ export const CenterControls = ({ playersRef }: CenterControlsProps) => {
   const setCurrentTime = useSetCurrentTime();
   const repeat = useRepeatStatus();
   const shuffle = useShuffleStatus();
+  const { bindings } = useHotkeySettings();
 
   const {
     handleNextTrack,
@@ -88,6 +94,9 @@ export const CenterControls = ({ playersRef }: CenterControlsProps) => {
     handleSkipForward,
     handleToggleRepeat,
     handleToggleShuffle,
+    handleStop,
+    handlePause,
+    handlePlay,
   } = useCenterControls({ playersRef });
 
   const currentTime = useCurrentTime();
@@ -112,6 +121,25 @@ export const CenterControls = ({ playersRef }: CenterControlsProps) => {
   }, [currentPlayerRef, isSeeking, setCurrentTime, playerType, status]);
 
   const [seekValue, setSeekValue] = useState(0);
+
+  useHotkeys([
+    [bindings.playPause.isGlobal ? '' : bindings.playPause.hotkey, handlePlayPause],
+    [bindings.play.isGlobal ? '' : bindings.play.hotkey, handlePlay],
+    [bindings.pause.isGlobal ? '' : bindings.pause.hotkey, handlePause],
+    [bindings.stop.isGlobal ? '' : bindings.stop.hotkey, handleStop],
+    [bindings.next.isGlobal ? '' : bindings.next.hotkey, handleNextTrack],
+    [bindings.previous.isGlobal ? '' : bindings.previous.hotkey, handlePrevTrack],
+    [bindings.toggleRepeat.isGlobal ? '' : bindings.toggleRepeat.hotkey, handleToggleRepeat],
+    [bindings.toggleShuffle.isGlobal ? '' : bindings.toggleShuffle.hotkey, handleToggleShuffle],
+    [
+      bindings.skipBackward.isGlobal ? '' : bindings.skipBackward.hotkey,
+      () => handleSkipBackward(skip?.skipBackwardSeconds || 5),
+    ],
+    [
+      bindings.skipForward.isGlobal ? '' : bindings.skipForward.hotkey,
+      () => handleSkipForward(skip?.skipForwardSeconds || 5),
+    ],
+  ]);
 
   return (
     <>

--- a/src/renderer/features/player/components/left-controls.tsx
+++ b/src/renderer/features/player/components/left-controls.tsx
@@ -1,5 +1,6 @@
 import React, { MouseEvent } from 'react';
 import { Center, Group } from '@mantine/core';
+import { useHotkeys } from '@mantine/hooks';
 import { motion, AnimatePresence, LayoutGroup } from 'framer-motion';
 import { RiArrowUpSLine, RiDiscLine, RiMore2Fill } from 'react-icons/ri';
 import { generatePath, Link } from 'react-router-dom';
@@ -12,6 +13,7 @@ import {
   useSetFullScreenPlayerStore,
   useFullScreenPlayerStore,
   useSidebarStore,
+  useHotkeySettings,
 } from '/@/renderer/store';
 import { fadeIn } from '/@/renderer/styles';
 import { LibraryItem } from '/@/renderer/api/types';
@@ -91,6 +93,7 @@ export const LeftControls = () => {
   const currentSong = useCurrentSong();
   const title = currentSong?.name;
   const artists = currentSong?.artists;
+  const { bindings } = useHotkeySettings();
 
   const isSongDefined = Boolean(currentSong?.id);
 
@@ -99,15 +102,22 @@ export const LeftControls = () => {
     SONG_CONTEXT_MENU_ITEMS,
   );
 
-  const handleToggleFullScreenPlayer = (e: MouseEvent<HTMLDivElement>) => {
-    e.stopPropagation();
+  const handleToggleFullScreenPlayer = (e?: MouseEvent<HTMLDivElement> | KeyboardEvent) => {
+    e?.stopPropagation();
     setFullScreenPlayerStore({ expanded: !isFullScreenPlayerExpanded });
   };
 
-  const handleToggleSidebarImage = (e: MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation();
+  const handleToggleSidebarImage = (e?: MouseEvent<HTMLButtonElement>) => {
+    e?.stopPropagation();
     setSideBar({ image: true });
   };
+
+  useHotkeys([
+    [
+      bindings.toggleFullscreenPlayer.allowGlobal ? '' : bindings.toggleFullscreenPlayer.hotkey,
+      handleToggleFullScreenPlayer,
+    ],
+  ]);
 
   return (
     <LeftControlsContainer>

--- a/src/renderer/features/player/components/right-controls.tsx
+++ b/src/renderer/features/player/components/right-controls.tsx
@@ -1,5 +1,6 @@
 import { MouseEvent } from 'react';
 import { Flex, Group } from '@mantine/core';
+import { useHotkeys } from '@mantine/hooks';
 import { HiOutlineQueueList } from 'react-icons/hi2';
 import {
   RiVolumeUpFill,
@@ -12,6 +13,7 @@ import {
   useAppStoreActions,
   useCurrentServer,
   useCurrentSong,
+  useHotkeySettings,
   useMuted,
   useSidebarStore,
   useVolume,
@@ -30,7 +32,9 @@ export const RightControls = () => {
   const currentSong = useCurrentSong();
   const { setSideBar } = useAppStoreActions();
   const { rightExpanded: isQueueExpanded } = useSidebarStore();
-  const { handleVolumeSlider, handleVolumeWheel, handleMute } = useRightControls();
+  const { bindings } = useHotkeySettings();
+  const { handleVolumeSlider, handleVolumeWheel, handleMute, handleVolumeDown, handleVolumeUp } =
+    useRightControls();
 
   const updateRatingMutation = useSetRating({});
   const addToFavoritesMutation = useCreateFavorite({});
@@ -94,8 +98,19 @@ export const RightControls = () => {
     }
   };
 
+  const handleToggleQueue = () => {
+    setSideBar({ rightExpanded: !isQueueExpanded });
+  };
+
   const isSongDefined = Boolean(currentSong?.id);
   const showRating = isSongDefined && server?.type === ServerType.NAVIDROME;
+
+  useHotkeys([
+    [bindings.volumeDown.isGlobal ? '' : bindings.volumeDown.hotkey, handleVolumeDown],
+    [bindings.volumeUp.isGlobal ? '' : bindings.volumeUp.hotkey, handleVolumeUp],
+    [bindings.volumeMute.isGlobal ? '' : bindings.volumeMute.hotkey, handleMute],
+    [bindings.toggleQueue.isGlobal ? '' : bindings.toggleQueue.hotkey, handleToggleQueue],
+  ]);
 
   return (
     <Flex
@@ -147,7 +162,7 @@ export const RightControls = () => {
           icon={<HiOutlineQueueList size="1.1rem" />}
           tooltip={{ label: 'View queue', openDelay: 500 }}
           variant="secondary"
-          onClick={() => setSideBar({ rightExpanded: !isQueueExpanded })}
+          onClick={handleToggleQueue}
         />
         <Group
           noWrap

--- a/src/renderer/features/player/hooks/use-center-controls.ts
+++ b/src/renderer/features/player/hooks/use-center-controls.ts
@@ -564,6 +564,14 @@ export const useCenterControls = (args: { playersRef: any }) => {
       mpvPlayerListener.rendererQuit(() => {
         handleQuit();
       });
+
+      mpvPlayerListener.rendererToggleShuffle(() => {
+        handleToggleShuffle();
+      });
+
+      mpvPlayerListener.rendererToggleRepeat(() => {
+        handleToggleRepeat();
+      });
     }
 
     return () => {
@@ -576,6 +584,8 @@ export const useCenterControls = (args: { playersRef: any }) => {
       ipc?.removeAllListeners('renderer-player-current-time');
       ipc?.removeAllListeners('renderer-player-auto-next');
       ipc?.removeAllListeners('renderer-player-quit');
+      ipc?.removeAllListeners('renderer-player-toggle-shuffle');
+      ipc?.removeAllListeners('renderer-player-toggle-repeat');
     };
   }, [
     autoNext,
@@ -587,6 +597,8 @@ export const useCenterControls = (args: { playersRef: any }) => {
     handlePrevTrack,
     handleQuit,
     handleStop,
+    handleToggleRepeat,
+    handleToggleShuffle,
     isMpvPlayer,
     next,
     pause,
@@ -684,6 +696,8 @@ export const useCenterControls = (args: { playersRef: any }) => {
 
   return {
     handleNextTrack,
+    handlePause,
+    handlePlay,
     handlePlayPause,
     handlePrevTrack,
     handleSeekSlider,

--- a/src/renderer/features/player/hooks/use-right-controls.ts
+++ b/src/renderer/features/player/hooks/use-right-controls.ts
@@ -1,9 +1,35 @@
-import { useEffect, WheelEvent } from 'react';
+import { useCallback, useEffect, WheelEvent } from 'react';
 import isElectron from 'is-electron';
 import { useMuted, usePlayerControls, useVolume } from '/@/renderer/store';
 import { useGeneralSettings } from '/@/renderer/store/settings.store';
 
 const mpvPlayer = isElectron() ? window.electron.mpvPlayer : null;
+const mpvPlayerListener = isElectron() ? window.electron.mpvPlayerListener : null;
+const ipc = isElectron() ? window.electron.ipc : null;
+
+const calculateVolumeUp = (volume: number, volumeWheelStep: number) => {
+  let volumeToSet;
+  const newVolumeGreaterThanHundred = volume + volumeWheelStep > 100;
+  if (newVolumeGreaterThanHundred) {
+    volumeToSet = 100;
+  } else {
+    volumeToSet = volume + volumeWheelStep;
+  }
+
+  return volumeToSet;
+};
+
+const calculateVolumeDown = (volume: number, volumeWheelStep: number) => {
+  let volumeToSet;
+  const newVolumeLessThanZero = volume - volumeWheelStep < 0;
+  if (newVolumeLessThanZero) {
+    volumeToSet = 0;
+  } else {
+    volumeToSet = volume - volumeWheelStep;
+  }
+
+  return volumeToSet;
+};
 
 export const useRightControls = () => {
   const { setVolume, setMuted } = usePlayerControls();
@@ -33,37 +59,66 @@ export const useRightControls = () => {
     setVolume(e);
   };
 
-  const handleVolumeWheel = (e: WheelEvent<HTMLDivElement>) => {
-    let volumeToSet;
-    if (e.deltaY > 0) {
-      const newVolumeLessThanZero = volume - volumeWheelStep < 0;
-      if (newVolumeLessThanZero) {
-        volumeToSet = 0;
-      } else {
-        volumeToSet = volume - volumeWheelStep;
-      }
-    } else {
-      const newVolumeGreaterThanHundred = volume + volumeWheelStep > 100;
-      if (newVolumeGreaterThanHundred) {
-        volumeToSet = 100;
-      } else {
-        volumeToSet = volume + volumeWheelStep;
-      }
-    }
-
+  const handleVolumeDown = useCallback(() => {
+    const volumeToSet = calculateVolumeDown(volume, volumeWheelStep);
     mpvPlayer?.volume(volumeToSet);
     setVolume(volumeToSet);
-  };
+  }, [setVolume, volume, volumeWheelStep]);
 
-  const handleMute = () => {
+  const handleVolumeUp = useCallback(() => {
+    const volumeToSet = calculateVolumeUp(volume, volumeWheelStep);
+    mpvPlayer?.volume(volumeToSet);
+    setVolume(volumeToSet);
+  }, [setVolume, volume, volumeWheelStep]);
+
+  const handleVolumeWheel = useCallback(
+    (e: WheelEvent<HTMLDivElement>) => {
+      let volumeToSet;
+      if (e.deltaY > 0) {
+        volumeToSet = calculateVolumeDown(volume, volumeWheelStep);
+      } else {
+        volumeToSet = calculateVolumeUp(volume, volumeWheelStep);
+      }
+
+      mpvPlayer?.volume(volumeToSet);
+      setVolume(volumeToSet);
+    },
+    [setVolume, volume, volumeWheelStep],
+  );
+
+  const handleMute = useCallback(() => {
     setMuted(!muted);
     mpvPlayer?.mute();
-  };
+  }, [muted, setMuted]);
+
+  useEffect(() => {
+    if (isElectron()) {
+      mpvPlayerListener?.rendererVolumeMute(() => {
+        handleMute();
+      });
+
+      mpvPlayerListener?.rendererVolumeUp(() => {
+        handleVolumeUp();
+      });
+
+      mpvPlayerListener?.rendererVolumeDown(() => {
+        handleVolumeDown();
+      });
+    }
+
+    return () => {
+      ipc?.removeAllListeners('renderer-player-volume-mute');
+      ipc?.removeAllListeners('renderer-player-volume-up');
+      ipc?.removeAllListeners('renderer-player-volume-down');
+    };
+  }, [handleMute, handleVolumeDown, handleVolumeUp]);
 
   return {
     handleMute,
+    handleVolumeDown,
     handleVolumeSlider,
     handleVolumeSliderState,
+    handleVolumeUp,
     handleVolumeWheel,
   };
 };

--- a/src/renderer/features/settings/components/hotkeys/hotkey-manager-settings.tsx
+++ b/src/renderer/features/settings/components/hotkeys/hotkey-manager-settings.tsx
@@ -1,0 +1,222 @@
+import { Group } from '@mantine/core';
+import { useCallback, useMemo, useState } from 'react';
+import { RiDeleteBinLine, RiEditLine, RiKeyboardBoxLine } from 'react-icons/ri';
+import styled from 'styled-components';
+import { Button, TextInput, Checkbox } from '/@/renderer/components';
+import isElectron from 'is-electron';
+import { BindingActions, useHotkeySettings, useSettingsStoreActions } from '/@/renderer/store';
+import { SettingsOptions } from '/@/renderer/features/settings/components/settings-option';
+
+const ipc = isElectron() ? window.electron.ipc : null;
+
+const BINDINGS_MAP: Record<BindingActions, string> = {
+  globalSearch: 'Global search',
+  localSearch: 'In-page search',
+  next: 'Next track',
+  pause: 'Pause',
+  play: 'Play',
+  playPause: 'Play / Pause',
+  previous: 'Previous track',
+  skipBackward: 'Skip backward',
+  skipForward: 'Skip forward',
+  stop: 'Stop',
+  toggleFullscreenPlayer: 'Toggle fullscreen player',
+  toggleQueue: 'Toggle queue',
+  toggleRepeat: 'Toggle repeat',
+  toggleShuffle: 'Toggle shuffle',
+  volumeDown: 'Volume down',
+  volumeMute: 'Volume mute',
+  volumeUp: 'Volume up',
+};
+
+const HotkeysContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  justify-content: center;
+  width: 100%;
+
+  button {
+    padding: 0 1rem;
+  }
+`;
+
+export const HotkeyManagerSettings = () => {
+  const { bindings, globalMediaHotkeys } = useHotkeySettings();
+  const { setSettings } = useSettingsStoreActions();
+  const [selected, setSelected] = useState<BindingActions | null>(null);
+
+  const handleSetHotkey = useCallback(
+    (binding: BindingActions, e: React.KeyboardEvent<HTMLInputElement>) => {
+      e.preventDefault();
+      const IGNORED_KEYS = ['Control', 'Alt', 'Shift', 'Meta', ' ', 'Escape'];
+      const keys = [];
+      if (e.ctrlKey) keys.push('mod');
+      if (e.altKey) keys.push('alt');
+      if (e.shiftKey) keys.push('shift');
+      if (e.metaKey) keys.push('meta');
+      if (e.key === ' ') keys.push('space');
+      if (!IGNORED_KEYS.includes(e.key)) {
+        if (e.code.includes('Numpad')) {
+          if (e.key === '+') keys.push('numpadadd');
+          else if (e.key === '-') keys.push('numpadsubtract');
+          else if (e.key === '*') keys.push('numpadmultiply');
+          else if (e.key === '/') keys.push('numpaddivide');
+          else if (e.key === '.') keys.push('numpaddecimal');
+          else keys.push(`numpad${e.key}`.toLowerCase());
+        } else {
+          keys.push(e.key?.toLowerCase());
+        }
+      }
+
+      const bindingString = keys.join('+');
+
+      const updatedBindings = {
+        ...bindings,
+        [binding]: { ...bindings[binding], hotkey: bindingString },
+      };
+
+      setSettings({
+        hotkeys: {
+          bindings: updatedBindings,
+          globalMediaHotkeys,
+        },
+      });
+
+      ipc?.send('set-global-shortcuts', updatedBindings);
+    },
+    [bindings, globalMediaHotkeys, setSettings],
+  );
+
+  const handleSetGlobalHotkey = useCallback(
+    (binding: BindingActions, e: React.ChangeEvent<HTMLInputElement>) => {
+      const updatedBindings = {
+        ...bindings,
+        [binding]: { ...bindings[binding], isGlobal: e.currentTarget.checked },
+      };
+
+      console.log('updatedBindings :>> ', updatedBindings);
+
+      setSettings({
+        hotkeys: {
+          bindings: updatedBindings,
+          globalMediaHotkeys,
+        },
+      });
+
+      ipc?.send('set-global-shortcuts', updatedBindings);
+    },
+    [bindings, globalMediaHotkeys, setSettings],
+  );
+
+  const handleClearHotkey = useCallback(
+    (binding: BindingActions) => {
+      const updatedBindings = {
+        ...bindings,
+        [binding]: { ...bindings[binding], hotkey: '', isGlobal: false },
+      };
+
+      setSettings({
+        hotkeys: {
+          bindings: updatedBindings,
+          globalMediaHotkeys,
+        },
+      });
+
+      ipc?.send('set-global-shortcuts', updatedBindings);
+    },
+    [bindings, globalMediaHotkeys, setSettings],
+  );
+
+  const duplicateHotkeyMap = useMemo(() => {
+    const countPerHotkey = Object.values(bindings).reduce((acc, key) => {
+      const hotkey = key.hotkey;
+      if (!hotkey) return acc;
+
+      if (acc[hotkey]) {
+        acc[hotkey] += 1;
+      } else {
+        acc[hotkey] = 1;
+      }
+
+      return acc;
+    }, {} as Record<string, number>);
+
+    const duplicateKeys = Object.keys(countPerHotkey).filter((key) => countPerHotkey[key] > 1);
+
+    return duplicateKeys;
+  }, [bindings]);
+
+  return (
+    <>
+      <SettingsOptions
+        control={<></>}
+        description="Configure application hotkeys. Toggle the checkbox to set as a global hotkey (desktop only)"
+        title="Application hotkeys"
+      />
+      <HotkeysContainer>
+        {Object.keys(bindings)
+          .filter((binding) => BINDINGS_MAP[binding as keyof typeof BINDINGS_MAP])
+          .map((binding) => (
+            <Group
+              key={`hotkey-${binding}`}
+              noWrap
+            >
+              <TextInput
+                readOnly
+                style={{ userSelect: 'none' }}
+                value={BINDINGS_MAP[binding as keyof typeof BINDINGS_MAP]}
+              />
+              <TextInput
+                readOnly
+                icon={<RiKeyboardBoxLine />}
+                id={`hotkey-${binding}`}
+                style={{
+                  opacity: selected === (binding as BindingActions) ? 0.8 : 1,
+                  outline: duplicateHotkeyMap.includes(
+                    bindings[binding as keyof typeof BINDINGS_MAP].hotkey!,
+                  )
+                    ? '1px dashed red'
+                    : undefined,
+                }}
+                value={bindings[binding as keyof typeof BINDINGS_MAP].hotkey}
+                onBlur={() => setSelected(null)}
+                onChange={() => {}}
+                onKeyDownCapture={(e) => {
+                  if (selected !== (binding as BindingActions)) return;
+                  handleSetHotkey(binding as BindingActions, e);
+                }}
+              />
+              {isElectron() && (
+                <Checkbox
+                  checked={bindings[binding as keyof typeof BINDINGS_MAP].isGlobal}
+                  disabled={bindings[binding as keyof typeof BINDINGS_MAP].hotkey === ''}
+                  size="xl"
+                  style={{
+                    opacity: bindings[binding as keyof typeof BINDINGS_MAP].allowGlobal ? 1 : 0,
+                  }}
+                  onChange={(e) => handleSetGlobalHotkey(binding as BindingActions, e)}
+                />
+              )}
+              <Button
+                variant="default"
+                w={100}
+                onClick={() => {
+                  setSelected(binding as BindingActions);
+                  document.getElementById(`hotkey-${binding}`)?.focus();
+                }}
+              >
+                <RiEditLine />
+              </Button>
+              <Button
+                variant="default"
+                onClick={() => handleClearHotkey(binding as BindingActions)}
+              >
+                <RiDeleteBinLine />
+              </Button>
+            </Group>
+          ))}
+      </HotkeysContainer>
+    </>
+  );
+};

--- a/src/renderer/features/settings/components/hotkeys/hotkeys-tab.tsx
+++ b/src/renderer/features/settings/components/hotkeys/hotkeys-tab.tsx
@@ -1,10 +1,13 @@
-import { Stack } from '@mantine/core';
+import { Divider, Stack } from '@mantine/core';
 import { WindowHotkeySettings } from './window-hotkey-settings';
+import { HotkeyManagerSettings } from '/@/renderer/features/settings/components/hotkeys/hotkey-manager-settings';
 
 export const HotkeysTab = () => {
   return (
     <Stack spacing="md">
       <WindowHotkeySettings />
+      <Divider />
+      <HotkeyManagerSettings />
     </Stack>
   );
 };

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -42,6 +42,26 @@ type MpvSettings = {
   replayGainPreampDB?: number;
 };
 
+export enum BindingActions {
+  GLOBAL_SEARCH = 'globalSearch',
+  LOCAL_SEARCH = 'localSearch',
+  MUTE = 'volumeMute',
+  NEXT = 'next',
+  PAUSE = 'pause',
+  PLAY = 'play',
+  PLAY_PAUSE = 'playPause',
+  PREVIOUS = 'previous',
+  SHUFFLE = 'toggleShuffle',
+  SKIP_BACKWARD = 'skipBackward',
+  SKIP_FORWARD = 'skipForward',
+  STOP = 'stop',
+  TOGGLE_FULLSCREEN_PLAYER = 'toggleFullscreenPlayer',
+  TOGGLE_QUEUE = 'toggleQueue',
+  TOGGLE_REPEAT = 'toggleRepeat',
+  VOLUME_DOWN = 'volumeDown',
+  VOLUME_UP = 'volumeUp',
+}
+
 export interface SettingsState {
   general: {
     followSystemTheme: boolean;
@@ -60,6 +80,7 @@ export interface SettingsState {
     volumeWheelStep: number;
   };
   hotkeys: {
+    bindings: Record<BindingActions, { allowGlobal: boolean; hotkey: string; isGlobal: boolean }>;
     globalMediaHotkeys: boolean;
   };
   playback: {
@@ -118,6 +139,25 @@ const initialState: SettingsState = {
     volumeWheelStep: 5,
   },
   hotkeys: {
+    bindings: {
+      globalSearch: { allowGlobal: false, hotkey: 'mod+k', isGlobal: false },
+      localSearch: { allowGlobal: false, hotkey: 'mod+f', isGlobal: false },
+      next: { allowGlobal: true, hotkey: '', isGlobal: false },
+      pause: { allowGlobal: true, hotkey: '', isGlobal: false },
+      play: { allowGlobal: true, hotkey: '', isGlobal: false },
+      playPause: { allowGlobal: true, hotkey: '', isGlobal: false },
+      previous: { allowGlobal: true, hotkey: '', isGlobal: false },
+      skipBackward: { allowGlobal: true, hotkey: '', isGlobal: false },
+      skipForward: { allowGlobal: true, hotkey: '', isGlobal: false },
+      stop: { allowGlobal: true, hotkey: '', isGlobal: false },
+      toggleFullscreenPlayer: { allowGlobal: false, hotkey: '', isGlobal: false },
+      toggleQueue: { allowGlobal: false, hotkey: '', isGlobal: false },
+      toggleRepeat: { allowGlobal: true, hotkey: '', isGlobal: false },
+      toggleShuffle: { allowGlobal: true, hotkey: '', isGlobal: false },
+      volumeDown: { allowGlobal: true, hotkey: '', isGlobal: false },
+      volumeMute: { allowGlobal: true, hotkey: '', isGlobal: false },
+      volumeUp: { allowGlobal: true, hotkey: '', isGlobal: false },
+    },
     globalMediaHotkeys: false,
   },
   playback: {


### PR DESCRIPTION
Closes #84 

![image](https://github.com/jeffvli/feishin/assets/42182408/985254e7-e5fc-4234-8bf3-aced1c576def)

Adds a global hotkey manager for app-specific commands. Allows for local (requires app focus) and global hotkeys (only desktop/electron).