### PR TITLE
[bugfix]: MPV do not next/prev on queue set

### DIFF
--- a/src/renderer/features/player/hooks/use-center-controls.ts
+++ b/src/renderer/features/player/hooks/use-center-controls.ts
@@ -308,7 +308,6 @@ export const useCenterControls = (args: { playersRef: any }) => {
                 const playerData = next();
                 mprisUpdateSong({ song: playerData.current.song, status: PlayerStatus.PLAYING });
                 mpvPlayer!.setQueue(playerData);
-                mpvPlayer!.next();
             },
             web: () => {
                 const playerData = next();
@@ -331,7 +330,6 @@ export const useCenterControls = (args: { playersRef: any }) => {
                         status: PlayerStatus.PLAYING,
                     });
                     mpvPlayer!.setQueue(playerData);
-                    mpvPlayer!.next();
                 }
             },
             web: () => {
@@ -359,7 +357,6 @@ export const useCenterControls = (args: { playersRef: any }) => {
                 const playerData = next();
                 mprisUpdateSong({ song: playerData.current.song, status: PlayerStatus.PLAYING });
                 mpvPlayer!.setQueue(playerData);
-                mpvPlayer!.next();
             },
             web: () => {
                 if (!isLastTrack) {
@@ -426,7 +423,6 @@ export const useCenterControls = (args: { playersRef: any }) => {
                         status: PlayerStatus.PLAYING,
                     });
                     mpvPlayer!.setQueue(playerData);
-                    mpvPlayer!.previous();
                 } else {
                     const playerData = setCurrentIndex(queue.length - 1);
                     mprisUpdateSong({
@@ -434,7 +430,6 @@ export const useCenterControls = (args: { playersRef: any }) => {
                         status: PlayerStatus.PLAYING,
                     });
                     mpvPlayer!.setQueue(playerData);
-                    mpvPlayer!.previous();
                 }
             },
             web: () => {
@@ -464,7 +459,6 @@ export const useCenterControls = (args: { playersRef: any }) => {
                     song: playerData.current.song,
                 });
                 mpvPlayer!.setQueue(playerData);
-                mpvPlayer!.previous();
             },
             web: () => {
                 if (isFirstTrack) {
@@ -491,7 +485,6 @@ export const useCenterControls = (args: { playersRef: any }) => {
                         status: PlayerStatus.PLAYING,
                     });
                     mpvPlayer!.setQueue(playerData);
-                    mpvPlayer!.previous();
                 } else {
                     mpvPlayer!.stop();
                 }


### PR DESCRIPTION
When calling setQueue, do not successively call next()/prev(). Somehow, prev() works, but for next() there is a race condition where after the first skip you will skip two tracks.