### PR TITLE
[bugfix]: Fix MPV player playing the same track twice after toggling repeat

### DIFF
--- a/src/renderer/features/player/hooks/use-center-controls.ts
+++ b/src/renderer/features/player/hooks/use-center-controls.ts
@@ -191,8 +191,9 @@ export const useCenterControls = (args: { playersRef: any }) => {
             return mpvPlayer?.setQueueNext(playerData);
         }
 
+        const playerData = setRepeat(PlayerRepeat.NONE);
         remote?.updateRepeat(PlayerRepeat.NONE);
-        return setRepeat(PlayerRepeat.NONE);
+        return mpvPlayer?.setQueueNext(playerData);
     }, [repeatStatus, setRepeat]);
 
     const checkIsLastTrack = useCallback(() => {


### PR DESCRIPTION
When toggling from repeat one -> repeat none, currently the MPV queue is not cleared. This fix updates the MPV queue again.