### PR TITLE
Show first instance when starting a second one

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -84,6 +84,10 @@ const singleInstance = app.requestSingleInstanceLock();
 
 if (!singleInstance) {
   app.quit();
+} else {
+  app.on('second-instance', (_event, _argv, _workingDirectory) => {
+    mainWindow?.show();
+  });
 }
 
 const RESOURCES_PATH = app.isPackaged


### PR DESCRIPTION
Fix for #145.
This way the application shows itself when a second instance is launched.