### PR TITLE
Fix MPRIS on Linux, muted, and add media session

### DIFF
--- a/src/main/features/linux/mpris.ts
+++ b/src/main/features/linux/mpris.ts
@@ -130,7 +130,7 @@ ipcMain.on(
       }
 
       if (shuffle) {
-        mprisPlayer.shuffle = shuffle;
+        mprisPlayer.shuffle = shuffle !== 'none';
       }
 
       if (!song) return;

--- a/src/renderer/features/player/components/playerbar.tsx
+++ b/src/renderer/features/player/components/playerbar.tsx
@@ -7,6 +7,7 @@ import { AudioPlayer } from '/@/renderer/components';
 import {
   useCurrentPlayer,
   useCurrentStatus,
+  useMuted,
   usePlayer1Data,
   usePlayer2Data,
   usePlayerControls,
@@ -62,6 +63,7 @@ export const Playerbar = () => {
   const player2 = usePlayer2Data();
   const status = useCurrentStatus();
   const player = useCurrentPlayer();
+  const muted = useMuted();
   const { autoNext } = usePlayerControls();
 
   const autoNextFn = useCallback(() => {
@@ -92,7 +94,7 @@ export const Playerbar = () => {
           crossfadeDuration={settings.crossfadeDuration}
           crossfadeStyle={settings.crossfadeStyle}
           currentPlayer={player}
-          muted={settings.muted}
+          muted={muted}
           playbackStyle={settings.style}
           player1={player1}
           player2={player2}

--- a/src/renderer/features/player/hooks/use-center-controls.ts
+++ b/src/renderer/features/player/hooks/use-center-controls.ts
@@ -754,7 +754,7 @@ export const useCenterControls = (args: { playersRef: any }) => {
       });
 
       mpris.requestVolume((_e: any, data: { volume: number }) => {
-        let newVolume = data.volume * 100;
+        let newVolume = Math.round(data.volume * 100);
 
         if (newVolume > 100) {
           newVolume = 100;
@@ -763,6 +763,7 @@ export const useCenterControls = (args: { playersRef: any }) => {
         }
 
         usePlayerStore.getState().actions.setVolume(newVolume);
+        mpris.updateVolume(data.volume);
 
         if (isMpvPlayer) {
           mpvPlayer.volume(newVolume);

--- a/src/renderer/features/player/hooks/use-center-controls.ts
+++ b/src/renderer/features/player/hooks/use-center-controls.ts
@@ -24,7 +24,7 @@ const mpvPlayerListener = isElectron() ? window.electron.mpvPlayerListener : nul
 const ipc = isElectron() ? window.electron.ipc : null;
 const utils = isElectron() ? window.electron.utils : null;
 const mpris = isElectron() && utils?.isLinux() ? window.electron.mpris : null;
-const mediaSession = !isElectron() ? navigator.mediaSession : null;
+const mediaSession = !isElectron() || !utils?.isLinux() ? navigator.mediaSession : null;
 
 export const useCenterControls = (args: { playersRef: any }) => {
   const { playersRef } = args;

--- a/src/renderer/features/player/hooks/use-right-controls.ts
+++ b/src/renderer/features/player/hooks/use-right-controls.ts
@@ -6,6 +6,8 @@ import { useGeneralSettings } from '/@/renderer/store/settings.store';
 const mpvPlayer = isElectron() ? window.electron.mpvPlayer : null;
 const mpvPlayerListener = isElectron() ? window.electron.mpvPlayerListener : null;
 const ipc = isElectron() ? window.electron.ipc : null;
+const utils = isElectron() ? window.electron.utils : null;
+const mpris = isElectron() && utils?.isLinux() ? window.electron.mpris : null;
 
 const calculateVolumeUp = (volume: number, volumeWheelStep: number) => {
   let volumeToSet;
@@ -41,6 +43,7 @@ export const useRightControls = () => {
   useEffect(() => {
     if (isElectron()) {
       mpvPlayer.volume(volume);
+      mpris?.updateVolume(volume / 100);
 
       if (muted) {
         mpvPlayer.mute();
@@ -52,22 +55,26 @@ export const useRightControls = () => {
 
   const handleVolumeSlider = (e: number) => {
     mpvPlayer?.volume(e);
+    mpris?.updateVolume(e / 100);
     setVolume(e);
   };
 
   const handleVolumeSliderState = (e: number) => {
+    mpris?.updateVolume(e / 100);
     setVolume(e);
   };
 
   const handleVolumeDown = useCallback(() => {
     const volumeToSet = calculateVolumeDown(volume, volumeWheelStep);
     mpvPlayer?.volume(volumeToSet);
+    mpris?.updateVolume(volumeToSet / 100);
     setVolume(volumeToSet);
   }, [setVolume, volume, volumeWheelStep]);
 
   const handleVolumeUp = useCallback(() => {
     const volumeToSet = calculateVolumeUp(volume, volumeWheelStep);
     mpvPlayer?.volume(volumeToSet);
+    mpris?.updateVolume(volumeToSet / 100);
     setVolume(volumeToSet);
   }, [setVolume, volume, volumeWheelStep]);
 
@@ -81,6 +88,7 @@ export const useRightControls = () => {
       }
 
       mpvPlayer?.volume(volumeToSet);
+      mpris?.updateVolume(volumeToSet / 100);
       setVolume(volumeToSet);
     },
     [setVolume, volume, volumeWheelStep],


### PR DESCRIPTION
Changes:
- Fix MPRIS: shuffle is a boolean, not a string.
- Fix MPRIS: handle volume properly (get/set)
- Make mute button actually work in the web ui
- Add navigator.mediasession to show current playing track/album/info and support and support media keys