### PR TITLE
[feature]: Support using system fonts

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -21,6 +21,8 @@ import {
     Menu,
     nativeImage,
     BrowserWindowConstructorOptions,
+    protocol,
+    net,
 } from 'electron';
 import electronLocalShortcut from 'electron-localshortcut';
 import log from 'electron-log';
@@ -42,6 +44,8 @@ export default class AppUpdater {
         autoUpdater.checkForUpdatesAndNotify();
     }
 }
+
+protocol.registerSchemesAsPrivileged([{ privileges: { bypassCSP: true }, scheme: 'feishin' }]);
 
 process.on('uncaughtException', (error: any) => {
     console.log('Error in main process', error);
@@ -655,6 +659,10 @@ app.on('window-all-closed', () => {
 
 app.whenReady()
     .then(() => {
+        protocol.handle('feishin', (request) => {
+            return net.fetch(`file://${request.url.slice('feishin://'.length)}`);
+        });
+
         createWindow();
         createTray();
         app.on('activate', () => {

--- a/src/main/preload/local-settings.ts
+++ b/src/main/preload/local-settings.ts
@@ -1,4 +1,4 @@
-import { ipcRenderer, webFrame } from 'electron';
+import { IpcRendererEvent, ipcRenderer, webFrame } from 'electron';
 import Store from 'electron-store';
 
 const store = new Store();
@@ -39,9 +39,14 @@ const setZoomFactor = (zoomFactor: number) => {
     webFrame.setZoomFactor(zoomFactor / 100);
 };
 
+const fontError = (cb: (event: IpcRendererEvent, file: string) => void) => {
+    ipcRenderer.on('custom-font-error', cb);
+};
+
 export const localSettings = {
     disableMediaKeys,
     enableMediaKeys,
+    fontError,
     get,
     passwordGet,
     passwordRemove,

--- a/src/renderer/api/types.ts
+++ b/src/renderer/api/types.ts
@@ -1130,3 +1130,12 @@ export enum LyricSource {
 }
 
 export type LyricsOverride = Omit<FullLyricsMetadata, 'lyrics'> & { id: string };
+
+// This type from https://wicg.github.io/local-font-access/#fontdata
+// NOTE: it is still experimental, so this should be updates as appropriate
+export type FontData = {
+    family: string;
+    fullName: string;
+    postscriptName: string;
+    style: string;
+};

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -23,7 +23,7 @@ import { PlayQueueHandlerContext } from '/@/renderer/features/player';
 import { AddToPlaylistContextModal } from '/@/renderer/features/playlists';
 import { getMpvProperties } from '/@/renderer/features/settings/components/playback/mpv-settings';
 import { PlayerState, usePlayerStore, useQueueControls } from '/@/renderer/store';
-import { PlaybackType, PlayerStatus } from '/@/renderer/types';
+import { FontType, PlaybackType, PlayerStatus } from '/@/renderer/types';
 import '@ag-grid-community/styles/ag-grid.css';
 
 ModuleRegistry.registerModules([ClientSideRowModelModule, InfiniteRowModelModule]);
@@ -37,7 +37,7 @@ const remote = isElectron() ? window.electron.remote : null;
 
 export const App = () => {
     const theme = useTheme();
-    const { builtIn, system, useSystem } = useSettingsStore((state) => state.font);
+    const { builtIn, custom, system, type } = useSettingsStore((state) => state.font);
     const { type: playbackType } = usePlaybackSettings();
     const { bindings } = useHotkeySettings();
     const handlePlayQueueAdd = useHandlePlayQueueAdd();
@@ -46,7 +46,7 @@ export const App = () => {
     const textStyleRef = useRef<HTMLStyleElement>();
 
     useEffect(() => {
-        if (useSystem && system) {
+        if (type === FontType.SYSTEM && system) {
             const root = document.documentElement;
             root.style.setProperty('--content-font-family', 'dynamic-font');
 
@@ -60,11 +60,25 @@ export const App = () => {
                 font-family: "dynamic-font";
                 src: local("${system}");
             }`;
+        } else if (type === FontType.CUSTOM && custom) {
+            const root = document.documentElement;
+            root.style.setProperty('--content-font-family', 'dynamic-font');
+
+            if (!textStyleRef.current) {
+                textStyleRef.current = document.createElement('style');
+                document.body.appendChild(textStyleRef.current);
+            }
+
+            textStyleRef.current.textContent = `
+            @font-face {
+                font-family: "dynamic-font";
+                src: url("feishin://${custom}");
+            }`;
         } else {
             const root = document.documentElement;
             root.style.setProperty('--content-font-family', builtIn);
         }
-    }, [builtIn, system, useSystem]);
+    }, [builtIn, custom, system, type]);
 
     const providerValue = useMemo(() => {
         return { handlePlayQueueAdd };

--- a/src/renderer/features/settings/components/general/application-settings.tsx
+++ b/src/renderer/features/settings/components/general/application-settings.tsx
@@ -1,14 +1,25 @@
+import { Switch } from '@mantine/core';
 import isElectron from 'is-electron';
-import { NumberInput, Select } from '/@/renderer/components';
+import { NumberInput, Select, toast } from '/@/renderer/components';
 import {
     SettingsSection,
     SettingOption,
 } from '/@/renderer/features/settings/components/settings-section';
-import { useGeneralSettings, useSettingsStoreActions } from '/@/renderer/store/settings.store';
+import {
+    useFontSettings,
+    useGeneralSettings,
+    useSettingsStoreActions,
+} from '/@/renderer/store/settings.store';
+import { useEffect, useState } from 'react';
 
 const localSettings = isElectron() ? window.electron.localSettings : null;
 
-const FONT_OPTIONS = [
+type Font = {
+    label: string;
+    value: string;
+};
+
+const FONT_OPTIONS: Font[] = [
     { label: 'Archivo', value: 'Archivo' },
     { label: 'Fredoka', value: 'Fredoka' },
     { label: 'Inter', value: 'Inter' },
@@ -22,7 +33,37 @@ const FONT_OPTIONS = [
 
 export const ApplicationSettings = () => {
     const settings = useGeneralSettings();
+    const fontSettings = useFontSettings();
     const { setSettings } = useSettingsStoreActions();
+    const [localFonts, setLocalFonts] = useState<Font[]>([]);
+
+    useEffect(() => {
+        const getFonts = async () => {
+            if (fontSettings.useSystem && localFonts.length === 0 && window.queryLocalFonts) {
+                try {
+                    const data = await window.queryLocalFonts();
+                    setLocalFonts(
+                        data.map((font) => ({
+                            label: font.fullName,
+                            value: font.postscriptName,
+                        })),
+                    );
+                } catch (error) {
+                    toast.error({
+                        message: 'An error occurred when trying to get system fonts',
+                    });
+
+                    setSettings({
+                        font: {
+                            ...fontSettings,
+                            useSystem: false,
+                        },
+                    });
+                }
+            }
+        };
+        getFonts();
+    }, [fontSettings, localFonts, setSettings]);
 
     const options: SettingOption[] = [
         {
@@ -38,23 +79,63 @@ export const ApplicationSettings = () => {
         },
         {
             control: (
+                <Switch
+                    defaultChecked={fontSettings.useSystem}
+                    onChange={(e) => {
+                        setSettings({
+                            font: {
+                                ...fontSettings,
+                                useSystem: e.currentTarget.checked,
+                            },
+                        });
+                    }}
+                />
+            ),
+            description: 'Whether to select from system fonts, or built-in fonts',
+            isHidden: !window.queryLocalFonts,
+            title: 'Use system font',
+        },
+        {
+            control: (
                 <Select
                     searchable
                     data={FONT_OPTIONS}
-                    defaultValue={settings.fontContent}
+                    value={fontSettings.builtIn}
                     onChange={(e) => {
                         if (!e) return;
                         setSettings({
-                            general: {
-                                ...settings,
-                                fontContent: e,
+                            font: {
+                                ...fontSettings,
+                                builtIn: e,
                             },
                         });
                     }}
                 />
             ),
             description: 'Sets the application content font',
-            isHidden: false,
+            isHidden: localFonts && fontSettings.useSystem,
+            title: 'Font (Content)',
+        },
+        {
+            control: (
+                <Select
+                    searchable
+                    data={localFonts}
+                    value={fontSettings.system}
+                    w={300}
+                    onChange={(e) => {
+                        if (!e) return;
+                        setSettings({
+                            font: {
+                                ...fontSettings,
+                                system: e,
+                            },
+                        });
+                    }}
+                />
+            ),
+            description: 'Sets the application content font',
+            isHidden: !localFonts || !fontSettings.useSystem,
             title: 'Font (Content)',
         },
         {

--- a/src/renderer/features/settings/components/general/application-settings.tsx
+++ b/src/renderer/features/settings/components/general/application-settings.tsx
@@ -41,6 +41,12 @@ export const ApplicationSettings = () => {
         const getFonts = async () => {
             if (fontSettings.useSystem && localFonts.length === 0 && window.queryLocalFonts) {
                 try {
+                    const status = await navigator.permissions.query({ name: 'local-fonts' });
+
+                    if (status.state === 'denied') {
+                        throw new Error('Access denied to local fonts');
+                    }
+
                     const data = await window.queryLocalFonts();
                     setLocalFonts(
                         data.map((font) => ({

--- a/src/renderer/preload.d.ts
+++ b/src/renderer/preload.d.ts
@@ -1,6 +1,6 @@
 import { IpcRendererEvent } from 'electron';
 import { PlayerData, PlayerState } from './store';
-import { InternetProviderLyricResponse, QueueSong } from '/@/renderer/api/types';
+import { FontData, InternetProviderLyricResponse, QueueSong } from '/@/renderer/api/types';
 import { Remote } from '/@/main/preload/remote';
 import { Mpris } from '/@/main/preload/mpris';
 import { MpvPLayer, MpvPlayerListener } from '/@/main/preload/mpv-player';
@@ -76,6 +76,7 @@ declare global {
             remote?: Remote;
             utils?: Utils;
         };
+        queryLocalFonts?: () => Promise<FontData[]>;
     }
 }
 

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -111,10 +111,15 @@ export enum BindingActions {
 }
 
 export interface SettingsState {
+    font: {
+        builtIn: string;
+        system: string | null;
+        useSystem: boolean;
+    };
     general: {
         defaultFullPlaylist: boolean;
         followSystemTheme: boolean;
-        fontContent: string;
+
         playButtonBehavior: Play;
         resume: boolean;
         showQueueDrawerButton: boolean;
@@ -208,10 +213,14 @@ const getPlatformDefaultWindowBarStyle = (): Platform => {
 const platformDefaultWindowBarStyle: Platform = getPlatformDefaultWindowBarStyle();
 
 const initialState: SettingsState = {
+    font: {
+        builtIn: 'Inter',
+        system: null,
+        useSystem: false,
+    },
     general: {
         defaultFullPlaylist: true,
         followSystemTheme: false,
-        fontContent: 'Inter',
         playButtonBehavior: Play.NOW,
         resume: false,
         showQueueDrawerButton: false,
@@ -538,3 +547,5 @@ export const useMpvSettings = () =>
 export const useLyricsSettings = () => useSettingsStore((state) => state.lyrics, shallow);
 
 export const useRemoteSettings = () => useSettingsStore((state) => state.remote, shallow);
+
+export const useFontSettings = () => useSettingsStore((state) => state.font, shallow);

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -19,6 +19,7 @@ import {
     PlaybackType,
     TableType,
     Platform,
+    FontType,
 } from '/@/renderer/types';
 import { randomString } from '/@/renderer/utils';
 
@@ -113,8 +114,9 @@ export enum BindingActions {
 export interface SettingsState {
     font: {
         builtIn: string;
+        custom: string | null;
         system: string | null;
-        useSystem: boolean;
+        type: FontType;
     };
     general: {
         defaultFullPlaylist: boolean;
@@ -215,8 +217,9 @@ const platformDefaultWindowBarStyle: Platform = getPlatformDefaultWindowBarStyle
 const initialState: SettingsState = {
     font: {
         builtIn: 'Inter',
+        custom: null,
         system: null,
-        useSystem: false,
+        type: FontType.BUILT_IN,
     },
     general: {
         defaultFullPlaylist: true,

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -203,3 +203,9 @@ export type SongUpdate = {
     /** This volume is in range 0-100 */
     volume?: number;
 };
+
+export enum FontType {
+    BUILT_IN = 'builtIn',
+    CUSTOM = 'custom',
+    SYSTEM = 'system',
+}


### PR DESCRIPTION
Uses the **experimental** queryLocalFonts API, when prompted, to get the fonts and do CSS. Resolves #270 and also resolves #288 (by proxy)

Caveats/notes:
- This is experimental, and is only supported by Chrome/Chromium/Edgeium (see https://caniuse.com/?search=querylocalfonts)
- As far as I can tell, the only way to dynamically change the font (shown in https://wicg.github.io/local-font-access/#example-style-with-local-fonts) was by DOM manipulation; css variables did not seem to work
- This shows **all** fonts, including their variants (bold/italic/etc); given that the style names could be localized, not sure of a way to parse this (on my system, for instance, I had 859 different combinations)
- I made fonts a separate top-level setting because it was easier to manipulate without causing as many rerenders; feel free to put that back