### PR TITLE
Fix Jellyfin album duration normalization

### DIFF
--- a/src/renderer/api/jellyfin/jellyfin-normalize.ts
+++ b/src/renderer/api/jellyfin/jellyfin-normalize.ts
@@ -201,7 +201,7 @@ const normalizeAlbum = (
         })),
         backdropImageUrl: null,
         createdAt: item.DateCreated,
-        duration: item.RunTimeTicks / 10000,
+        duration: item.RunTimeTicks / 10000000,
         genres: item.GenreItems?.map((entry) => ({ id: entry.Id, name: entry.Name })),
         id: item.Id,
         imagePlaceholderUrl: null,

--- a/src/renderer/features/albums/components/album-detail-header.tsx
+++ b/src/renderer/features/albums/components/album-detail-header.tsx
@@ -37,7 +37,8 @@ export const AlbumDetailHeader = forwardRef(
                 id: 'duration',
                 secondary: false,
                 value:
-                    detailQuery?.data?.duration && formatDurationString(detailQuery.data.duration),
+                    detailQuery?.data?.duration &&
+                    formatDurationString(detailQuery.data.duration * 1000),
             },
         ];
 


### PR DESCRIPTION
This PR fixes wrong album durations in the album table view.
The Jellyfin API provides the album runtime as 10,000,000 Ticks per second, just like the songs.

![image](https://github.com/jeffvli/feishin/assets/30231932/ed8bfcca-b67d-42a4-b590-db3b1e7e817e)
becomes
![image](https://github.com/jeffvli/feishin/assets/30231932/35c2d3b4-77c2-4085-bd0e-52f2efccdfda)
