### PR TITLE
[bugfix]: remove ignore CORS/SSL switches from web version

### DIFF
--- a/src/renderer/features/servers/components/server-list.tsx
+++ b/src/renderer/features/servers/components/server-list.tsx
@@ -98,21 +98,25 @@ export const ServerList = () => {
                         );
                     })}
                 </Accordion>
-                <Divider />
-                <Group>
-                    <Switch
-                        checked={ignoreCORS === 'true'}
-                        label="Ignore CORS (requires restart)"
-                        onChange={handleUpdateIgnoreCORS}
-                    />
-                </Group>
-                <Group>
-                    <Switch
-                        checked={ignoreSSL === 'true'}
-                        label="Ignore SSL (requires restart)"
-                        onChange={handleUpdateIgnoreSSL}
-                    />
-                </Group>
+                {isElectron() && (
+                    <>
+                        <Divider />
+                        <Group>
+                            <Switch
+                                checked={ignoreCORS === 'true'}
+                                label="Ignore CORS (requires restart)"
+                                onChange={handleUpdateIgnoreCORS}
+                            />
+                        </Group>
+                        <Group>
+                            <Switch
+                                checked={ignoreSSL === 'true'}
+                                label="Ignore SSL (requires restart)"
+                                onChange={handleUpdateIgnoreSSL}
+                            />
+                        </Group>
+                    </>
+                )}
             </Stack>
         </>
     );


### PR DESCRIPTION
Disabling CORS/ignoring SSL checks are things that only the browser can (and should) do, so remove their visibility if we're not in an Electron (desktop) environment.