### PR TITLE
[bugfix]: fix artist discography year filter not clearing

### DIFF
--- a/src/renderer/features/albums/components/navidrome-album-filters.tsx
+++ b/src/renderer/features/albums/components/navidrome-album-filters.tsx
@@ -152,11 +152,11 @@ export const NavidromeAlbumFilters = ({
             customFilters,
             data: {
                 _custom: {
+                    ...filter._custom,
                     navidrome: {
                         ...filter._custom?.navidrome,
                         year: e === '' ? undefined : (e as number),
                     },
-                    ...filter._custom,
                 },
             },
             itemType: LibraryItem.ALBUM,


### PR DESCRIPTION
Resolves #267. Makes the year filter consistent with the other filters