### PR TITLE
fix scrobble durations

### DIFF
--- a/src/renderer/features/player/hooks/use-scrobble.ts
+++ b/src/renderer/features/player/hooks/use-scrobble.ts
@@ -36,17 +36,18 @@ Progress Events (Jellyfin only):
 const checkScrobbleConditions = (args: {
     scrobbleAtDuration: number;
     scrobbleAtPercentage: number;
-    songCompletedDuration: number;
-    songDuration: number;
+    songCompletedDurationSec: number;
+    songDurationMs: number;
 }) => {
-    const { scrobbleAtDuration, scrobbleAtPercentage, songCompletedDuration, songDuration } = args;
-    const percentageOfSongCompleted = songDuration
-        ? (songCompletedDuration / songDuration) * 100
+    const { scrobbleAtDuration, scrobbleAtPercentage, songCompletedDurationSec, songDurationMs } =
+        args;
+    const percentageOfSongCompleted = songDurationMs
+        ? ((songCompletedDurationSec * 1000) / songDurationMs) * 100
         : 0;
 
     return (
         percentageOfSongCompleted >= scrobbleAtPercentage ||
-        songCompletedDuration >= scrobbleAtDuration
+        songCompletedDurationSec >= scrobbleAtDuration
     );
 };
 
@@ -104,8 +105,8 @@ export const useScrobble = () => {
                 const shouldSubmitScrobble = checkScrobbleConditions({
                     scrobbleAtDuration: scrobbleSettings?.scrobbleAtDuration,
                     scrobbleAtPercentage: scrobbleSettings?.scrobbleAtPercentage,
-                    songCompletedDuration: previousSongTime,
-                    songDuration: previousSong.duration,
+                    songCompletedDurationSec: previousSongTime,
+                    songDurationMs: previousSong.duration,
                 });
 
                 if (
@@ -219,8 +220,8 @@ export const useScrobble = () => {
                 const shouldSubmitScrobble = checkScrobbleConditions({
                     scrobbleAtDuration: scrobbleSettings?.scrobbleAtDuration,
                     scrobbleAtPercentage: scrobbleSettings?.scrobbleAtPercentage,
-                    songCompletedDuration: usePlayerStore.getState().current.time,
-                    songDuration: currentSong.duration,
+                    songCompletedDurationSec: usePlayerStore.getState().current.time,
+                    songDurationMs: currentSong.duration,
                 });
 
                 if (!isCurrentSongScrobbled && shouldSubmitScrobble) {
@@ -263,8 +264,8 @@ export const useScrobble = () => {
             const shouldSubmitScrobble = checkScrobbleConditions({
                 scrobbleAtDuration: scrobbleSettings?.scrobbleAtDuration,
                 scrobbleAtPercentage: scrobbleSettings?.scrobbleAtPercentage,
-                songCompletedDuration: currentTime,
-                songDuration: currentSong.duration,
+                songCompletedDurationSec: currentTime,
+                songDurationMs: currentSong.duration,
             });
 
             if (!isCurrentSongScrobbled && shouldSubmitScrobble) {


### PR DESCRIPTION
Something changed to the duration that makes it ms, but the song time is measured in seconds. This PR seeks to address that. (note that I am not sure if this is all of the cases, but it _appears_ to behave in Jellyfin and Navidrome)