### PR TITLE
[Remote] Fix Favicon, Support auth on ios

### DIFF
--- a/.erb/configs/webpack.config.remote.dev.ts
+++ b/.erb/configs/webpack.config.remote.dev.ts
@@ -96,6 +96,7 @@ const configuration: webpack.Configuration = {
     new HtmlWebpackPlugin({
       filename: path.join('index.html'),
       template: path.join(webpackPaths.srcRemotePath, 'index.ejs'),
+      favicon: path.join(webpackPaths.assetsPath, 'icons', 'favicon.ico'),
       minify: {
         collapseWhitespace: true,
         removeAttributeQuotes: true,

--- a/.erb/configs/webpack.config.remote.prod.ts
+++ b/.erb/configs/webpack.config.remote.prod.ts
@@ -117,6 +117,7 @@ const configuration: webpack.Configuration = {
     new HtmlWebpackPlugin({
       filename: 'index.html',
       template: path.join(webpackPaths.srcRendererPath, 'index.ejs'),
+      favicon: path.join(webpackPaths.assetsPath, 'icons', 'favicon.ico'),
       minify: {
         collapseWhitespace: true,
         removeAttributeQuotes: true,

--- a/src/remote/components/shell.tsx
+++ b/src/remote/components/shell.tsx
@@ -26,7 +26,6 @@ export const Shell = () => {
                         <Grid.Col span="auto">
                             <div>
                                 <Image
-                                    bg="rgb(25, 25, 25)"
                                     fit="contain"
                                     height={60}
                                     src="/favicon.ico"


### PR DESCRIPTION
Favicon path appears to have moved, use new one.
Websockets (at least on iOS) do not include additional headers (notably, basic auth headers), so as a workaround have different authentication scheme: client (after basic auth), sends a request to `/credentials`, returning the header (cannot easily access headers), then socket will send that.