### PR TITLE
[feature]: support running feishin on custom path

### DIFF
--- a/.erb/configs/webpack.config.web.prod.ts
+++ b/.erb/configs/webpack.config.web.prod.ts
@@ -38,7 +38,7 @@ const configuration: webpack.Configuration = {
 
     output: {
         path: webpackPaths.distWebPath,
-        publicPath: '/',
+        publicPath: 'auto',
         filename: 'renderer.js',
         library: {
             type: 'umd',

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,9 @@ RUN npm run build:web
 # --- Production stage
 FROM nginx:alpine-slim
 
-COPY --from=builder /app/release/app/dist/web /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --chown=nginx:nginx --from=builder /app/release/app/dist/web /usr/share/nginx/html
+COPY ng.conf.template /etc/nginx/templates/default.conf.template
 
+ENV PUBLIC_PATH="/"
 EXPOSE 9180
 CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ docker run --name feishin --port 9180:9180 feishin
 
 -   **Navidrome** - For the best experience, select "Save password" when creating the server and configure the `SessionTimeout` setting in your Navidrome config to a larger value (e.g. 72h).
 
+3. _Optional_ - If you want to host Feishin on a subpath (not `/`), then pass in the following environment variable: `PUBLIC_PATH=PATH`. For example, to host on `/feishin`, pass in `PUBLIC_PATH=/feishin`.
+
 ## FAQ
 
 ### MPV is either not working or is rapidly switching between pause/play states

--- a/ng.conf.template
+++ b/ng.conf.template
@@ -12,9 +12,8 @@ server {
   gzip_types        text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
   gzip_comp_level   9;
 
-  root /usr/share/nginx/html;
-
-  location / {
+  location ${PUBLIC_PATH} {
+    alias /usr/share/nginx/html/;
     try_files $uri $uri/ /index.html =404;
   }
 }


### PR DESCRIPTION
Support serving Feishin on a subpath, and change webpack to autodetect the subpath as opposed to hardcoding `/`. This can be changed dynamically with an environment variable.
Note for users, that `/path/` and `/path` will see different results.