### PR TITLE
Add global search / command palette

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@tanstack/react-query-devtools": "^4.29.6",
         "@ts-rest/core": "^3.19.4",
         "axios": "^1.4.0",
+        "cmdk": "^0.2.0",
         "dayjs": "^1.11.6",
         "electron-debug": "^3.2.0",
         "electron-localshortcut": "^3.2.1",
@@ -2534,12 +2535,230 @@
         "react": "^16.8 || ^17.0 || ^18.0"
       }
     },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.0.0.tgz",
+      "integrity": "sha512-Yn9YU+QlHYLWwV1XfKiqnGVpWYWk6MeBVM6x/bcoyPvxgjQGoeT35482viLPctTMWoMw0PoHgqfSox7Ig+957Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.0",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-context": "1.0.0",
+        "@radix-ui/react-dismissable-layer": "1.0.0",
+        "@radix-ui/react-focus-guards": "1.0.0",
+        "@radix-ui/react-focus-scope": "1.0.0",
+        "@radix-ui/react-id": "1.0.0",
+        "@radix-ui/react-portal": "1.0.0",
+        "@radix-ui/react-presence": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.0",
+        "@radix-ui/react-slot": "1.0.0",
+        "@radix-ui/react-use-controllable-state": "1.0.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.4"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.0.tgz",
+      "integrity": "sha512-EyXe6mnRlHZ8b6f4ilTDrXmkLShICIuOTTj0GX4w1rp+wSxf3+TD05u1UOITC8VsJ2a9nwHvdXtOXEOl0Cw/zQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-slot": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.0.tgz",
+      "integrity": "sha512-3mrKauI/tWXo1Ll+gN5dHcxDPdm/Df1ufcDLCecn+pnCIVcdWE7CujXo8QaXOWRJyZyQWWbpB8eFwHzWXlv5mQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/react-remove-scroll": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.4.tgz",
+      "integrity": "sha512-xGVKJJr0SJGQVirVFAUZ2k1QLyO6m+2fy0l8Qawbp5Jgrv3DeLalrfMNBFSlmz5kriGGzsVBtGVnf4pTKIhhWA==",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.3",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-direction": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.0.tgz",
       "integrity": "sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.0.tgz",
+      "integrity": "sha512-n7kDRfx+LB1zLueRDvZ1Pd0bxdJWDUZNQ/GWoxDn2prnuJKRdxsjulejX/ePkOsLi2tTm6P24mDqlMSgQpsT6g==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.0",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.0",
+        "@radix-ui/react-use-callback-ref": "1.0.0",
+        "@radix-ui/react-use-escape-keydown": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-primitive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.0.tgz",
+      "integrity": "sha512-EyXe6mnRlHZ8b6f4ilTDrXmkLShICIuOTTj0GX4w1rp+wSxf3+TD05u1UOITC8VsJ2a9nwHvdXtOXEOl0Cw/zQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-slot": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-slot": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.0.tgz",
+      "integrity": "sha512-3mrKauI/tWXo1Ll+gN5dHcxDPdm/Df1ufcDLCecn+pnCIVcdWE7CujXo8QaXOWRJyZyQWWbpB8eFwHzWXlv5mQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.0.tgz",
+      "integrity": "sha512-UagjDk4ijOAnGu4WMUPj9ahi7/zJJqNZ9ZAiGPp7waUWJO0O1aWXi/udPphI0IUjvrhBsZJGSN66dR2dsueLWQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.0.tgz",
+      "integrity": "sha512-C4SWtsULLGf/2L4oGeIHlvWQx7Rf+7cX/vKOAD2dXW0A1b5QXwi3wWeaEgW+wn+SEVrraMUk05vLU9fZZz5HbQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.0",
+        "@radix-ui/react-use-callback-ref": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-primitive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.0.tgz",
+      "integrity": "sha512-EyXe6mnRlHZ8b6f4ilTDrXmkLShICIuOTTj0GX4w1rp+wSxf3+TD05u1UOITC8VsJ2a9nwHvdXtOXEOl0Cw/zQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-slot": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-slot": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.0.tgz",
+      "integrity": "sha512-3mrKauI/tWXo1Ll+gN5dHcxDPdm/Df1ufcDLCecn+pnCIVcdWE7CujXo8QaXOWRJyZyQWWbpB8eFwHzWXlv5mQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.0.tgz",
+      "integrity": "sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-layout-effect": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.0.0.tgz",
+      "integrity": "sha512-a8qyFO/Xb99d8wQdu4o7qnigNjTPG123uADNecz0eX4usnQEj7o+cG4ZX4zkqq98NYekT7UoEQIjxBNWIFuqTA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-primitive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.0.tgz",
+      "integrity": "sha512-EyXe6mnRlHZ8b6f4ilTDrXmkLShICIuOTTj0GX4w1rp+wSxf3+TD05u1UOITC8VsJ2a9nwHvdXtOXEOl0Cw/zQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-slot": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-slot": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.0.tgz",
+      "integrity": "sha512-3mrKauI/tWXo1Ll+gN5dHcxDPdm/Df1ufcDLCecn+pnCIVcdWE7CujXo8QaXOWRJyZyQWWbpB8eFwHzWXlv5mQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.0"
       },
       "peerDependencies": {
         "react": "^16.8 || ^17.0 || ^18.0"
@@ -2611,6 +2830,30 @@
       "integrity": "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.0.tgz",
+      "integrity": "sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-callback-ref": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.0.tgz",
+      "integrity": "sha512-JwfBCUIfhXRxKExgIqGa4CQsiMemo1Xt0W/B4ei3fpzpvPENKpMKQ8mZSB6Acj3ebrAEgi2xiQvcI1PAAodvyg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-callback-ref": "1.0.0"
       },
       "peerDependencies": {
         "react": "^16.8 || ^17.0 || ^18.0"
@@ -6110,6 +6353,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/cmdk": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-0.2.0.tgz",
+      "integrity": "sha512-JQpKvEOb86SnvMZbYaFKYhvzFntWBeSZdyii0rZPhKJj9uwJBxu4DaVYDrRN7r3mPop56oPhRw+JYWTKs66TYw==",
+      "dependencies": {
+        "@radix-ui/react-dialog": "1.0.0",
+        "command-score": "0.1.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -6198,6 +6454,11 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/command-score": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/command-score/-/command-score-0.1.2.tgz",
+      "integrity": "sha512-VtDvQpIJBvBatnONUsPzXYFVKQQAhuf3XTNOAsdBxCNO/QCtUUd8LSgjn0GVarBkCad6aJCZfXgrjYbl/KRr7w=="
     },
     "node_modules/commander": {
       "version": "5.1.0",
@@ -25175,12 +25436,176 @@
         "@babel/runtime": "^7.13.10"
       }
     },
+    "@radix-ui/react-dialog": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.0.0.tgz",
+      "integrity": "sha512-Yn9YU+QlHYLWwV1XfKiqnGVpWYWk6MeBVM6x/bcoyPvxgjQGoeT35482viLPctTMWoMw0PoHgqfSox7Ig+957Q==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.0",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-context": "1.0.0",
+        "@radix-ui/react-dismissable-layer": "1.0.0",
+        "@radix-ui/react-focus-guards": "1.0.0",
+        "@radix-ui/react-focus-scope": "1.0.0",
+        "@radix-ui/react-id": "1.0.0",
+        "@radix-ui/react-portal": "1.0.0",
+        "@radix-ui/react-presence": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.0",
+        "@radix-ui/react-slot": "1.0.0",
+        "@radix-ui/react-use-controllable-state": "1.0.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.4"
+      },
+      "dependencies": {
+        "@radix-ui/react-primitive": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.0.tgz",
+          "integrity": "sha512-EyXe6mnRlHZ8b6f4ilTDrXmkLShICIuOTTj0GX4w1rp+wSxf3+TD05u1UOITC8VsJ2a9nwHvdXtOXEOl0Cw/zQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@radix-ui/react-slot": "1.0.0"
+          }
+        },
+        "@radix-ui/react-slot": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.0.tgz",
+          "integrity": "sha512-3mrKauI/tWXo1Ll+gN5dHcxDPdm/Df1ufcDLCecn+pnCIVcdWE7CujXo8QaXOWRJyZyQWWbpB8eFwHzWXlv5mQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@radix-ui/react-compose-refs": "1.0.0"
+          }
+        },
+        "react-remove-scroll": {
+          "version": "2.5.4",
+          "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.4.tgz",
+          "integrity": "sha512-xGVKJJr0SJGQVirVFAUZ2k1QLyO6m+2fy0l8Qawbp5Jgrv3DeLalrfMNBFSlmz5kriGGzsVBtGVnf4pTKIhhWA==",
+          "requires": {
+            "react-remove-scroll-bar": "^2.3.3",
+            "react-style-singleton": "^2.2.1",
+            "tslib": "^2.1.0",
+            "use-callback-ref": "^1.3.0",
+            "use-sidecar": "^1.1.2"
+          }
+        }
+      }
+    },
     "@radix-ui/react-direction": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.0.tgz",
       "integrity": "sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ==",
       "requires": {
         "@babel/runtime": "^7.13.10"
+      }
+    },
+    "@radix-ui/react-dismissable-layer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.0.tgz",
+      "integrity": "sha512-n7kDRfx+LB1zLueRDvZ1Pd0bxdJWDUZNQ/GWoxDn2prnuJKRdxsjulejX/ePkOsLi2tTm6P24mDqlMSgQpsT6g==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.0",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.0",
+        "@radix-ui/react-use-callback-ref": "1.0.0",
+        "@radix-ui/react-use-escape-keydown": "1.0.0"
+      },
+      "dependencies": {
+        "@radix-ui/react-primitive": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.0.tgz",
+          "integrity": "sha512-EyXe6mnRlHZ8b6f4ilTDrXmkLShICIuOTTj0GX4w1rp+wSxf3+TD05u1UOITC8VsJ2a9nwHvdXtOXEOl0Cw/zQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@radix-ui/react-slot": "1.0.0"
+          }
+        },
+        "@radix-ui/react-slot": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.0.tgz",
+          "integrity": "sha512-3mrKauI/tWXo1Ll+gN5dHcxDPdm/Df1ufcDLCecn+pnCIVcdWE7CujXo8QaXOWRJyZyQWWbpB8eFwHzWXlv5mQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@radix-ui/react-compose-refs": "1.0.0"
+          }
+        }
+      }
+    },
+    "@radix-ui/react-focus-guards": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.0.tgz",
+      "integrity": "sha512-UagjDk4ijOAnGu4WMUPj9ahi7/zJJqNZ9ZAiGPp7waUWJO0O1aWXi/udPphI0IUjvrhBsZJGSN66dR2dsueLWQ==",
+      "requires": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
+    "@radix-ui/react-focus-scope": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.0.tgz",
+      "integrity": "sha512-C4SWtsULLGf/2L4oGeIHlvWQx7Rf+7cX/vKOAD2dXW0A1b5QXwi3wWeaEgW+wn+SEVrraMUk05vLU9fZZz5HbQ==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.0",
+        "@radix-ui/react-use-callback-ref": "1.0.0"
+      },
+      "dependencies": {
+        "@radix-ui/react-primitive": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.0.tgz",
+          "integrity": "sha512-EyXe6mnRlHZ8b6f4ilTDrXmkLShICIuOTTj0GX4w1rp+wSxf3+TD05u1UOITC8VsJ2a9nwHvdXtOXEOl0Cw/zQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@radix-ui/react-slot": "1.0.0"
+          }
+        },
+        "@radix-ui/react-slot": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.0.tgz",
+          "integrity": "sha512-3mrKauI/tWXo1Ll+gN5dHcxDPdm/Df1ufcDLCecn+pnCIVcdWE7CujXo8QaXOWRJyZyQWWbpB8eFwHzWXlv5mQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@radix-ui/react-compose-refs": "1.0.0"
+          }
+        }
+      }
+    },
+    "@radix-ui/react-id": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.0.tgz",
+      "integrity": "sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-layout-effect": "1.0.0"
+      }
+    },
+    "@radix-ui/react-portal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.0.0.tgz",
+      "integrity": "sha512-a8qyFO/Xb99d8wQdu4o7qnigNjTPG123uADNecz0eX4usnQEj7o+cG4ZX4zkqq98NYekT7UoEQIjxBNWIFuqTA==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.0"
+      },
+      "dependencies": {
+        "@radix-ui/react-primitive": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.0.tgz",
+          "integrity": "sha512-EyXe6mnRlHZ8b6f4ilTDrXmkLShICIuOTTj0GX4w1rp+wSxf3+TD05u1UOITC8VsJ2a9nwHvdXtOXEOl0Cw/zQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@radix-ui/react-slot": "1.0.0"
+          }
+        },
+        "@radix-ui/react-slot": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.0.tgz",
+          "integrity": "sha512-3mrKauI/tWXo1Ll+gN5dHcxDPdm/Df1ufcDLCecn+pnCIVcdWE7CujXo8QaXOWRJyZyQWWbpB8eFwHzWXlv5mQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@radix-ui/react-compose-refs": "1.0.0"
+          }
+        }
       }
     },
     "@radix-ui/react-presence": {
@@ -25234,6 +25659,24 @@
       "integrity": "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==",
       "requires": {
         "@babel/runtime": "^7.13.10"
+      }
+    },
+    "@radix-ui/react-use-controllable-state": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.0.tgz",
+      "integrity": "sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-callback-ref": "1.0.0"
+      }
+    },
+    "@radix-ui/react-use-escape-keydown": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.0.tgz",
+      "integrity": "sha512-JwfBCUIfhXRxKExgIqGa4CQsiMemo1Xt0W/B4ei3fpzpvPENKpMKQ8mZSB6Acj3ebrAEgi2xiQvcI1PAAodvyg==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-callback-ref": "1.0.0"
       }
     },
     "@radix-ui/react-use-layout-effect": {
@@ -27993,6 +28436,15 @@
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
       "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
     },
