### PR TITLE
Fix full screen overflow

### DIFF
--- a/src/renderer/features/player/components/full-screen-player-image.tsx
+++ b/src/renderer/features/player/components/full-screen-player-image.tsx
@@ -12,11 +12,19 @@ import { useFastAverageColor } from '/@/renderer/hooks';
 import { AppRoute } from '/@/renderer/router/routes';
 import { PlayerData, usePlayerData, usePlayerStore } from '/@/renderer/store';
 
+const PlayerContainer = styled(Flex)`
+  flex: 0.5;
+  gap: '1rem';
+
+  @media screen and (min-width: 1080px) {
+    max-width: 60%;
+  }
+`;
+
 const Image = styled(motion.img)`
   position: absolute;
   width: 100%;
   max-width: 100%;
-  height: 100%;
   max-height: 100%;
   object-fit: cover;
   border-radius: 5px;
@@ -29,6 +37,7 @@ const ImageContainer = styled(motion.div)`
   align-items: center;
   height: 65%;
   aspect-ratio: 1/1;
+  max-width: 100%;
 `;
 
 const imageVariants: Variants = {
@@ -120,13 +129,12 @@ export const FullScreenPlayerImage = () => {
   }, [imageState, queue, setImageState]);
 
   return (
-    <Flex
+    <PlayerContainer
       align="center"
       className="full-screen-player-image-container"
       direction="column"
       justify="flex-start"
       p="1rem"
-      sx={{ flex: 0.5, gap: '1rem' }}
     >
       <ImageContainer>
         <AnimatePresence
@@ -171,6 +179,7 @@ export const FullScreenPlayerImage = () => {
       <Stack
         className="full-screen-player-image-metadata"
         spacing="sm"
+        sx={{ maxWidth: '100%' }}
       >
         <TextTitle
           align="center"
@@ -232,6 +241,6 @@ export const FullScreenPlayerImage = () => {
           {currentSong?.releaseYear && <Badge size="lg">{currentSong?.releaseYear}</Badge>}
         </Group>
       </Stack>
-    </Flex>
+    </PlayerContainer>
   );
 };

--- a/src/renderer/features/player/components/full-screen-player-queue.tsx
+++ b/src/renderer/features/player/components/full-screen-player-queue.tsx
@@ -72,7 +72,10 @@ export const FullScreenPlayerQueue = () => {
         position="center"
       >
         {headerItems.map((item) => (
-          <Box pos="relative">
+          <Box
+            key={`tab-${item.label}`}
+            pos="relative"
+          >
             <Button
               fullWidth
               uppercase


### PR DESCRIPTION
With large enough song titles, in full screen mode the track description + image takes up the entire screen (as opposed to showing part of the queue). This PR does a few style changes to make the overflowing text actually limited in width, and restrict the image to 60% of the window. (not sure if other numbers are better)

![image](https://github.com/jeffvli/feishin/assets/17521368/b728ffa2-606f-4867-bc24-7f9d78fe3864)

![image](https://github.com/jeffvli/feishin/assets/17521368/41cd9f13-01d9-4d1a-91d5-9aaceace81bf)
