### PR TITLE
always call autoNext, even if not used

### DIFF
--- a/src/renderer/features/player/components/playerbar.tsx
+++ b/src/renderer/features/player/components/playerbar.tsx
@@ -73,8 +73,9 @@ export const Playerbar = () => {
     const { autoNext } = usePlayerControls();
 
     const autoNextFn = useCallback(() => {
+        const playerData = autoNext();
+
         if (remote) {
-            const playerData = autoNext();
             remote.updateSong({
                 currentTime: 0,
                 song: playerData.current.song,


### PR DESCRIPTION
One more for the road. This is necessary to actually advance the tracks. Sorry for breaking it in the first place .-.