### PR TITLE
Added docker image build script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,17 @@
+# --- Builder stage
+FROM node:18-alpine as builder
+WORKDIR /app
+COPY . /app
+
+# Scripts include electron-specific dependencies, which we don't need
+RUN npm install --legacy-peer-deps --ignore-scripts
+RUN npm run build:web
+
+# --- Production stage
 FROM nginx:alpine-slim
-COPY release/app/dist/web /usr/share/nginx/html
+
+COPY --from=builder /app/release/app/dist/web /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+
 EXPOSE 9180
+CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx:latest
+COPY release/app/dist/web /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:latest
+FROM nginx:alpine-slim
 COPY release/app/dist/web /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
-EXPOSE 80
+EXPOSE 9180

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,20 @@
+server {
+  listen 80;
+  sendfile on;
+  default_type application/octet-stream;
+
+  gzip on;
+  gzip_http_version 1.1;
+  gzip_disable      "MSIE [1-6]\.";
+  gzip_min_length   256;
+  gzip_vary         on;
+  gzip_proxied      expired no-cache no-store private auth;
+  gzip_types        text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+  gzip_comp_level   9;
+
+  root /usr/share/nginx/html;
+
+  location / {
+    try_files $uri $uri/ /index.html =404;
+  }
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,5 +1,5 @@
 server {
-  listen 80;
+  listen 9180;
   sendfile on;
   default_type application/octet-stream;
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "build:remote": "cross-env NODE_ENV=production TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.remote.prod.ts",
         "build:renderer": "cross-env NODE_ENV=production TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.renderer.prod.ts",
         "build:web": "cross-env NODE_ENV=production TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.web.prod.ts",
+        "build:docker": "npm run build:web && docker build -t jeffvli/feishin .",
         "rebuild": "electron-rebuild --parallel --types prod,dev,optional --module-dir release/app",
         "lint": "cross-env NODE_ENV=development eslint . --ext .js,.jsx,.ts,.tsx",
         "lint:fix": "cross-env NODE_ENV=development eslint . --ext .js,.jsx,.ts,.tsx --fix",


### PR DESCRIPTION
This PR adds the becesary files to build and serve a production ready docker image that uses the web version behind an nginx server. It is perfect for self hosted people like me. The build script is ready to be just ran and the image uploaded to as a "official" feishin docker image. the built image is around 200MB in size, 90MB compressed. Wich makes this a really light app.

It is note worthy that it might be necesary to change the port from 80 to something else as this settings are intended to be ran behind a proxy and not directly as a service, but some people might want to do it that way.