### PR TITLE
[bugfix]: properly implement Jellyfin getSongDetail

### DIFF
--- a/src/renderer/api/controller.ts
+++ b/src/renderer/api/controller.ts
@@ -128,7 +128,7 @@ const endpoints: ApiController = {
         getPlaylistList: jfController.getPlaylistList,
         getPlaylistSongList: jfController.getPlaylistSongList,
         getRandomSongList: jfController.getRandomSongList,
-        getSongDetail: undefined,
+        getSongDetail: jfController.getSongDetail,
         getSongList: jfController.getSongList,
         getTopSongs: jfController.getTopSongList,
         getUserList: undefined,

--- a/src/renderer/api/jellyfin/jellyfin-api.ts
+++ b/src/renderer/api/jellyfin/jellyfin-api.ts
@@ -160,7 +160,7 @@ export const contract = c.router({
     },
     getSongDetail: {
         method: 'GET',
-        path: 'song/:id',
+        path: 'users/:userId/items/:id',
         responses: {
             200: jfType._response.song,
             400: jfType._response.error,

--- a/src/renderer/api/jellyfin/jellyfin-controller.ts
+++ b/src/renderer/api/jellyfin/jellyfin-controller.ts
@@ -47,6 +47,8 @@ import {
     LyricsArgs,
     LyricsResponse,
     genreListSortMap,
+    SongDetailArgs,
+    SongDetailResponse,
 } from '/@/renderer/api/types';
 import { jfApiClient } from '/@/renderer/api/jellyfin/jellyfin-api';
 import { jfNormalize } from './jellyfin-normalize';
@@ -940,6 +942,23 @@ const getLyrics = async (args: LyricsArgs): Promise<LyricsResponse> => {
     return res.body.Lyrics.map((lyric) => [lyric.Start! / 1e4, lyric.Text]);
 };
 
+const getSongDetail = async (args: SongDetailArgs): Promise<SongDetailResponse> => {
+    const { query, apiClientProps } = args;
+
+    const res = await jfApiClient(apiClientProps).getSongDetail({
+        params: {
+            id: query.id,
+            userId: apiClientProps.server?.userId ?? '',
+        },
+    });
+
+    if (res.status !== 200) {
+        throw new Error('Failed to get song detail');
+    }
+
+    return jfNormalize.song(res.body, apiClientProps.server, '');
+};
+
 export const jfController = {
     addToPlaylist,
     authenticate,
@@ -959,6 +978,7 @@ export const jfController = {
     getPlaylistList,
     getPlaylistSongList,
     getRandomSongList,
+    getSongDetail,
     getSongList,
     getTopSongList,
     removeFromPlaylist,


### PR DESCRIPTION
Resolves #294. Adds `getSongDetail` (uses the same endpoint as other items)