### PR TITLE
Adjust quarantine bit warning wording to include all Macs running 12+

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Rewrite of [Sonixd](https://github.com/jeffvli/sonixd).
 
 Download the [latest desktop client](https://github.com/jeffvli/feishin/releases).
 
-If you're using an M1 macOS device, [check here](https://github.com/jeffvli/feishin/issues/104#issuecomment-1553914730) for instructions on how to remove the app from quarantine.
+If you're using a device running macOS 12 (Monterey) or higher, [check here](https://github.com/jeffvli/feishin/issues/104#issuecomment-1553914730) for instructions on how to remove the app from quarantine.
 
 ### Configuration
 


### PR DESCRIPTION
Just installed Feishin on a couple of my Macs -- an older Intel Mac running Monterey, and a brand-new Macbook Pro running Ventura on an M2 Pro processor. Both required me to remove the quarantine bit before I could launch the dmg.

I noticed the wording in the README only refers to the first Apple Silicon processor, the M1, and no subsequent processors, and doesn't include any Intel machines at all. Since recent versions of macOS seem to care about the quarantine bit regardless of architecture, I figured you might want to change the language.

Sorry if my commit message isn't up to snuff, this is my first contribution. Just figured I'd pitch in since I've been a very happy Sonixd user for years.