+    "cmdk": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-0.2.0.tgz",
+      "integrity": "sha512-JQpKvEOb86SnvMZbYaFKYhvzFntWBeSZdyii0rZPhKJj9uwJBxu4DaVYDrRN7r3mPop56oPhRw+JYWTKs66TYw==",
+      "requires": {
+        "@radix-ui/react-dialog": "1.0.0",
+        "command-score": "0.1.2"
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -28061,6 +28513,11 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "command-score": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/command-score/-/command-score-0.1.2.tgz",
+      "integrity": "sha512-VtDvQpIJBvBatnONUsPzXYFVKQQAhuf3XTNOAsdBxCNO/QCtUUd8LSgjn0GVarBkCad6aJCZfXgrjYbl/KRr7w=="
     },
     "commander": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -265,6 +265,7 @@
     "@tanstack/react-query-devtools": "^4.29.6",
     "@ts-rest/core": "^3.19.4",
     "axios": "^1.4.0",
+    "cmdk": "^0.2.0",
     "dayjs": "^1.11.6",
     "electron-debug": "^3.2.0",
     "electron-localshortcut": "^3.2.1",

--- a/src/renderer/api/controller.ts
+++ b/src/renderer/api/controller.ts
@@ -256,6 +256,15 @@ const getSongList = async (args: SongListArgs) => {
   )?.(args);
 };
 
