### PR TITLE
In the fullscreen player use dynamic resolution for the main image

### DIFF
--- a/src/renderer/features/player/components/full-screen-player-image.tsx
+++ b/src/renderer/features/player/components/full-screen-player-image.tsx
@@ -148,7 +148,7 @@ export const FullScreenPlayerImage = () => {
     const updateImageSize = ()=>{
       if (mainImageRef.current) {
         setMainImageDimensions({
-            idealSize: Math.round(mainImageRef.current.offsetHeight / 100) * 100
+            idealSize: Math.ceil(mainImageRef.current.offsetHeight / 100) * 100
         });
 
         setImageState({


### PR DESCRIPTION
With the **current** behaviour, the full screen player main cover art is **always** at 500×500. On smaller screens this looks fine, but on higher resolution screens, it can be too blurry.

Now, instead of hard-coding a value, the client will fetch the **ideal** size depending on the client's display resolution. So higher resolution clients, can fetch **prettier pictures**, and lower resolution clients **save on bandwidth**.

I've tested this on Firefox, compiled with docker.

#### Technical stuff
- To allow for more cache hits, it gets image sizes in multiples of 100, preferring the next highest one
 (Ex: 155px -> 200px)
- To minimize the issue of it loading the image twice, the first time it loads the image as 1×1, before figuring out the right size. (I haven't found a cleaner solution, feel free to change it if you find a better one) 