### PR TITLE
Fix sidebar layout to show full album cover

### DIFF
--- a/src/renderer/features/sidebar/components/sidebar.tsx
+++ b/src/renderer/features/sidebar/components/sidebar.tsx
@@ -57,10 +57,14 @@ import { Platform } from '/@/renderer/types';
 
 const SidebarContainer = styled.div<{ windowBarStyle: Platform }>`
     height: 100%;
-    max-height: ${(props) =>
-        props.windowBarStyle === Platform.WEB || props.windowBarStyle === Platform.LINUX
-            ? 'calc(100vh - 149px)'
-            : 'calc(100vh - 179px)'}; // Playerbar (90px), titlebar (65px), windowbar (30px)
+    max-height: ${
+        (props) =>
+            props.windowBarStyle === Platform.WEB || props.windowBarStyle === Platform.LINUX
+                ? 'calc(100vh - 160px)' // Playerbar (90px) & ActionBar (70px)
+                : 'calc(100vh - 190px)' // plus windowbar (30px) if the windowBarStyle is Windows/Mac
+        // We use the height of the SidebarContainer to keep the Stack below the ActionBar at the correct height
+        // ActionBar uses height: 100%; so it has the full height of its parent
+    };
     user-select: none;
 `;
 


### PR DESCRIPTION
I had a closer look at the Sidebar layout to fix #158 and now understand how it works.
I don't know how the previous numbers came to be, I assume they're from a now changed previous layout?
If the Titlebar does not have any relevance for the sidebar (I've only ever seen it on the right-hand side of the window when using the “Web” Window bar style) this should be fixed.

Also, a question from a web-dev noob: Why not use something like Flexbox for this kind of layout, wouldn't that make it easier?