+const getSongDetail = async (args: SongDetailArgs) => {
+  return (
+    apiController(
+      'getSongDetail',
+      args.apiClientProps.server?.type,
+    ) as ControllerEndpoint['getSongDetail']
+  )?.(args);
+};
+
 const getMusicFolderList = async (args: MusicFolderListArgs) => {
   return (
     apiController(
@@ -444,6 +453,7 @@ export const controller = {
   getPlaylistDetail,
   getPlaylistList,
   getPlaylistSongList,
+  getSongDetail,
   getSongList,
   getTopSongList,
   getUserList,

--- a/src/renderer/api/controller.ts
+++ b/src/renderer/api/controller.ts
@@ -128,7 +128,7 @@ const endpoints: ApiController = {
     getUserList: undefined,
     removeFromPlaylist: jfController.removeFromPlaylist,
     scrobble: jfController.scrobble,
-    search: undefined,
+    search: jfController.search,
     setRating: undefined,
     updatePlaylist: jfController.updatePlaylist,
   },

--- a/src/renderer/api/jellyfin/jellyfin-api.ts
+++ b/src/renderer/api/jellyfin/jellyfin-api.ts
@@ -224,6 +224,15 @@ export const contract = c.router({
       400: jfType._response.error,
     },
   },
+  search: {
+    method: 'GET',
+    path: 'users/:userId/items',
+    query: jfType._parameters.search,
+    responses: {
+      200: jfType._response.search,
+      400: jfType._response.error,
+    },
+  },
   updatePlaylist: {
     body: jfType._parameters.updatePlaylist,
     method: 'PUT',

--- a/src/renderer/api/jellyfin/jellyfin-types.ts
+++ b/src/renderer/api/jellyfin/jellyfin-types.ts
@@ -49,7 +49,12 @@ const baseParameters = z.object({
   ExcludeItemTypes: z.string().optional(),
   Fields: z.string().optional(),
   ImageTypeLimit: z.number().optional(),
+  IncludeArtists: z.boolean().optional(),
+  IncludeGenres: z.boolean().optional(),
   IncludeItemTypes: z.string().optional(),
+  IncludeMedia: z.boolean().optional(),
+  IncludePeople: z.boolean().optional(),
+  IncludeStudios: z.boolean().optional(),
   IsFavorite: z.boolean().optional(),
   Limit: z.number().optional(),
   MediaTypes: z.string().optional(),
@@ -622,6 +627,10 @@ const favorite = z.object({
 
 const favoriteParameters = z.object({});
 
+const searchParameters = paginationParameters.merge(baseParameters);
+
+const search = z.any();
+
 export const jfType = {
   _enum: {
     collection: jfCollection,
@@ -643,6 +652,7 @@ export const jfType = {
     playlistList: playlistListParameters,
     removeFromPlaylist: removeFromPlaylistParameters,
     scrobble: scrobbleParameters,
+    search: searchParameters,
     similarArtistList: similarArtistListParameters,
     songList: songListParameters,
     updatePlaylist: updatePlaylistParameters,
@@ -666,6 +676,7 @@ export const jfType = {
     playlistSongList,
     removeFromPlaylist,
     scrobble,
+    search,
     song,
     songList,
     topSongsList,

--- a/src/renderer/api/query-keys.ts
+++ b/src/renderer/api/query-keys.ts
@@ -10,6 +10,7 @@ import type {
   UserListQuery,
   AlbumArtistDetailQuery,
   TopSongListQuery,
+  SearchQuery,
 } from './types';
 
 export const queryKeys = {
@@ -75,6 +76,13 @@ export const queryKeys = {
       if (id) return [serverId, 'playlists', id, 'songList'] as const;
       return [serverId, 'playlists', 'songList'] as const;
     },
+  },
+  search: {
+    list: (serverId: string, query?: SearchQuery) => {
+      if (query) return [serverId, 'search', 'list', query] as const;
+      return [serverId, 'search', 'list'] as const;
+    },
+    root: (serverId: string) => [serverId, 'search'] as const,
   },
   server: {
     root: (serverId: string) => [serverId] as const,

--- a/src/renderer/api/query-keys.ts
+++ b/src/renderer/api/query-keys.ts
@@ -11,6 +11,7 @@ import type {
   AlbumArtistDetailQuery,
   TopSongListQuery,
   SearchQuery,
+  SongDetailQuery,
 } from './types';
 
 export const queryKeys = {
@@ -88,6 +89,10 @@ export const queryKeys = {
     root: (serverId: string) => [serverId] as const,
   },
   songs: {
+    detail: (serverId: string, query?: SongDetailQuery) => {
+      if (query) return [serverId, 'songs', 'detail', query] as const;
+      return [serverId, 'songs', 'detail'] as const;
+    },
     list: (serverId: string, query?: SongListQuery) => {
       if (query) return [serverId, 'songs', 'list', query] as const;
       return [serverId, 'songs', 'list'] as const;

--- a/src/renderer/api/subsonic/subsonic-api.ts
+++ b/src/renderer/api/subsonic/subsonic-api.ts
@@ -65,6 +65,14 @@ export const contract = c.router({
       200: ssType._response.scrobble,
     },
   },
+  search3: {
+    method: 'GET',
+    path: 'search3.view',
+    query: ssType._parameters.search3,
+    responses: {
+      200: ssType._response.search3,
+    },
+  },
   setRating: {
     method: 'GET',
     path: 'setRating.view',
@@ -165,9 +173,14 @@ export const ssApiClient = (args: {
           status: result.status,
         };
       } catch (e: Error | AxiosError | any) {
+        console.log('CATCH ERR');
+
         if (isAxiosError(e)) {
           const error = e as AxiosError;
           const response = error.response as AxiosResponse;
+
+          console.log(response, 'response');
+
           return {
             body: response?.data,
             status: response?.status,

--- a/src/renderer/api/subsonic/subsonic-controller.ts
+++ b/src/renderer/api/subsonic/subsonic-controller.ts
@@ -310,8 +310,6 @@ const scrobble = async (args: ScrobbleArgs): Promise<ScrobbleResponse> => {
 const search3 = async (args: SearchArgs): Promise<SearchResponse> => {
   const { query, apiClientProps } = args;
 
-  console.log('search api');
-
   const res = await ssApiClient(apiClientProps).search3({
     query: {
       albumCount: query.albumLimit,

--- a/src/renderer/api/subsonic/subsonic-controller.ts
+++ b/src/renderer/api/subsonic/subsonic-controller.ts
@@ -17,6 +17,8 @@ import {
   ScrobbleResponse,
   SongListResponse,
   TopSongListArgs,
+  SearchArgs,
+  SearchResponse,
 } from '/@/renderer/api/types';
 import { randomString } from '/@/renderer/utils';
 
@@ -305,6 +307,40 @@ const scrobble = async (args: ScrobbleArgs): Promise<ScrobbleResponse> => {
   return null;
 };
 
+const search3 = async (args: SearchArgs): Promise<SearchResponse> => {
+  const { query, apiClientProps } = args;
+
+  console.log('search api');
+
+  const res = await ssApiClient(apiClientProps).search3({
+    query: {
+      albumCount: query.albumLimit,
+      albumOffset: query.albumStartIndex,
+      artistCount: query.albumArtistLimit,
+      artistOffset: query.albumArtistStartIndex,
+      query: query.query,
+      songCount: query.songLimit,
+      songOffset: query.songStartIndex,
+    },
+  });
+
+  if (res.status !== 200) {
+    throw new Error('Failed to search');
+  }
+
+  return {
+    albumArtists: res.body.searchResult3?.artist?.map((artist) =>
+      ssNormalize.albumArtist(artist, apiClientProps.server),
+    ),
+    albums: res.body.searchResult3?.album?.map((album) =>
+      ssNormalize.album(album, apiClientProps.server),
+    ),
+    songs: res.body.searchResult3?.song?.map((song) =>
+      ssNormalize.song(song, apiClientProps.server, ''),
+    ),
+  };
+};
+
 export const ssController = {
   authenticate,
   createFavorite,
@@ -313,5 +349,6 @@ export const ssController = {
   getTopSongList,
   removeFavorite,
   scrobble,
+  search3,
   setRating,
 };

--- a/src/renderer/api/subsonic/subsonic-types.ts
+++ b/src/renderer/api/subsonic/subsonic-types.ts
@@ -173,6 +173,25 @@ const scrobbleParameters = z.object({
 
 const scrobble = z.null();
 
+const search3 = z.object({
+  searchResult3: z.object({
+    album: z.array(album),
+    artist: z.array(albumArtist),
+    song: z.array(song),
+  }),
+});
+
+const search3Parameters = z.object({
+  albumCount: z.number().optional(),
+  albumOffset: z.number().optional(),
+  artistCount: z.number().optional(),
+  artistOffset: z.number().optional(),
+  musicFolderId: z.string().optional(),
+  query: z.string().optional(),
+  songCount: z.number().optional(),
+  songOffset: z.number().optional(),
+});
+
 export const ssType = {
   _parameters: {
     albumList: albumListParameters,
@@ -181,10 +200,13 @@ export const ssType = {
     createFavorite: createFavoriteParameters,
     removeFavorite: removeFavoriteParameters,
     scrobble: scrobbleParameters,
+    search3: search3Parameters,
     setRating: setRatingParameters,
     topSongsList: topSongsListParameters,
   },
   _response: {
+    album,
+    albumArtist,
     albumArtistList,
     albumList,
     artistInfo,
@@ -194,6 +216,7 @@ export const ssType = {
     musicFolderList,
     removeFavorite,
     scrobble,
+    search3,
     setRating,
     song,
     topSongsList,

--- a/src/renderer/api/types.ts
+++ b/src/renderer/api/types.ts
@@ -959,3 +959,24 @@ export type ScrobbleQuery = {
   position?: number;
   submission: boolean;
 };
+
+export type SearchQuery = {
+  albumArtistLimit?: number;
+  albumArtistStartIndex?: number;
+  albumLimit?: number;
+  albumStartIndex?: number;
+  musicFolderId?: string;
+  query?: string;
+  songLimit?: number;
+  songStartIndex?: number;
+};
+
+export type SearchArgs = {
+  query: SearchQuery;
+} & BaseEndpointArgs;
+
+export type SearchResponse = {
+  albumArtists: AlbumArtist[];
+  albums: Album[];
+  songs: Song[];
+};

--- a/src/renderer/api/types.ts
+++ b/src/renderer/api/types.ts
@@ -167,7 +167,7 @@ export type Album = {
 } & { songs?: Song[] };
 
 export type Song = {
-  album: string;
+  album: string | undefined;
   albumArtists: RelatedArtist[];
   albumId: string;
   artistName: string;
@@ -969,6 +969,27 @@ export type SearchQuery = {
   query?: string;
   songLimit?: number;
   songStartIndex?: number;
+};
+
+export type SearchSongsQuery = {
+  musicFolderId?: string;
+  query?: string;
+  songLimit?: number;
+  songStartIndex?: number;
+};
+
+export type SearchAlbumsQuery = {
+  albumLimit?: number;
+  albumStartIndex?: number;
+  musicFolderId?: string;
+  query?: string;
+};
+
+export type SearchAlbumArtistsQuery = {
+  albumArtistLimit?: number;
+  albumArtistStartIndex?: number;
+  musicFolderId?: string;
+  query?: string;
 };
 
 export type SearchArgs = {

--- a/src/renderer/features/context-menu/hooks/use-handle-context-menu.ts
+++ b/src/renderer/features/context-menu/hooks/use-handle-context-menu.ts
@@ -16,6 +16,10 @@ export const useHandleTableContextMenu = (
     let selectedNodes = sortBy(e.api.getSelectedNodes(), ['rowIndex']);
     let selectedRows = selectedNodes.map((node) => node.data);
 
+    if (!e.data?.id) {
+      return;
+    }
+
     const shouldReplaceSelected = !selectedNodes.map((node) => node.data.id).includes(e.data.id);
 
     if (shouldReplaceSelected) {

--- a/src/renderer/features/search/components/command-palette.tsx
+++ b/src/renderer/features/search/components/command-palette.tsx
@@ -132,9 +132,11 @@ export const CommandPalette = ({ modalProps }: CommandPaletteProps) => {
                 <Command.Item
                   key={`search-album-${album.id}`}
                   value={`search-${album.id}`}
-                  onSelect={() =>
-                    navigate(generatePath(AppRoute.LIBRARY_ALBUMS_DETAIL, { albumId: album.id }))
-                  }
+                  onSelect={() => {
+                    navigate(generatePath(AppRoute.LIBRARY_ALBUMS_DETAIL, { albumId: album.id }));
+                    modalProps.handlers.close();
+                    setQuery('');
+                  }}
                 >
                   <LibraryCommandItem
                     handlePlayQueueAdd={handlePlayQueueAdd}
@@ -154,13 +156,15 @@ export const CommandPalette = ({ modalProps }: CommandPaletteProps) => {
                 <Command.Item
                   key={`artist-${artist.id}`}
                   value={`search-${artist.id}`}
-                  onSelect={() =>
+                  onSelect={() => {
                     navigate(
                       generatePath(AppRoute.LIBRARY_ALBUM_ARTISTS_DETAIL, {
                         albumArtistId: artist.id,
                       }),
-                    )
-                  }
+                    );
+                    modalProps.handlers.close();
+                    setQuery('');
+                  }}
                 >
                   <LibraryCommandItem
                     handlePlayQueueAdd={handlePlayQueueAdd}
@@ -182,13 +186,15 @@ export const CommandPalette = ({ modalProps }: CommandPaletteProps) => {
                 <Command.Item
                   key={`artist-${song.id}`}
                   value={`search-${song.id}`}
-                  onSelect={() =>
+                  onSelect={() => {
                     navigate(
                       generatePath(AppRoute.LIBRARY_ALBUMS_DETAIL, {
                         albumId: song.albumId,
                       }),
-                    )
-                  }
+                    );
+                    modalProps.handlers.close();
+                    setQuery('');
+                  }}
                 >
                   <LibraryCommandItem
                     handlePlayQueueAdd={handlePlayQueueAdd}

--- a/src/renderer/features/search/components/command-palette.tsx
+++ b/src/renderer/features/search/components/command-palette.tsx
@@ -1,11 +1,20 @@
 /* eslint-disable react/no-unknown-property */
 import { useCallback, useState } from 'react';
-import { useDisclosure } from '@mantine/hooks';
+import { Group, Kbd, ScrollArea } from '@mantine/core';
+import { useDisclosure, useDebouncedValue } from '@mantine/hooks';
+import { generatePath, useNavigate } from 'react-router';
 import styled from 'styled-components';
 import { GoToCommands } from './go-to-commands';
 import { Command, CommandPalettePages } from '/@/renderer/features/search/components/command';
-import { Modal } from '/@/renderer/components';
+import { Modal, Paper, Spinner } from '/@/renderer/components';
 import { HomeCommands } from './home-commands';
+import { ServerCommands } from '/@/renderer/features/search/components/server-commands';
+import { useSearch } from '/@/renderer/features/search/queries/search-query';
+import { useCurrentServer } from '/@/renderer/store';
+import { AppRoute } from '/@/renderer/router/routes';
+import { LibraryCommandItem } from '/@/renderer/features/search/components/library-command-item';
+import { LibraryItem } from '/@/renderer/api/types';
+import { usePlayQueueAdd } from '/@/renderer/features/player';
 
 interface CommandPaletteProps {
   modalProps: typeof useDisclosure['arguments'];
@@ -18,8 +27,11 @@ const CustomModal = styled(Modal)`
 `;
 
 export const CommandPalette = ({ modalProps }: CommandPaletteProps) => {
+  const navigate = useNavigate();
+  const server = useCurrentServer();
   const [value, setValue] = useState('');
   const [query, setQuery] = useState('');
+  const [debouncedQuery] = useDebouncedValue(query, 400);
   const [pages, setPages] = useState<CommandPalettePages[]>([CommandPalettePages.HOME]);
   const activePage = pages[pages.length - 1];
   const isHome = activePage === CommandPalettePages.HOME;
@@ -31,6 +43,26 @@ export const CommandPalette = ({ modalProps }: CommandPaletteProps) => {
       return x;
     });
   }, []);
+
+  const { data, isLoading } = useSearch({
+    options: { enabled: debouncedQuery !== '' && query !== '' },
+    query: {
+      albumArtistLimit: 4,
+      albumArtistStartIndex: 0,
+      albumLimit: 4,
+      albumStartIndex: 0,
+      query: debouncedQuery,
+      songLimit: 4,
+      songStartIndex: 0,
+    },
+    serverId: server?.id,
+  });
+
+  const showAlbumGroup = Boolean(query && data && data?.albums?.length > 0);
+  const showArtistGroup = Boolean(query && data && data?.albumArtists?.length > 0);
+  const showTrackGroup = Boolean(query && data && data?.songs?.length > 0);
+
+  const handlePlayQueueAdd = usePlayQueueAdd();
 
   return (
     <CustomModal
@@ -47,7 +79,6 @@ export const CommandPalette = ({ modalProps }: CommandPaletteProps) => {
           }
         },
         toggle: () => {
-          console.log('toggle');
           if (isHome) {
             modalProps.handlers.toggle();
             setQuery('');
@@ -56,11 +87,13 @@ export const CommandPalette = ({ modalProps }: CommandPaletteProps) => {
           }
         },
       }}
+      scrollAreaComponent={ScrollArea.Autosize}
+      size="lg"
     >
       <Command
         filter={(value, search) => {
           if (value.includes(search)) return 1;
-          if (value === 'search') return 1;
+          if (value.includes('search')) return 1;
           return 0;
         }}
         label="Global Command Menu"
@@ -69,14 +102,89 @@ export const CommandPalette = ({ modalProps }: CommandPaletteProps) => {
       >
         <Command.Input
           autoFocus
-          placeholder="Enter your search..."
+          placeholder="Enter search..."
           value={query}
           onValueChange={setQuery}
         />
         <Command.Separator />
         <Command.List>
           <Command.Empty>No results found.</Command.Empty>
-
+          {showAlbumGroup && (
+            <Command.Group heading="Albums">
+              {data?.albums?.map((album) => (
+                <Command.Item
+                  key={`search-album-${album.id}`}
+                  value={`search-${album.id}`}
+                  onSelect={() =>
+                    navigate(generatePath(AppRoute.LIBRARY_ALBUMS_DETAIL, { albumId: album.id }))
+                  }
+                >
+                  <LibraryCommandItem
+                    handlePlayQueueAdd={handlePlayQueueAdd}
+                    id={album.id}
+                    imageUrl={album.imageUrl}
+                    itemType={LibraryItem.ALBUM}
+                    subtitle={album.albumArtists.map((artist) => artist.name).join(', ')}
+                    title={album.name}
+                  />
+                </Command.Item>
+              ))}
+            </Command.Group>
+          )}
+          {showArtistGroup && (
+            <Command.Group heading="Artists">
+              {data?.albumArtists.map((artist) => (
+                <Command.Item
+                  key={`artist-${artist.id}`}
+                  value={`search-${artist.id}`}
+                  onSelect={() =>
+                    navigate(
+                      generatePath(AppRoute.LIBRARY_ALBUM_ARTISTS_DETAIL, {
+                        albumArtistId: artist.id,
+                      }),
+                    )
+                  }
+                >
+                  <LibraryCommandItem
+                    handlePlayQueueAdd={handlePlayQueueAdd}
+                    id={artist.id}
+                    imageUrl={artist.imageUrl}
+                    itemType={LibraryItem.ALBUM_ARTIST}
+                    subtitle={
+                      (artist?.albumCount || 0) > 0 ? `${artist.albumCount} albums` : undefined
+                    }
+                    title={artist.name}
+                  />
+                </Command.Item>
+              ))}
+            </Command.Group>
+          )}
+          {showTrackGroup && (
+            <Command.Group heading="Tracks">
+              {data?.songs.map((song) => (
+                <Command.Item
+                  key={`artist-${song.id}`}
+                  value={`search-${song.id}`}
+                  onSelect={() =>
+                    navigate(
+                      generatePath(AppRoute.LIBRARY_ALBUMS_DETAIL, {
+                        albumId: song.albumId,
+                      }),
+                    )
+                  }
+                >
+                  <LibraryCommandItem
+                    handlePlayQueueAdd={handlePlayQueueAdd}
+                    id={song.id}
+                    imageUrl={song.imageUrl}
+                    itemType={LibraryItem.SONG}
+                    subtitle={song.artists.map((artist) => artist.name).join(', ')}
+                    title={song.name}
+                  />
+                </Command.Item>
+              ))}
+            </Command.Group>
+          )}
           {activePage === CommandPalettePages.HOME && (
             <HomeCommands
               handleClose={modalProps.handlers.close}
@@ -90,10 +198,32 @@ export const CommandPalette = ({ modalProps }: CommandPaletteProps) => {
             <GoToCommands
               handleClose={modalProps.handlers.close}
               setPages={setPages}
+              setQuery={setQuery}
+            />
+          )}
+          {activePage === CommandPalettePages.MANAGE_SERVERS && (
+            <ServerCommands
+              handleClose={modalProps.handlers.close}
+              setPages={setPages}
+              setQuery={setQuery}
             />
           )}
         </Command.List>
       </Command>
+      <Paper
+        mt="0.5rem"
+        p="0.5rem"
+      >
+        <Group position="apart">
+          <Command.Loading>{isLoading && query !== '' && <Spinner />}</Command.Loading>
+          <Group spacing="sm">
+            <Kbd size="md">ESC</Kbd>
+            <Kbd size="md">↑</Kbd>
+            <Kbd size="md">↓</Kbd>
+            <Kbd size="md">⏎</Kbd>
+          </Group>
+        </Group>
+      </Paper>
     </CustomModal>
   );
 };

--- a/src/renderer/features/search/components/command-palette.tsx
+++ b/src/renderer/features/search/components/command-palette.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable react/no-unknown-property */
-import { useCallback, useState } from 'react';
+import { useCallback, useState, Fragment } from 'react';
 import { Group, Kbd, ScrollArea } from '@mantine/core';
 import { useDisclosure, useDebouncedValue } from '@mantine/hooks';
 import { generatePath, useNavigate } from 'react-router';
 import styled from 'styled-components';
 import { GoToCommands } from './go-to-commands';
 import { Command, CommandPalettePages } from '/@/renderer/features/search/components/command';
-import { Modal, Paper, Spinner } from '/@/renderer/components';
+import { Button, Modal, Paper, Spinner } from '/@/renderer/components';
 import { HomeCommands } from './home-commands';
 import { ServerCommands } from '/@/renderer/features/search/components/server-commands';
 import { useSearch } from '/@/renderer/features/search/queries/search-query';
@@ -90,6 +90,23 @@ export const CommandPalette = ({ modalProps }: CommandPaletteProps) => {
       scrollAreaComponent={ScrollArea.Autosize}
       size="lg"
     >
+      <Group
+        mb="1rem"
+        spacing="sm"
+      >
+        {pages.map((page, index) => (
+          <Fragment key={page}>
+            {index > 0 && ' > '}
+            <Button
+              compact
+              disabled
+              variant="default"
+            >
+              {page?.toLocaleUpperCase()}
+            </Button>
+          </Fragment>
+        ))}
+      </Group>
       <Command
         filter={(value, search) => {
           if (value.includes(search)) return 1;

--- a/src/renderer/features/search/components/command-palette.tsx
+++ b/src/renderer/features/search/components/command-palette.tsx
@@ -1,0 +1,99 @@
+/* eslint-disable react/no-unknown-property */
+import { useCallback, useState } from 'react';
+import { useDisclosure } from '@mantine/hooks';
+import styled from 'styled-components';
+import { GoToCommands } from './go-to-commands';
+import { Command, CommandPalettePages } from '/@/renderer/features/search/components/command';
+import { Modal } from '/@/renderer/components';
+import { HomeCommands } from './home-commands';
+
+interface CommandPaletteProps {
+  modalProps: typeof useDisclosure['arguments'];
+}
+
+const CustomModal = styled(Modal)`
+  & .mantine-Modal-header {
+    display: none;
+  }
+`;
+
+export const CommandPalette = ({ modalProps }: CommandPaletteProps) => {
+  const [value, setValue] = useState('');
+  const [query, setQuery] = useState('');
+  const [pages, setPages] = useState<CommandPalettePages[]>([CommandPalettePages.HOME]);
+  const activePage = pages[pages.length - 1];
+  const isHome = activePage === CommandPalettePages.HOME;
+
+  const popPage = useCallback(() => {
+    setPages((pages) => {
+      const x = [...pages];
+      x.splice(-1, 1);
+      return x;
+    });
+  }, []);
+
+  return (
+    <CustomModal
+      {...modalProps}
+      centered
+      handlers={{
+        ...modalProps.handlers,
+        close: () => {
+          if (isHome) {
+            modalProps.handlers.close();
+            setQuery('');
+          } else {
+            popPage();
+          }
+        },
+        toggle: () => {
+          console.log('toggle');
+          if (isHome) {
+            modalProps.handlers.toggle();
+            setQuery('');
+          } else {
+            popPage();
+          }
+        },
+      }}
+    >
+      <Command
+        filter={(value, search) => {
+          if (value.includes(search)) return 1;
+          if (value === 'search') return 1;
+          return 0;
+        }}
+        label="Global Command Menu"
+        value={value}
+        onValueChange={setValue}
+      >
+        <Command.Input
+          autoFocus
+          placeholder="Enter your search..."
+          value={query}
+          onValueChange={setQuery}
+        />
+        <Command.Separator />
+        <Command.List>
+          <Command.Empty>No results found.</Command.Empty>
+
+          {activePage === CommandPalettePages.HOME && (
+            <HomeCommands
+              handleClose={modalProps.handlers.close}
+              pages={pages}
+              query={query}
+              setPages={setPages}
+              setQuery={setQuery}
+            />
+          )}
+          {activePage === CommandPalettePages.GO_TO && (
+            <GoToCommands
+              handleClose={modalProps.handlers.close}
+              setPages={setPages}
+            />
+          )}
+        </Command.List>
+      </Command>
+    </CustomModal>
+  );
+};

--- a/src/renderer/features/search/components/command.tsx
+++ b/src/renderer/features/search/components/command.tsx
@@ -45,7 +45,7 @@ export const Command = styled(Cmdk)`
     display: flex;
     gap: 0.5rem;
     align-items: center;
-    padding: 1rem 0.5rem;
+    padding: 0.5rem;
     color: var(--btn-default-fg);
     font-family: var(--content-font-family);
     background: var(--btn-default-bg);

--- a/src/renderer/features/search/components/command.tsx
+++ b/src/renderer/features/search/components/command.tsx
@@ -1,0 +1,61 @@
+import { Command as Cmdk } from 'cmdk';
+import styled from 'styled-components';
+
+export enum CommandPalettePages {
+  GO_TO = 'go to',
+  HOME = 'home',
+}
+
+export const Command = styled(Cmdk)`
+  [cmdk-root] {
+    font-family: var(--content-font-family);
+    background-color: var(--background-color);
+  }
+
+  input[cmdk-input] {
+    width: 100%;
+    height: 2rem;
+    margin-bottom: 1rem;
+    padding: 0 0.5rem;
+    color: var(--input-fg);
+    font-size: 1.1rem;
+    background: transparent;
+    border: none;
+
+    &::placeholder {
+      color: var(--input-placeholder-fg);
+    }
+  }
+
+  div[cmdk-group-heading] {
+    margin: 1rem 0;
+    font-size: 0.9rem;
+    opacity: 0.8;
+  }
+
+  div[cmdk-item] {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    padding: 1rem 0.5rem;
+    color: var(--btn-subtle-fg);
+    background: var(--btn-subtle-bg);
+    border-radius: 5px;
+
+    svg {
+      width: 1.2rem;
+      height: 1.2rem;
+    }
+
+    &[data-selected] {
+      color: var(--btn-subtle-fg-hover);
+      background: rgba(255, 255, 255, 10%);
+    }
+  }
+
+  div[cmdk-separator] {
+    height: 1px;
+    margin: 0 0 0.5rem;
+    background: var(--generic-border-color);
+  }
+`;

--- a/src/renderer/features/search/components/command.tsx
+++ b/src/renderer/features/search/components/command.tsx
@@ -18,7 +18,6 @@ export const Command = styled(Cmdk)`
     margin-bottom: 1rem;
     padding: 1.3rem 0.5rem;
     color: var(--input-fg);
-    font-size: 1.2rem;
     font-family: var(--content-font-family);
     background: var(--input-bg);
     border: none;
@@ -59,7 +58,7 @@ export const Command = styled(Cmdk)`
 
     &[data-selected] {
       color: var(--btn-default-fg-hover);
-      background: rgba(255, 255, 255, 10%);
+      background: var(--btn-default-bg-hover);
     }
   }
 

--- a/src/renderer/features/search/components/command.tsx
+++ b/src/renderer/features/search/components/command.tsx
@@ -2,45 +2,55 @@ import { Command as Cmdk } from 'cmdk';
 import styled from 'styled-components';
 
 export enum CommandPalettePages {
-  GO_TO = 'go to',
+  GO_TO = 'go',
   HOME = 'home',
+  MANAGE_SERVERS = 'servers',
 }
 
 export const Command = styled(Cmdk)`
   [cmdk-root] {
-    font-family: var(--content-font-family);
     background-color: var(--background-color);
   }
 
   input[cmdk-input] {
     width: 100%;
-    height: 2rem;
+    height: 1.5rem;
     margin-bottom: 1rem;
-    padding: 0 0.5rem;
+    padding: 1.3rem 0.5rem;
     color: var(--input-fg);
-    font-size: 1.1rem;
-    background: transparent;
+    font-size: 1.2rem;
+    font-family: var(--content-font-family);
+    background: var(--input-bg);
     border: none;
+    border-radius: 5px;
 
     &::placeholder {
       color: var(--input-placeholder-fg);
     }
   }
 
-  div[cmdk-group-heading] {
+  [cmdk-group-heading] {
     margin: 1rem 0;
     font-size: 0.9rem;
     opacity: 0.8;
   }
 
-  div[cmdk-item] {
+  [cmdk-group-items] {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  [cmdk-item] {
     display: flex;
     gap: 0.5rem;
     align-items: center;
     padding: 1rem 0.5rem;
-    color: var(--btn-subtle-fg);
-    background: var(--btn-subtle-bg);
+    color: var(--btn-default-fg);
+    font-family: var(--content-font-family);
+    background: var(--btn-default-bg);
     border-radius: 5px;
+    cursor: pointer;
 
     svg {
       width: 1.2rem;
@@ -48,12 +58,12 @@ export const Command = styled(Cmdk)`
     }
 
     &[data-selected] {
-      color: var(--btn-subtle-fg-hover);
+      color: var(--btn-default-fg-hover);
       background: rgba(255, 255, 255, 10%);
     }
   }
 
-  div[cmdk-separator] {
+  [cmdk-separator] {
     height: 1px;
     margin: 0 0 0.5rem;
     background: var(--generic-border-color);

--- a/src/renderer/features/search/components/go-to-commands.tsx
+++ b/src/renderer/features/search/components/go-to-commands.tsx
@@ -1,0 +1,41 @@
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router';
+import { Command, CommandPalettePages } from '/@/renderer/features/search/components/command';
+import { AppRoute } from '/@/renderer/router/routes';
+
+interface GoToCommandsProps {
+  handleClose: () => void;
+  setPages: (pages: CommandPalettePages[]) => void;
+}
+
+export const GoToCommands = ({ setPages, handleClose }: GoToCommandsProps) => {
+  const navigate = useNavigate();
+
+  const goTo = useCallback(
+    (route: string) => {
+      navigate(route);
+      setPages([CommandPalettePages.HOME]);
+      handleClose();
+    },
+    [handleClose, navigate, setPages],
+  );
+
+  return (
+    <>
+      <Command.Item onSelect={() => goTo(AppRoute.HOME)}>Home</Command.Item>
+      <Command.Item onSelect={() => goTo(AppRoute.SEARCH)}>Search</Command.Item>
+      <Command.Item onSelect={() => goTo(AppRoute.SETTINGS)}>Settings</Command.Item>
+      <Command.Group heading="Library">
+        <Command.Item onSelect={() => goTo(AppRoute.LIBRARY_ALBUMS)}>Albums</Command.Item>
+        <Command.Item onSelect={() => goTo(AppRoute.LIBRARY_SONGS)}>Tracks</Command.Item>
+        <Command.Item onSelect={() => goTo(AppRoute.LIBRARY_ALBUM_ARTISTS)}>
+          Album artists
+        </Command.Item>
+        <Command.Item onSelect={() => goTo(AppRoute.LIBRARY_GENRES)}>Genres</Command.Item>
+        <Command.Item onSelect={() => goTo(AppRoute.LIBRARY_FOLDERS)}>Folders</Command.Item>
+        <Command.Item onSelect={() => goTo(AppRoute.PLAYLISTS)}>Playlists</Command.Item>
+      </Command.Group>
+      <Command.Separator />
+    </>
+  );
+};

--- a/src/renderer/features/search/components/go-to-commands.tsx
+++ b/src/renderer/features/search/components/go-to-commands.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, Dispatch } from 'react';
 import { useNavigate } from 'react-router';
 import { Command, CommandPalettePages } from '/@/renderer/features/search/components/command';
 import { AppRoute } from '/@/renderer/router/routes';
@@ -6,25 +6,29 @@ import { AppRoute } from '/@/renderer/router/routes';
 interface GoToCommandsProps {
   handleClose: () => void;
   setPages: (pages: CommandPalettePages[]) => void;
+  setQuery: Dispatch<string>;
 }
 
-export const GoToCommands = ({ setPages, handleClose }: GoToCommandsProps) => {
+export const GoToCommands = ({ setQuery, setPages, handleClose }: GoToCommandsProps) => {
   const navigate = useNavigate();
 
   const goTo = useCallback(
     (route: string) => {
       navigate(route);
-      setPages([CommandPalettePages.HOME]);
       handleClose();
+      setPages([CommandPalettePages.HOME]);
+      setQuery('');
     },
-    [handleClose, navigate, setPages],
+    [handleClose, navigate, setPages, setQuery],
   );
 
   return (
     <>
-      <Command.Item onSelect={() => goTo(AppRoute.HOME)}>Home</Command.Item>
-      <Command.Item onSelect={() => goTo(AppRoute.SEARCH)}>Search</Command.Item>
-      <Command.Item onSelect={() => goTo(AppRoute.SETTINGS)}>Settings</Command.Item>
+      <Command.Group>
+        <Command.Item onSelect={() => goTo(AppRoute.HOME)}>Home</Command.Item>
+        <Command.Item onSelect={() => goTo(AppRoute.SEARCH)}>Search</Command.Item>
+        <Command.Item onSelect={() => goTo(AppRoute.SETTINGS)}>Settings</Command.Item>
+      </Command.Group>
       <Command.Group heading="Library">
         <Command.Item onSelect={() => goTo(AppRoute.LIBRARY_ALBUMS)}>Albums</Command.Item>
         <Command.Item onSelect={() => goTo(AppRoute.LIBRARY_SONGS)}>Tracks</Command.Item>

--- a/src/renderer/features/search/components/home-commands.tsx
+++ b/src/renderer/features/search/components/home-commands.tsx
@@ -1,0 +1,62 @@
+import { openModal, closeAllModals } from '@mantine/modals';
+import { Dispatch, useCallback } from 'react';
+import { useNavigate } from 'react-router';
+import { CreatePlaylistForm } from '/@/renderer/features/playlists';
+import { Command, CommandPalettePages } from '/@/renderer/features/search/components/command';
+import { AppRoute } from '/@/renderer/router/routes';
+import { useCurrentServer } from '/@/renderer/store';
+import { ServerType } from '/@/renderer/types';
+
+interface HomeCommandsProps {
+  handleClose: () => void;
+  pages: CommandPalettePages[];
+  query: string;
+  setPages: Dispatch<CommandPalettePages[]>;
+  setQuery: Dispatch<string>;
+}
+
+export const HomeCommands = ({
+  query,
+  setQuery,
+  pages,
+  setPages,
+  handleClose,
+}: HomeCommandsProps) => {
+  const navigate = useNavigate();
+  const server = useCurrentServer();
+
+  const handleCreatePlaylistModal = useCallback(() => {
+    handleClose();
+
+    openModal({
+      children: <CreatePlaylistForm onCancel={() => closeAllModals()} />,
+      size: server?.type === ServerType?.NAVIDROME ? 'lg' : 'sm',
+      title: 'Create Playlist',
+    });
+  }, [handleClose, server?.type]);
+
+  const handleSearch = useCallback(() => {
+    navigate(AppRoute.SEARCH);
+    setQuery('');
+    handleClose();
+  }, [handleClose, navigate, setQuery]);
+
+  return (
+    <>
+      <Command.Group heading="Commands">
+        <Command.Item onSelect={handleCreatePlaylistModal}>Create playlist...</Command.Item>
+        <Command.Item onSelect={() => setPages([...pages, CommandPalettePages.GO_TO])}>
+          Go to page...
+        </Command.Item>
+        {query !== '' && (
+          <Command.Item
+            value="Search"
+            onSelect={handleSearch}
+          >
+            {query ? `Search for "${query}"...` : 'Search...'}
+          </Command.Item>
+        )}
+      </Command.Group>
+    </>
+  );
+};

--- a/src/renderer/features/search/components/home-commands.tsx
+++ b/src/renderer/features/search/components/home-commands.tsx
@@ -1,6 +1,9 @@
 import { openModal, closeAllModals } from '@mantine/modals';
+import { nanoid } from 'nanoid/non-secure';
 import { Dispatch, useCallback } from 'react';
-import { useNavigate } from 'react-router';
+import { generatePath, useNavigate } from 'react-router';
+import { createSearchParams } from 'react-router-dom';
+import { LibraryItem } from '/@/renderer/api/types';
 import { CreatePlaylistForm } from '/@/renderer/features/playlists';
 import { Command, CommandPalettePages } from '/@/renderer/features/search/components/command';
 import { AppRoute } from '/@/renderer/router/routes';
@@ -35,11 +38,23 @@ export const HomeCommands = ({
     });
   }, [handleClose, server?.type]);
 
-  const handleSearch = useCallback(() => {
-    navigate(AppRoute.SEARCH);
+  const handleSearch = () => {
+    navigate(
+      {
+        pathname: generatePath(AppRoute.SEARCH, { itemType: LibraryItem.SONG }),
+        search: createSearchParams({
+          query,
+        }).toString(),
+      },
+      {
+        state: {
+          navigationId: nanoid(),
+        },
+      },
+    );
     handleClose();
     setQuery('');
-  }, [handleClose, navigate, setQuery]);
+  };
 
   return (
     <>

--- a/src/renderer/features/search/components/home-commands.tsx
+++ b/src/renderer/features/search/components/home-commands.tsx
@@ -37,8 +37,8 @@ export const HomeCommands = ({
 
   const handleSearch = useCallback(() => {
     navigate(AppRoute.SEARCH);
-    setQuery('');
     handleClose();
+    setQuery('');
   }, [handleClose, navigate, setQuery]);
 
   return (
@@ -47,6 +47,9 @@ export const HomeCommands = ({
         <Command.Item onSelect={handleCreatePlaylistModal}>Create playlist...</Command.Item>
         <Command.Item onSelect={() => setPages([...pages, CommandPalettePages.GO_TO])}>
           Go to page...
+        </Command.Item>
+        <Command.Item onSelect={() => setPages([...pages, CommandPalettePages.MANAGE_SERVERS])}>
+          Server commands...
         </Command.Item>
         {query !== '' && (
           <Command.Item

--- a/src/renderer/features/search/components/library-command-item.tsx
+++ b/src/renderer/features/search/components/library-command-item.tsx
@@ -1,0 +1,179 @@
+import { Center, Flex } from '@mantine/core';
+import { useCallback, MouseEvent } from 'react';
+import {
+  RiAddBoxFill,
+  RiAddCircleFill,
+  RiAlbumFill,
+  RiPlayFill,
+  RiPlayListFill,
+  RiUserVoiceFill,
+} from 'react-icons/ri';
+import styled from 'styled-components';
+import { LibraryItem } from '/@/renderer/api/types';
+import { Button, MotionFlex, Text } from '/@/renderer/components';
+import { Play, PlayQueueAddOptions } from '/@/renderer/types';
+
+const ItemGrid = styled.div<{ height: number }>`
+  display: grid;
+  grid-auto-columns: 1fr;
+  grid-template-areas: 'image info';
+  grid-template-rows: 1fr;
+  grid-template-columns: ${(props) => props.height}px minmax(0, 1fr);
+  gap: 0.5rem;
+  width: 100%;
+  max-width: 100%;
+  height: 100%;
+  letter-spacing: 0.5px;
+`;
+
+const ImageWrapper = styled.div`
+  display: flex;
+  grid-area: image;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+`;
+
+const MetadataWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  grid-area: info;
+  justify-content: center;
+  width: 100%;
+`;
+
+const StyledImage = styled.img`
+  object-fit: cover;
+  border-radius: 4px;
+`;
+
+interface LibraryCommandItemProps {
+  handlePlayQueueAdd?: (options: PlayQueueAddOptions) => void;
+  id: string;
+  imageUrl: string | null;
+  itemType: LibraryItem;
+  subtitle?: string;
+  title?: string;
+}
+
+export const LibraryCommandItem = ({
+  id,
+  imageUrl,
+  subtitle,
+  title,
+  itemType,
+  handlePlayQueueAdd,
+}: LibraryCommandItemProps) => {
+  let Placeholder = RiAlbumFill;
+
+  switch (itemType) {
+    case LibraryItem.ALBUM:
+      Placeholder = RiAlbumFill;
+      break;
+    case LibraryItem.ARTIST:
+      Placeholder = RiUserVoiceFill;
+      break;
+    case LibraryItem.ALBUM_ARTIST:
+      Placeholder = RiUserVoiceFill;
+      break;
+    case LibraryItem.PLAYLIST:
+      Placeholder = RiPlayListFill;
+      break;
+    default:
+      Placeholder = RiAlbumFill;
+      break;
+  }
+
+  const handlePlay = useCallback(
+    (e: MouseEvent, id: string, play: Play) => {
+      e.stopPropagation();
+      handlePlayQueueAdd?.({
+        byItemType: {
+          id,
+          type: itemType,
+        },
+        play,
+      });
+    },
+    [handlePlayQueueAdd, itemType],
+  );
+
+  return (
+    <Flex
+      gap="xl"
+      justify="space-between"
+      style={{ height: '40px', width: '100%' }}
+    >
+      <ItemGrid height={40}>
+        <ImageWrapper>
+          {imageUrl ? (
+            <StyledImage
+              alt="cover"
+              height={40}
+              placeholder="var(--placeholder-bg)"
+              src={imageUrl}
+              style={{}}
+              width={40}
+            />
+          ) : (
+            <Center
+              style={{
+                background: 'var(--placeholder-bg)',
+                borderRadius: 'var(--card-default-radius)',
+                height: `${40}px`,
+                width: `${40}px`,
+              }}
+            >
+              <Placeholder
+                color="var(--placeholder-fg)"
+                size={35}
+              />
+            </Center>
+          )}
+        </ImageWrapper>
+        <MetadataWrapper>
+          <Text overflow="hidden">{title}</Text>
+          <Text
+            $secondary
+            overflow="hidden"
+          >
+            {subtitle}
+          </Text>
+        </MetadataWrapper>
+      </ItemGrid>
+      <MotionFlex
+        align="center"
+        gap="sm"
+        justify="flex-end"
+      >
+        <Button
+          compact
+          size="md"
+          tooltip={{ label: 'Play', openDelay: 500 }}
+          variant="default"
+          onClick={(e) => handlePlay(e, id, Play.NOW)}
+        >
+          <RiPlayFill />
+        </Button>
+        <Button
+          compact
+          size="md"
+          tooltip={{ label: 'Add to queue', openDelay: 500 }}
+          variant="default"
+          onClick={(e) => handlePlay(e, id, Play.LAST)}
+        >
+          <RiAddBoxFill />
+        </Button>
+        <Button
+          compact
+          size="md"
+          tooltip={{ label: 'Play next', openDelay: 500 }}
+          variant="default"
+          onClick={(e) => handlePlay(e, id, Play.NEXT)}
+        >
+          <RiAddCircleFill />
+        </Button>
+      </MotionFlex>
+    </Flex>
+  );
+};

--- a/src/renderer/features/search/components/library-command-item.tsx
+++ b/src/renderer/features/search/components/library-command-item.tsx
@@ -10,8 +10,10 @@ import {
 } from 'react-icons/ri';
 import styled from 'styled-components';
 import { LibraryItem } from '/@/renderer/api/types';
-import { Button, MotionFlex, Text } from '/@/renderer/components';
+import { Button, Text } from '/@/renderer/components';
 import { Play, PlayQueueAddOptions } from '/@/renderer/types';
+
+const Item = styled(Flex)``;
 
 const ItemGrid = styled.div<{ height: number }>`
   display: grid;
@@ -46,6 +48,8 @@ const StyledImage = styled.img`
   object-fit: cover;
   border-radius: 4px;
 `;
+
+const ActionsContainer = styled(Flex)``;
 
 interface LibraryCommandItemProps {
   handlePlayQueueAdd?: (options: PlayQueueAddOptions) => void;
@@ -99,7 +103,7 @@ export const LibraryCommandItem = ({
   );
 
   return (
-    <Flex
+    <Item
       gap="xl"
       justify="space-between"
       style={{ height: '40px', width: '100%' }}
@@ -141,7 +145,7 @@ export const LibraryCommandItem = ({
           </Text>
         </MetadataWrapper>
       </ItemGrid>
-      <MotionFlex
+      <ActionsContainer
         align="center"
         gap="sm"
         justify="flex-end"
@@ -173,7 +177,7 @@ export const LibraryCommandItem = ({
         >
           <RiAddCircleFill />
         </Button>
-      </MotionFlex>
-    </Flex>
+      </ActionsContainer>
+    </Item>
   );
 };

--- a/src/renderer/features/search/components/search-content.tsx
+++ b/src/renderer/features/search/components/search-content.tsx
@@ -1,0 +1,143 @@
+import {
+  ColDef,
+  GridReadyEvent,
+  RowDoubleClickedEvent,
+  IDatasource,
+} from '@ag-grid-community/core';
+import type { AgGridReact as AgGridReactType } from '@ag-grid-community/react/lib/agGridReact';
+import { Stack } from '@mantine/core';
+import { MutableRefObject, useMemo, useCallback } from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
+import { LibraryItem, QueueSong } from '/@/renderer/api/types';
+import { VirtualGridAutoSizerContainer } from '/@/renderer/components/virtual-grid';
+import { VirtualTable, getColumnDefs } from '/@/renderer/components/virtual-table';
+import { useHandleTableContextMenu } from '/@/renderer/features/context-menu';
+import { SONG_CONTEXT_MENU_ITEMS } from '/@/renderer/features/context-menu/context-menu-items';
+import { usePlayQueueAdd } from '/@/renderer/features/player';
+import { generatePath, useNavigate } from 'react-router';
+import { AppRoute } from '../../../router/routes';
+import {
+  useCurrentServer,
+  useSongListStore,
+  usePlayButtonBehavior,
+  useAlbumListStore,
+  useAlbumArtistListStore,
+} from '/@/renderer/store';
+
+interface SearchContentProps {
+  getDatasource: (searchQuery: string, itemType: LibraryItem) => IDatasource | undefined;
+  tableRef: MutableRefObject<AgGridReactType | null>;
+}
+
+export const SearchContent = ({ tableRef, getDatasource }: SearchContentProps) => {
+  const navigate = useNavigate();
+  const server = useCurrentServer();
+  const { itemType } = useParams() as { itemType: LibraryItem };
+  const [searchParams] = useSearchParams();
+  const songListStore = useSongListStore();
+  const albumListStore = useAlbumListStore();
+  const albumArtistListStore = useAlbumArtistListStore();
+  const handlePlayQueueAdd = usePlayQueueAdd();
+  const playButtonBehavior = usePlayButtonBehavior();
+
+  const isPaginationEnabled = true;
+
+  const getTable = useCallback(
+    (itemType: string) => {
+      switch (itemType) {
+        case LibraryItem.SONG:
+          return songListStore.table;
+        case LibraryItem.ALBUM:
+          return albumListStore.table;
+        case LibraryItem.ALBUM_ARTIST:
+          return albumArtistListStore.table;
+        default:
+          return undefined;
+      }
+    },
+    [albumArtistListStore.table, albumListStore.table, songListStore.table],
+  );
+
+  const table = getTable(itemType)!;
+
+  const columnDefs: ColDef[] = useMemo(() => getColumnDefs(table.columns), [table.columns]);
+
+  const onGridReady = useCallback(
+    (params: GridReadyEvent) => {
+      const datasource = getDatasource(searchParams.get('query') || '', itemType);
+      if (!datasource) return;
+
+      params.api.setDatasource(datasource);
+      params.api.ensureIndexVisible(table.scrollOffset, 'top');
+    },
+    [getDatasource, itemType, searchParams, table.scrollOffset],
+  );
+
+  const handleGridSizeChange = () => {
+    if (table.autoFit) {
+      tableRef?.current?.api.sizeColumnsToFit();
+    }
+  };
+
+  const handleContextMenu = useHandleTableContextMenu(LibraryItem.SONG, SONG_CONTEXT_MENU_ITEMS);
+
+  const handleRowDoubleClick = (e: RowDoubleClickedEvent<QueueSong>) => {
+    if (!e.data) return;
+    switch (itemType) {
+      case LibraryItem.ALBUM:
+        navigate(generatePath(AppRoute.LIBRARY_ALBUMS_DETAIL, { albumId: e.data.id }));
+        break;
+      case LibraryItem.ALBUM_ARTIST:
+        navigate(generatePath(AppRoute.LIBRARY_ALBUM_ARTISTS_DETAIL, { albumArtistId: e.data.id }));
+        break;
+      case LibraryItem.SONG:
+        handlePlayQueueAdd?.({
+          byData: [e.data],
+          play: playButtonBehavior,
+        });
+        break;
+    }
+  };
+
+  return (
+    <Stack
+      h="100%"
+      spacing={0}
+    >
+      <VirtualGridAutoSizerContainer>
+        <VirtualTable
+          // https://github.com/ag-grid/ag-grid/issues/5284
+          // Key is used to force remount of table when display, rowHeight, or server changes
+          key={`table-${itemType}-${table.rowHeight}-${server?.id}`}
+          ref={tableRef}
+          alwaysShowHorizontalScroll
+          suppressRowDrag
+          autoFitColumns={table.autoFit}
+          blockLoadDebounceMillis={200}
+          cacheBlockSize={25}
+          cacheOverflowSize={1}
+          columnDefs={columnDefs}
+          context={{
+            query: searchParams.get('query'),
+          }}
+          getRowId={(data) => data.data.id}
+          infiniteInitialRowCount={25}
+          pagination={isPaginationEnabled}
+          paginationAutoPageSize={isPaginationEnabled}
+          paginationPageSize={table.pagination.itemsPerPage || 100}
+          rowBuffer={20}
+          rowHeight={table.rowHeight || 40}
+          rowModelType="infinite"
+          rowSelection="multiple"
+          // onBodyScrollEnd={handleScroll}
+          onCellContextMenu={handleContextMenu}
+          // onColumnMoved={handleColumnChange}
+          // onColumnResized={debouncedColumnChange}
+          onGridReady={onGridReady}
+          onGridSizeChanged={handleGridSizeChange}
+          onRowDoubleClicked={handleRowDoubleClick}
+        />
+      </VirtualGridAutoSizerContainer>
+    </Stack>
+  );
+};

--- a/src/renderer/features/search/components/search-content.tsx
+++ b/src/renderer/features/search/components/search-content.tsx
@@ -12,7 +12,11 @@ import { LibraryItem, QueueSong } from '/@/renderer/api/types';
 import { VirtualGridAutoSizerContainer } from '/@/renderer/components/virtual-grid';
 import { VirtualTable, getColumnDefs } from '/@/renderer/components/virtual-table';
 import { useHandleTableContextMenu } from '/@/renderer/features/context-menu';
-import { SONG_CONTEXT_MENU_ITEMS } from '/@/renderer/features/context-menu/context-menu-items';
+import {
+  ALBUM_CONTEXT_MENU_ITEMS,
+  ARTIST_CONTEXT_MENU_ITEMS,
+  SONG_CONTEXT_MENU_ITEMS,
+} from '/@/renderer/features/context-menu/context-menu-items';
 import { usePlayQueueAdd } from '/@/renderer/features/player';
 import { generatePath, useNavigate } from 'react-router';
 import { AppRoute } from '../../../router/routes';
@@ -79,7 +83,20 @@ export const SearchContent = ({ tableRef, getDatasource }: SearchContentProps) =
     }
   };
 
-  const handleContextMenu = useHandleTableContextMenu(LibraryItem.SONG, SONG_CONTEXT_MENU_ITEMS);
+  const contextMenuItems = () => {
+    switch (itemType) {
+      case LibraryItem.ALBUM:
+        return ALBUM_CONTEXT_MENU_ITEMS;
+      case LibraryItem.ALBUM_ARTIST:
+        return ARTIST_CONTEXT_MENU_ITEMS;
+      case LibraryItem.SONG:
+        return SONG_CONTEXT_MENU_ITEMS;
+      default:
+        return [];
+    }
+  };
+
+  const handleContextMenu = useHandleTableContextMenu(itemType, contextMenuItems());
 
   const handleRowDoubleClick = (e: RowDoubleClickedEvent<QueueSong>) => {
     if (!e.data) return;

--- a/src/renderer/features/search/components/search-header.tsx
+++ b/src/renderer/features/search/components/search-header.tsx
@@ -1,0 +1,106 @@
+import { ChangeEvent, MutableRefObject } from 'react';
+import { IDatasource } from '@ag-grid-community/core';
+import type { AgGridReact as AgGridReactType } from '@ag-grid-community/react/lib/agGridReact';
+import { Stack, Flex, Group } from '@mantine/core';
+import debounce from 'lodash/debounce';
+import { generatePath, Link, useParams, useSearchParams } from 'react-router-dom';
+import { LibraryItem } from '/@/renderer/api/types';
+import { Button, PageHeader, SearchInput } from '/@/renderer/components';
+import { FilterBar, LibraryHeaderBar } from '/@/renderer/features/shared';
+import { useContainerQuery } from '/@/renderer/hooks';
+import { AppRoute } from '/@/renderer/router/routes';
+
+interface SearchHeaderProps {
+  getDatasource: (searchQuery: string, itemType: LibraryItem) => IDatasource | undefined;
+  navigationId: string;
+  tableRef: MutableRefObject<AgGridReactType | null>;
+}
+
+export const SearchHeader = ({ tableRef, getDatasource, navigationId }: SearchHeaderProps) => {
+  const { itemType } = useParams() as { itemType: LibraryItem };
+  const [searchParams, setSearchParams] = useSearchParams();
+  const cq = useContainerQuery();
+
+  const handleSearch = debounce((e: ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.value) return;
+    setSearchParams({ query: e.target.value }, { replace: true, state: { navigationId } });
+    const datasource = getDatasource(e.target.value, itemType);
+    if (!datasource) return;
+    tableRef.current?.api.setDatasource(datasource);
+  }, 200);
+
+  return (
+    <Stack
+      ref={cq.ref}
+      spacing={0}
+    >
+      <PageHeader>
+        <Flex
+          justify="space-between"
+          w="100%"
+        >
+          <LibraryHeaderBar>
+            <LibraryHeaderBar.Title>Search</LibraryHeaderBar.Title>
+          </LibraryHeaderBar>
+          <Group>
+            <SearchInput
+              // key={`search-input-${initialQuery}`}
+              defaultValue={searchParams.get('query') || ''}
+              openedWidth={cq.isMd ? 250 : cq.isSm ? 200 : 150}
+              onChange={handleSearch}
+            />
+          </Group>
+        </Flex>
+      </PageHeader>
+      <FilterBar>
+        <Group>
+          <Button
+            compact
+            replace
+            component={Link}
+            fw={600}
+            size="md"
+            state={{ navigationId }}
+            to={{
+              pathname: generatePath(AppRoute.SEARCH, { itemType: LibraryItem.SONG }),
+              search: searchParams.toString(),
+            }}
+            variant={itemType === LibraryItem.SONG ? 'filled' : 'subtle'}
+          >
+            Tracks
+          </Button>
+          <Button
+            compact
+            replace
+            component={Link}
+            fw={600}
+            size="md"
+            state={{ navigationId }}
+            to={{
+              pathname: generatePath(AppRoute.SEARCH, { itemType: LibraryItem.ALBUM }),
+              search: searchParams.toString(),
+            }}
+            variant={itemType === LibraryItem.ALBUM ? 'filled' : 'subtle'}
+          >
+            Albums
+          </Button>
+          <Button
+            compact
+            replace
+            component={Link}
+            fw={600}
+            size="md"
+            state={{ navigationId }}
+            to={{
+              pathname: generatePath(AppRoute.SEARCH, { itemType: LibraryItem.ALBUM_ARTIST }),
+              search: searchParams.toString(),
+            }}
+            variant={itemType === LibraryItem.ALBUM_ARTIST ? 'filled' : 'subtle'}
+          >
+            Artists
+          </Button>
+        </Group>
+      </FilterBar>
+    </Stack>
+  );
+};

--- a/src/renderer/features/search/components/server-commands.tsx
+++ b/src/renderer/features/search/components/server-commands.tsx
@@ -1,0 +1,58 @@
+import { useCallback, Dispatch } from 'react';
+import { openModal } from '@mantine/modals';
+import { Command, CommandPalettePages } from '/@/renderer/features/search/components/command';
+import { ServerList } from '/@/renderer/features/servers';
+import { useAuthStoreActions, useServerList } from '/@/renderer/store';
+import { ServerListItem } from '/@/renderer/types';
+import { useNavigate } from 'react-router';
+import { AppRoute } from '/@/renderer/router/routes';
+
+interface ServerCommandsProps {
+  handleClose: () => void;
+  setPages: (pages: CommandPalettePages[]) => void;
+  setQuery: Dispatch<string>;
+}
+
+export const ServerCommands = ({ setQuery, setPages, handleClose }: ServerCommandsProps) => {
+  const serverList = useServerList();
+  const navigate = useNavigate();
+  const { setCurrentServer } = useAuthStoreActions();
+
+  const handleManageServersModal = useCallback(() => {
+    openModal({
+      children: <ServerList />,
+      title: 'Manage Servers',
+    });
+    handleClose();
+    setQuery('');
+    setPages([CommandPalettePages.HOME]);
+  }, [handleClose, setPages, setQuery]);
+
+  const handleSelectServer = useCallback(
+    (server: ServerListItem) => {
+      navigate(AppRoute.HOME);
+      setCurrentServer(server);
+      handleClose();
+      setQuery('');
+      setPages([CommandPalettePages.HOME]);
+    },
+    [handleClose, navigate, setCurrentServer, setPages, setQuery],
+  );
+
+  return (
+    <>
+      <Command.Group heading="Select a server">
+        {Object.keys(serverList).map((key) => (
+          <Command.Item
+            key={key}
+            onSelect={() => handleSelectServer(serverList[key])}
+          >{`Switch to ${serverList[key].name}...`}</Command.Item>
+        ))}
+      </Command.Group>
+      <Command.Group heading="Manage">
+        <Command.Item onSelect={handleManageServersModal}>Manage servers...</Command.Item>
+      </Command.Group>
+      <Command.Separator />
+    </>
+  );
+};

--- a/src/renderer/features/search/queries/search-query.ts
+++ b/src/renderer/features/search/queries/search-query.ts
@@ -1,0 +1,27 @@
+import { SearchQuery } from '/@/renderer/api/types';
+import { QueryHookArgs } from '/@/renderer/lib/react-query';
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '/@/renderer/api/query-keys';
+import { getServerById } from '/@/renderer/store';
+import { api } from '/@/renderer/api';
+
+export const useSearch = (args: QueryHookArgs<SearchQuery>) => {
+  const { options, query, serverId } = args;
+  const server = getServerById(serverId);
+
+  return useQuery({
+    enabled: !!serverId,
+    queryFn: ({ signal }) => {
+      if (!server) throw new Error('Server not found');
+      return api.controller.search({
+        apiClientProps: {
+          server,
+          signal,
+        },
+        query,
+      });
+    },
+    queryKey: queryKeys.search.list(serverId || '', query),
+    ...options,
+  });
+};

--- a/src/renderer/features/search/routes/search-route.tsx
+++ b/src/renderer/features/search/routes/search-route.tsx
@@ -1,0 +1,186 @@
+import { useCallback, useId, useRef } from 'react';
+import { SearchContent } from '/@/renderer/features/search/components/search-content';
+import { SearchHeader } from '/@/renderer/features/search/components/search-header';
+import { AnimatedPage } from '/@/renderer/features/shared';
+import { IDatasource } from '@ag-grid-community/core';
+import type { AgGridReact as AgGridReactType } from '@ag-grid-community/react/lib/agGridReact';
+import { useCurrentServer } from '/@/renderer/store';
+import { useQueryClient } from '@tanstack/react-query';
+import { api } from '/@/renderer/api';
+import { queryKeys } from '/@/renderer/api/query-keys';
+import { LibraryItem, SearchQuery } from '/@/renderer/api/types';
+import { useLocation, useParams } from 'react-router';
+
+const SearchRoute = () => {
+  const { state: locationState } = useLocation();
+  const localNavigationId = useId();
+  const navigationId = locationState?.navigationId || localNavigationId;
+  const { itemType } = useParams() as { itemType: string };
+  const tableRef = useRef<AgGridReactType | null>(null);
+  const server = useCurrentServer();
+  const queryClient = useQueryClient();
+
+  const getDatasource = useCallback(
+    (searchQuery: string, itemType: LibraryItem) => {
+      let dataSource: IDatasource | undefined;
+
+      switch (itemType) {
+        case LibraryItem.ALBUM:
+          dataSource = {
+            getRows: async (params) => {
+              const limit = params.endRow - params.startRow;
+              const startIndex = params.startRow;
+
+              const query: SearchQuery = {
+                albumArtistLimit: 0,
+                albumArtistStartIndex: 0,
+                albumLimit: limit,
+                albumStartIndex: startIndex,
+                query: searchQuery || ' ',
+                songLimit: 0,
+                songStartIndex: 0,
+              };
+
+              const queryKey = queryKeys.search.list(server?.id || '', query);
+
+              const res = await queryClient.fetchQuery(
+                queryKey,
+                async ({ signal }) =>
+                  api.controller.search({
+                    apiClientProps: {
+                      server,
+                      signal,
+                    },
+                    query,
+                  }),
+                { cacheTime: 1000 * 60 },
+              );
+
+              if (!res) return;
+
+              const items = res.albums || [];
+              const numOfItems = items.length;
+
+              let lastRow = -1;
+              if (numOfItems < limit) {
+                lastRow = startIndex + numOfItems;
+              }
+
+              params.successCallback(items, lastRow);
+            },
+          };
+          break;
+        case LibraryItem.ALBUM_ARTIST:
+          dataSource = {
+            getRows: async (params) => {
+              const limit = params.endRow - params.startRow;
+              const startIndex = params.startRow;
+
+              const query: SearchQuery = {
+                albumArtistLimit: limit,
+                albumArtistStartIndex: startIndex,
+                albumLimit: 0,
+                albumStartIndex: 0,
+                query: searchQuery || ' ',
+                songLimit: 0,
+                songStartIndex: 0,
+              };
+
+              const queryKey = queryKeys.search.list(server?.id || '', query);
+
+              const res = await queryClient.fetchQuery(
+                queryKey,
+                async ({ signal }) =>
+                  api.controller.search({
+                    apiClientProps: {
+                      server,
+                      signal,
+                    },
+                    query,
+                  }),
+                { cacheTime: 1000 * 60 },
+              );
+
+              if (!res) return;
+
+              const items = res.albumArtists || [];
+              const numOfItems = items.length;
+
+              let lastRow = -1;
+              if (numOfItems < limit) {
+                lastRow = startIndex + numOfItems;
+              }
+
+              params.successCallback(items, lastRow);
+            },
+          };
+          break;
+        case LibraryItem.SONG:
+          dataSource = {
+            getRows: async (params) => {
+              const limit = params.endRow - params.startRow;
+              const startIndex = params.startRow;
+
+              const query: SearchQuery = {
+                albumArtistLimit: 0,
+                albumArtistStartIndex: 0,
+                albumLimit: 0,
+                albumStartIndex: 0,
+                query: searchQuery || ' ',
+                songLimit: limit,
+                songStartIndex: startIndex,
+              };
+
+              const queryKey = queryKeys.search.list(server?.id || '', query);
+
+              const res = await queryClient.fetchQuery(
+                queryKey,
+                async ({ signal }) =>
+                  api.controller.search({
+                    apiClientProps: {
+                      server,
+                      signal,
+                    },
+                    query,
+                  }),
+                { cacheTime: 1000 * 60 },
+              );
+
+              if (!res) return;
+
+              const items = res.songs || [];
+              const numOfItems = items.length;
+
+              let lastRow = -1;
+              if (numOfItems < limit) {
+                lastRow = startIndex + numOfItems;
+              }
+
+              params.successCallback(items, lastRow);
+            },
+          };
+          break;
+      }
+
+      return dataSource;
+    },
+    [queryClient, server],
+  );
+
+  return (
+    <AnimatedPage key={`search-${navigationId}`}>
+      <SearchHeader
+        getDatasource={getDatasource}
+        navigationId={navigationId}
+        tableRef={tableRef}
+      />
+      <SearchContent
+        key={`page-${itemType}`}
+        getDatasource={getDatasource}
+        tableRef={tableRef}
+      />
+    </AnimatedPage>
+  );
+};
+
+export default SearchRoute;

--- a/src/renderer/features/sidebar/components/action-bar.tsx
+++ b/src/renderer/features/sidebar/components/action-bar.tsx
@@ -1,10 +1,11 @@
-import { Grid, Group, TextInput } from '@mantine/core';
+import { Grid, Group } from '@mantine/core';
 import { RiSearchLine, RiMenuFill, RiArrowLeftSLine, RiArrowRightSLine } from 'react-icons/ri';
 import { useNavigate } from 'react-router';
 import styled from 'styled-components';
-import { Button, DropdownMenu } from '/@/renderer/components';
+import { Button, DropdownMenu, TextInput } from '/@/renderer/components';
 import { AppMenu } from '/@/renderer/features/titlebar/components/app-menu';
 import { useContainerQuery } from '/@/renderer/hooks';
+import { useCommandPalette } from '/@/renderer/store';
 
 const ActionsContainer = styled(Grid)`
   display: flex;
@@ -21,6 +22,7 @@ const ActionsContainer = styled(Grid)`
 export const ActionBar = () => {
   const cq = useContainerQuery({ sm: 300 });
   const navigate = useNavigate();
+  const { open } = useCommandPalette();
 
   return (
     <ActionsContainer
@@ -29,11 +31,16 @@ export const ActionBar = () => {
     >
       <Grid.Col span={cq.isSm ? 7 : 6}>
         <TextInput
-          disabled
           readOnly
           icon={<RiSearchLine />}
           placeholder="Search"
           size="md"
+          onClick={open}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              open();
+            }
+          }}
         />
       </Grid.Col>
       <Grid.Col span={cq.isSm ? 5 : 6}>

--- a/src/renderer/features/sidebar/components/collapsed-sidebar.tsx
+++ b/src/renderer/features/sidebar/components/collapsed-sidebar.tsx
@@ -16,6 +16,8 @@ import {
   RiFlag2Fill,
   RiFolder3Fill,
   RiPlayListFill,
+  RiSearchLine,
+  RiSearchFill,
 } from 'react-icons/ri';
 import { useLocation } from 'react-router';
 import { Link } from 'react-router-dom';
@@ -24,7 +26,7 @@ import { DropdownMenu, ScrollArea } from '/@/renderer/components';
 import { CollapsedSidebarItem } from '/@/renderer/features/sidebar/components/collapsed-sidebar-item';
 import { AppMenu } from '/@/renderer/features/titlebar/components/app-menu';
 import { AppRoute } from '/@/renderer/router/routes';
-import { useWindowSettings } from '/@/renderer/store';
+import { useCommandPalette, useWindowSettings } from '/@/renderer/store';
 import { Platform } from '/@/renderer/types';
 
 const SidebarContainer = styled(motion.div)<{ windowBarStyle: Platform }>`
@@ -41,6 +43,7 @@ const SidebarContainer = styled(motion.div)<{ windowBarStyle: Platform }>`
 export const CollapsedSidebar = () => {
   const location = useLocation();
   const { windowBarStyle } = useWindowSettings();
+  const { open } = useCommandPalette();
 
   return (
     <SidebarContainer windowBarStyle={windowBarStyle}>
@@ -61,6 +64,12 @@ export const CollapsedSidebar = () => {
             <AppMenu />
           </DropdownMenu.Dropdown>
         </DropdownMenu>
+        <CollapsedSidebarItem
+          activeIcon={<RiSearchFill size="25" />}
+          icon={<RiSearchLine size="25" />}
+          label="Search"
+          onClick={open}
+        />
         <CollapsedSidebarItem
           active={location.pathname === AppRoute.HOME}
           activeIcon={<RiHome6Fill size="25" />}

--- a/src/renderer/layouts/default-layout.tsx
+++ b/src/renderer/layouts/default-layout.tsx
@@ -1,10 +1,17 @@
 import { lazy } from 'react';
 import isElectron from 'is-electron';
 import styled from 'styled-components';
-import { useWindowSettings, useSettingsStore } from '/@/renderer/store/settings.store';
+import {
+  useWindowSettings,
+  useSettingsStore,
+  useHotkeySettings,
+} from '/@/renderer/store/settings.store';
 import { Platform, PlaybackType } from '/@/renderer/types';
 import { MainContent } from '/@/renderer/layouts/default-layout/main-content';
 import { PlayerBar } from '/@/renderer/layouts/default-layout/player-bar';
+import { useHotkeys } from '@mantine/hooks';
+import { CommandPalette } from '/@/renderer/features/search/components/command-palette';
+import { useCommandPalette } from '/@/renderer/store';
 
 if (!isElectron()) {
   useSettingsStore.getState().actions.setSettings({
@@ -42,6 +49,10 @@ interface DefaultLayoutProps {
 
 export const DefaultLayout = ({ shell }: DefaultLayoutProps) => {
   const { windowBarStyle } = useWindowSettings();
+  const { opened, ...handlers } = useCommandPalette();
+  const { bindings } = useHotkeySettings();
+
+  useHotkeys([[bindings.globalSearch.hotkey, () => handlers.open()]]);
 
   return (
     <>
@@ -53,6 +64,7 @@ export const DefaultLayout = ({ shell }: DefaultLayoutProps) => {
         <MainContent shell={shell} />
         <PlayerBar />
       </Layout>
+      <CommandPalette modalProps={{ handlers, opened }} />
     </>
   );
 };

--- a/src/renderer/lib/react-query.ts
+++ b/src/renderer/lib/react-query.ts
@@ -22,12 +22,14 @@ const queryConfig: DefaultOptions = {
   queries: {
     cacheTime: 1000 * 60 * 3,
     onError: (err) => {
-      console.error(err);
+      console.error('react query error:', err);
     },
     refetchOnWindowFocus: false,
     retry: process.env.NODE_ENV === 'production',
     staleTime: 1000 * 5,
-    useErrorBoundary: true,
+    useErrorBoundary: (error: any) => {
+      return error?.response?.status >= 500;
+    },
   },
 };
 

--- a/src/renderer/router/app-router.tsx
+++ b/src/renderer/router/app-router.tsx
@@ -60,6 +60,8 @@ const AlbumDetailRoute = lazy(
 
 const SettingsRoute = lazy(() => import('/@/renderer/features/settings/routes/settings-route'));
 
+const SearchRoute = lazy(() => import('/@/renderer/features/search/routes/search-route'));
+
 const RouteErrorBoundary = lazy(
   () => import('/@/renderer/features/action-required/components/route-error-boundary'),
 );
@@ -85,6 +87,11 @@ export const AppRouter = () => {
                 element={<HomeRoute />}
                 errorElement={<RouteErrorBoundary />}
                 path={AppRoute.HOME}
+              />
+              <Route
+                element={<SearchRoute />}
+                errorElement={<RouteErrorBoundary />}
+                path={AppRoute.SEARCH}
               />
               <Route
                 element={<SettingsRoute />}

--- a/src/renderer/router/routes.ts
+++ b/src/renderer/router/routes.ts
@@ -19,7 +19,7 @@ export enum AppRoute {
   PLAYLISTS = '/playlists',
   PLAYLISTS_DETAIL = '/playlists/:playlistId',
   PLAYLISTS_DETAIL_SONGS = '/playlists/:playlistId/songs',
-  SEARCH = '/search',
+  SEARCH = '/search/:itemType',
   SERVERS = '/servers',
   SETTINGS = '/settings',
 }

--- a/src/renderer/store/app.store.ts
+++ b/src/renderer/store/app.store.ts
@@ -18,7 +18,15 @@ type TitlebarProps = {
   outOfView: boolean;
 };
 
+type CommandPaletteProps = {
+  close: () => void;
+  open: () => void;
+  opened: boolean;
+  toggle: () => void;
+};
+
 export interface AppState {
+  commandPalette: CommandPaletteProps;
   isReorderingQueue: boolean;
   platform: Platform;
   sidebar: SidebarProps;
@@ -49,6 +57,24 @@ export const useAppStore = create<AppSlice>()(
           setTitleBar: (options) => {
             set((state) => {
               state.titlebar = { ...state.titlebar, ...options };
+            });
+          },
+        },
+        commandPalette: {
+          close: () => {
+            set((state) => {
+              state.commandPalette.opened = false;
+            });
+          },
+          open: () => {
+            set((state) => {
+              state.commandPalette.opened = true;
+            });
+          },
+          opened: false,
+          toggle: () => {
+            set((state) => {
+              state.commandPalette.opened = !state.commandPalette.opened;
             });
           },
         },
@@ -88,3 +114,5 @@ export const useSidebarRightExpanded = () => useAppStore((state) => state.sideba
 export const useSetTitlebar = () => useAppStore((state) => state.actions.setTitleBar);
 
 export const useTitlebarStore = () => useAppStore((state) => state.titlebar);
+
+export const useCommandPalette = () => useAppStore((state) => state.commandPalette);

--- a/src/renderer/store/player.store.ts
+++ b/src/renderer/store/player.store.ts
@@ -6,7 +6,7 @@ import create from 'zustand';
 import { devtools, persist, subscribeWithSelector } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
 import { shallow } from 'zustand/shallow';
-import { QueueSong, Song } from '/@/renderer/api/types';
+import { QueueSong } from '/@/renderer/api/types';
 import { PlayerStatus, PlayerRepeat, PlayerShuffle, Play } from '/@/renderer/types';
 
 export interface PlayerState {
@@ -56,7 +56,7 @@ export interface QueueData {
 
 export interface PlayerSlice extends PlayerState {
   actions: {
-    addToQueue: (songs: Song[], type: Play) => PlayerData;
+    addToQueue: (songs: QueueSong[], type: Play) => PlayerData;
     autoNext: () => PlayerData;
     checkIsFirstTrack: () => boolean;
     checkIsLastTrack: () => boolean;


### PR DESCRIPTION
## Initial command palette open:
- Can open via sidebar search buttons or by configurable hotkey

![image](https://github.com/jeffvli/feishin/assets/42182408/0f70bfc1-a98c-4e14-8889-c12ca07a9157)

## Command palette search
- Returns up to 4 results for each of albums/artists/tracks
- Includes a further "search" option to navigate to the search page

![image](https://github.com/jeffvli/feishin/assets/42182408/d7ec8d41-4576-4955-83ce-ad83ab6d2399)

## Search page
- Includes 3 search tabs for either tracks/albums/artists
- Uses an infinitely scrolling list to return all results from your library based on the search query
- Currently no table pagination option or ability to configure the table from this view; The configuration will come from the respective table options from other views (e.g. track search columns will come from the tracks list page)

![image](https://github.com/jeffvli/feishin/assets/42182408/032301fd-92dc-4217-8679-862e8fc4385e)

