### PR TITLE
Improve MPV initialization and restore

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -11,11 +11,6 @@
 import { access, constants, readFile, writeFile } from 'fs';
 import path, { join } from 'path';
 import { deflate, inflate } from 'zlib';
-import electronLocalShortcut from 'electron-localshortcut';
-import log from 'electron-log';
-import { autoUpdater } from 'electron-updater';
-import uniq from 'lodash/uniq';
-import MpvAPI from 'node-mpv';
 import {
     app,
     BrowserWindow,
@@ -27,6 +22,11 @@ import {
     nativeImage,
     BrowserWindowConstructorOptions,
 } from 'electron';
+import electronLocalShortcut from 'electron-localshortcut';
+import log from 'electron-log';
+import { autoUpdater } from 'electron-updater';
+import uniq from 'lodash/uniq';
+import MpvAPI from 'node-mpv';
 import { disableMediaKeys, enableMediaKeys } from './features/core/player/media-keys';
 import { store } from './features/core/settings/index';
 import MenuBuilder from './menu';
@@ -453,12 +453,15 @@ const createMpv = (data: { extraParameters?: string[]; properties?: Record<strin
         params,
     );
 
-    console.log('Setting MPV properties: ', properties);
-    mpv.setMultipleProperties(properties || {});
-
-    mpv.start().catch((error) => {
-        console.log('MPV failed to start', error);
-    });
+    // eslint-disable-next-line promise/catch-or-return
+    mpv.start()
+        .catch((error) => {
+            console.log('MPV failed to start', error);
+        })
+        .finally(() => {
+            console.log('Setting MPV properties: ', properties);
+            mpv.setMultipleProperties(properties || {});
+        });
 
     mpv.on('status', (status, ...rest) => {
         console.log('MPV Event: status', status.property, status.value, rest);

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -73,6 +73,7 @@ export const App = () => {
 
                 mpvPlayer?.volume(properties.volume);
             }
+            mpvPlayer?.restoreQueue();
         };
 
         if (isElectron() && playbackType === PlaybackType.LOCAL) {
@@ -94,8 +95,6 @@ export const App = () => {
 
     useEffect(() => {
         if (isElectron()) {
-            mpvPlayer!.restoreQueue();
-
             mpvPlayerListener!.rendererSaveQueue(() => {
                 const { current, queue } = usePlayerStore.getState();
                 const stateToSave: Partial<Pick<PlayerState, 'current' | 'queue'>> = {

--- a/src/renderer/store/player.store.ts
+++ b/src/renderer/store/player.store.ts
@@ -701,6 +701,7 @@ export const usePlayerStore = create<PlayerSlice>()(
                                 state.current = {
                                     ...state.current,
                                     ...data.current,
+                                    time: 0,
                                 };
                                 state.queue = {
                                     ...state.queue,


### PR DESCRIPTION
- set mpv settings only after it has successfully started (at least on linux, settings were not taken)
- change timing of restore queue to behave properly