### PR TITLE
Update default window bar style to be platform-specific

### DIFF
--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -21,6 +21,8 @@ import {
   Platform,
 } from '/@/renderer/types';
 
+const utils = isElectron() ? window.electron.utils : null;
+
 export type SidebarItemType = {
   disabled: boolean;
   id: string;
@@ -168,6 +170,13 @@ export interface SettingsSlice extends SettingsState {
     setSidebarItems: (items: SidebarItemType[]) => void;
   };
 }
+
+// Determines the default/initial windowBarStyle value based on the current platform.
+const getPlatformDefaultWindowBarStyle = (): Platform => {
+  return isElectron() ? (utils.isMacOS() ? Platform.MACOS : Platform.WINDOWS) : Platform.WEB;
+};
+
+const platformDefaultWindowBarStyle: Platform = getPlatformDefaultWindowBarStyle();
 
 const initialState: SettingsState = {
   general: {
@@ -369,7 +378,7 @@ const initialState: SettingsState = {
     disableAutoUpdate: false,
     exitToTray: false,
     minimizeToTray: false,
-    windowBarStyle: isElectron() ? Platform.WINDOWS : Platform.WEB,
+    windowBarStyle: platformDefaultWindowBarStyle,
   },
 };
 


### PR DESCRIPTION
On MacOS this will update the (default) window bar to the native MacOS style (maintaining existing behaviour for windows, linux & web).

![Screenshot 2023-06-19 at 12 47 06](https://github.com/jeffvli/feishin/assets/2040617/5d81f960-1860-4160-9831-3d3fadd89acf)
