### PR TITLE
Add zooming functionality

### DIFF
--- a/src/main/preload/local-settings.ts
+++ b/src/main/preload/local-settings.ts
@@ -1,4 +1,4 @@
-import { ipcRenderer } from 'electron';
+import { ipcRenderer, webFrame } from 'electron';
 import Store from 'electron-store';
 
 const store = new Store();
@@ -23,10 +23,15 @@ const disableMediaKeys = () => {
   ipcRenderer.send('global-media-keys-disable');
 };
 
+const setZoomFactor = (zoomFactor: number) => {
+  webFrame.setZoomFactor(zoomFactor / 100);
+};
+
 export const localSettings = {
   disableMediaKeys,
   enableMediaKeys,
   get,
   restart,
   set,
+  setZoomFactor,
 };

--- a/src/renderer/features/settings/components/general/application-settings.tsx
+++ b/src/renderer/features/settings/components/general/application-settings.tsx
@@ -1,9 +1,12 @@
-import { Select } from '/@/renderer/components';
+import isElectron from 'is-electron';
+import { NumberInput, Select } from '/@/renderer/components';
 import {
   SettingsSection,
   SettingOption,
 } from '/@/renderer/features/settings/components/settings-section';
 import { useGeneralSettings, useSettingsStoreActions } from '/@/renderer/store/settings.store';
+
+const localSettings = isElectron() ? window.electron.localSettings : null;
 
 const FONT_OPTIONS = [
   { label: 'Archivo', value: 'Archivo' },
@@ -52,6 +55,30 @@ export const ApplicationSettings = () => {
       description: 'Sets the application content font',
       isHidden: false,
       title: 'Font (Content)',
+    },
+    {
+      control: (
+        <NumberInput
+          disabled={!isElectron()}
+          max={300}
+          min={50}
+          value={settings.zoomFactor}
+          onChange={(e) => {
+            console.log(e);
+            if (!e) return;
+            setSettings({
+              general: {
+                ...settings,
+                zoomFactor: e,
+              },
+            });
+            localSettings.setZoomFactor(e);
+          }}
+        />
+      ),
+      description: 'Sets the application zoom factor in percent',
+      isHidden: false,
+      title: 'Zoom factor',
     },
   ];
 

