### PR TITLE
Prevent MPV from loading user config/scripts (#234 & #242)

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -426,7 +426,7 @@ const prefetchPlaylistParams = [
 ];
 
 const DEFAULT_MPV_PARAMETERS = (extraParameters?: string[]) => {
-    const parameters = ['--idle=yes'];
+    const parameters = ['--idle=yes', '--no-config', '--load-scripts=no'];
 
     if (!extraParameters?.some((param) => prefetchPlaylistParams.includes(param))) {
         parameters.push('--prefetch-playlist=yes');


### PR DESCRIPTION
This is a very quick fix which just disables mpv loading the users configuration file and local scripts.  
Tested with the same scenario from #234.