--- a/src/renderer/features/settings/components/general/application-settings.tsx
+++ b/src/renderer/features/settings/components/general/application-settings.tsx
@@ -63,16 +63,18 @@ export const ApplicationSettings = () => {
           max={300}
           min={50}
           value={settings.zoomFactor}
-          onChange={(e) => {
-            console.log(e);
+          onBlur={(e) => {
             if (!e) return;
+            const newVal = e.currentTarget.value
+              ? Math.min(Math.max(Number(e.currentTarget.value), 50), 300)
+              : settings.zoomFactor;
             setSettings({
               general: {
                 ...settings,
-                zoomFactor: e,
+                zoomFactor: newVal,
               },
             });
-            localSettings.setZoomFactor(e);
+            localSettings.setZoomFactor(newVal);
           }}
         />
       ),

--- a/src/renderer/features/settings/components/hotkeys/hotkey-manager-settings.tsx
+++ b/src/renderer/features/settings/components/hotkeys/hotkey-manager-settings.tsx
@@ -67,6 +67,8 @@ export const HotkeyManagerSettings = () => {
           else if (e.key === '/') keys.push('numpaddivide');
           else if (e.key === '.') keys.push('numpaddecimal');
           else keys.push(`numpad${e.key}`.toLowerCase());
+        } else if (e.key === '+') {
+          keys.push('equal');
         } else {
           keys.push(e.key?.toLowerCase());
         }

--- a/src/renderer/features/settings/components/hotkeys/hotkey-manager-settings.tsx
+++ b/src/renderer/features/settings/components/hotkeys/hotkey-manager-settings.tsx
@@ -28,6 +28,8 @@ const BINDINGS_MAP: Record<BindingActions, string> = {
   volumeDown: 'Volume down',
   volumeMute: 'Volume mute',
   volumeUp: 'Volume up',
+  zoomIn: 'Zoom in',
+  zoomOut: 'Zoom out',
 };
 
 const HotkeysContainer = styled.div`

--- a/src/renderer/layouts/default-layout.tsx
+++ b/src/renderer/layouts/default-layout.tsx
@@ -11,7 +11,7 @@ import {
 import { Platform, PlaybackType } from '/@/renderer/types';
 import { MainContent } from '/@/renderer/layouts/default-layout/main-content';
 import { PlayerBar } from '/@/renderer/layouts/default-layout/player-bar';
-import { useHotkeys } from '@mantine/hooks';
+import { HotkeyItem, useHotkeys } from '@mantine/hooks';
 import { CommandPalette } from '/@/renderer/features/search/components/command-palette';
 import { useCommandPalette } from '/@/renderer/store';
 
@@ -67,14 +67,19 @@ export const DefaultLayout = ({ shell }: DefaultLayoutProps) => {
         zoomFactor: newVal,
       },
     });
-    console.log(settings.zoomFactor);
     localSettings?.setZoomFactor(settings.zoomFactor);
   };
   localSettings?.setZoomFactor(settings.zoomFactor);
 
-  useHotkeys([[bindings.zoomIn.hotkey, () => updateZoom(5)]]);
-  useHotkeys([[bindings.zoomOut.hotkey, () => updateZoom(-5)]]);
-  useHotkeys([[bindings.globalSearch.hotkey, () => handlers.open()]]);
+  const zoomHotkeys: HotkeyItem[] = [
+    [bindings.zoomIn.hotkey, () => updateZoom(5)],
+    [bindings.zoomOut.hotkey, () => updateZoom(-5)],
+  ];
+
+  useHotkeys([
+    [bindings.globalSearch.hotkey, () => handlers.open()],
+    ...(isElectron() ? zoomHotkeys : []),
+  ]);
 
   return (
     <>

--- a/src/renderer/layouts/default-layout.tsx
+++ b/src/renderer/layouts/default-layout.tsx
@@ -5,6 +5,8 @@ import {
   useWindowSettings,
   useSettingsStore,
   useHotkeySettings,
+  useGeneralSettings,
+  useSettingsStoreActions,
 } from '/@/renderer/store/settings.store';
 import { Platform, PlaybackType } from '/@/renderer/types';
 import { MainContent } from '/@/renderer/layouts/default-layout/main-content';
@@ -52,7 +54,26 @@ export const DefaultLayout = ({ shell }: DefaultLayoutProps) => {
   const { windowBarStyle } = useWindowSettings();
   const { opened, ...handlers } = useCommandPalette();
   const { bindings } = useHotkeySettings();
+  const localSettings = isElectron() ? window.electron.localSettings : null;
+  const settings = useGeneralSettings();
+  const { setSettings } = useSettingsStoreActions();
 
+  const updateZoom = (increase: number) => {
+    const newVal = settings.zoomFactor + increase;
+    if (newVal > 300 || newVal < 50 || !isElectron()) return;
+    setSettings({
+      general: {
+        ...settings,
+        zoomFactor: newVal,
+      },
+    });
+    console.log(settings.zoomFactor);
+    localSettings?.setZoomFactor(settings.zoomFactor);
+  };
+  localSettings?.setZoomFactor(settings.zoomFactor);
+
+  useHotkeys([[bindings.zoomIn.hotkey, () => updateZoom(5)]]);
+  useHotkeys([[bindings.zoomOut.hotkey, () => updateZoom(-5)]]);
   useHotkeys([[bindings.globalSearch.hotkey, () => handlers.open()]]);
 
   return (

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -95,6 +95,8 @@ export enum BindingActions {
   TOGGLE_REPEAT = 'toggleRepeat',
   VOLUME_DOWN = 'volumeDown',
   VOLUME_UP = 'volumeUp',
+  ZOOM_IN = 'zoomIn',
+  ZOOM_OUT = 'zoomOut',
 }
 
 export interface SettingsState {
@@ -116,6 +118,7 @@ export interface SettingsState {
     themeDark: AppTheme;
     themeLight: AppTheme;
     volumeWheelStep: number;
+    zoomFactor: number;
   };
   hotkeys: {
     bindings: Record<BindingActions, { allowGlobal: boolean; hotkey: string; isGlobal: boolean }>;
@@ -185,6 +188,7 @@ const initialState: SettingsState = {
     themeDark: AppTheme.DEFAULT_DARK,
     themeLight: AppTheme.DEFAULT_LIGHT,
     volumeWheelStep: 5,
+    zoomFactor: 100,
   },
   hotkeys: {
     bindings: {
@@ -205,6 +209,8 @@ const initialState: SettingsState = {
       volumeDown: { allowGlobal: true, hotkey: '', isGlobal: false },
       volumeMute: { allowGlobal: true, hotkey: '', isGlobal: false },
       volumeUp: { allowGlobal: true, hotkey: '', isGlobal: false },
+      zoomIn: { allowGlobal: true, hotkey: '', isGlobal: false },
+      zoomOut: { allowGlobal: true, hotkey: '', isGlobal: false },
     },
     globalMediaHotkeys: true,
   },


### PR DESCRIPTION
Hey, this should allow scaling the app and maybe even be a quick fix for #124 and #130.
I noticed that we aren't able to use the plus key in hotkeys. There doesn't seem to be a way around it, since [Mantines hotkey parser splits hotkey strings at pluses](https://github.com/mantinedev/mantine/blob/8c12a76c56da51af34213f18dd67c8b72a0ddb44/src/mantine-hooks/src/use-hotkeys/parse-hotkey.ts#L18). Do you maybe know a way around this to allow mod+plus and mod+minus to be the hotkeys for zooming?