### PR TITLE
[feature]: Add Equalizer

### DIFF
--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -25,6 +25,7 @@ import { getMpvProperties } from '/@/renderer/features/settings/components/playb
 import { PlayerState, usePlayerStore, useQueueControls } from '/@/renderer/store';
 import { PlaybackType, PlayerStatus } from '/@/renderer/types';
 import '@ag-grid-community/styles/ag-grid.css';
+import { bandsToAudioFilter } from '/@/renderer/utils';
 
 ModuleRegistry.registerModules([ClientSideRowModelModule, InfiniteRowModelModule]);
 
@@ -38,6 +39,7 @@ const remote = isElectron() ? window.electron.remote : null;
 export const App = () => {
     const theme = useTheme();
     const contentFont = useSettingsStore((state) => state.general.fontContent);
+    const audioBands = useSettingsStore((state) => state.audio.bands);
     const { type: playbackType } = usePlaybackSettings();
     const { bindings } = useHotkeySettings();
     const handlePlayQueueAdd = useHandlePlayQueueAdd();
@@ -66,12 +68,15 @@ export const App = () => {
                     ...getMpvProperties(useSettingsStore.getState().playback.mpvProperties),
                 };
 
+                const volume = properties.volume;
+                properties.af = bandsToAudioFilter(audioBands);
+
                 mpvPlayer?.initialize({
                     extraParameters,
                     properties,
                 });
 
-                mpvPlayer?.volume(properties.volume);
+                mpvPlayer?.volume(volume);
             }
             mpvPlayer?.restoreQueue();
         };
@@ -85,6 +90,8 @@ export const App = () => {
             mpvPlayer?.stop();
             mpvPlayer?.cleanup();
         };
+        // audioBands should NOT cause a cleanup of this function
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [clearQueue, playbackType]);
 
     useEffect(() => {

--- a/src/renderer/components/audio-player/index.tsx
+++ b/src/renderer/components/audio-player/index.tsx
@@ -7,13 +7,10 @@ import {
     crossfadeHandler,
     gaplessHandler,
 } from '/@/renderer/components/audio-player/utils/list-handlers';
-import {
-    AudioFrequencies,
-    useAudioSettings,
-    useSettingsStore,
-} from '/@/renderer/store/settings.store';
+import { useAudioSettings, useSettingsStore } from '/@/renderer/store/settings.store';
 import type { CrossfadeStyle } from '/@/renderer/types';
 import { PlaybackStyle, PlayerStatus } from '/@/renderer/types';
+import { AudioFrequencies, AudioQuality } from '/@/renderer/utils';
 
 interface AudioPlayerProps extends ReactPlayerProps {
     crossfadeDuration: number;
@@ -135,8 +132,9 @@ export const AudioPlayer = forwardRef(
 
                 for (let i = 0; i < AudioFrequencies.length; i += 1) {
                     const filter = context.createBiquadFilter();
+                    filter.frequency.value = AudioFrequencies[i];
                     filter.type = 'peaking';
-                    filter.Q.value = AudioFrequencies[i].quality;
+                    filter.Q.value = AudioQuality;
                     priorNode.connect(filter);
                     priorNode = filter;
                     filters.push(filter);

--- a/src/renderer/features/settings/components/advanced-audio/advanced-audio-tab.tsx
+++ b/src/renderer/features/settings/components/advanced-audio/advanced-audio-tab.tsx
@@ -1,0 +1,11 @@
+import { Divider, Stack } from '@mantine/core';
+import { Equalizer } from '/@/renderer/features/settings/components/advanced-audio/equalizer';
+
+export const AdvancedAudioTab = () => {
+    return (
+        <Stack spacing="md">
+            <Equalizer />
+            <Divider />
+        </Stack>
+    );
+};

--- a/src/renderer/features/settings/components/advanced-audio/eqalizer-slider.tsx
+++ b/src/renderer/features/settings/components/advanced-audio/eqalizer-slider.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from 'react';
+import { Group, NumberInputProps, Stack, rem } from '@mantine/core';
+import { useMove, usePrevious } from '@mantine/hooks';
+import { Text } from '/@/renderer/components/text';
+import { NumberInput } from '/@/renderer/components';
+import styled from 'styled-components';
+
+interface VerticalSliderProps {
+    onChange: (value: number) => void;
+
+    title?: string;
+    value: number;
+}
+
+export const DB_RADIUS = 6;
+const DB_DIAMATER = 2 * DB_RADIUS;
+const DB_SCALE = 100 / DB_DIAMATER;
+
+const EqualizerNumberInput = styled(NumberInput)<NumberInputProps>`
+    & .mantine-NumberInput-input {
+        text-align: center;
+    }
+`;
+
+export const EqualizerSlider = ({ value, title, onChange }: VerticalSliderProps) => {
+    const [seekingValue, setValue] = useState(value);
+
+    const { ref, active } = useMove(({ y }) => {
+        const value = Math.round((0.5 - y) * DB_DIAMATER * 10) / 10;
+        setValue(value);
+    });
+
+    const wasActive = usePrevious(active);
+
+    useEffect(() => {
+        if (wasActive && !active) {
+            onChange(seekingValue);
+        }
+    }, [active, onChange, seekingValue, wasActive]);
+
+    const displayValue = active ? seekingValue : value;
+
+    return (
+        <>
+            <Stack align="center">
+                {title && (
+                    <Text
+                        mt="sm"
+                        ta="center"
+                    >
+                        {title}
+                    </Text>
+                )}
+                <div
+                    ref={ref}
+                    style={{
+                        backgroundColor: 'var(--input-bg)',
+                        height: rem(120),
+                        position: 'relative',
+                        width: rem(16),
+                    }}
+                >
+                    <div
+                        style={{
+                            backgroundColor: 'var(--primary-color)',
+                            bottom: 0,
+                            height: `${(displayValue + DB_RADIUS) * DB_SCALE}%`,
+                            position: 'absolute',
+                            width: rem(16),
+                        }}
+                    />
+                    <div
+                        style={{
+                            backgroundColor: 'var(--input-active-fg)',
+                            bottom: `calc(${(displayValue + DB_RADIUS) * DB_SCALE}% - ${rem(8)})`,
+                            height: rem(16),
+                            left: 0,
+                            position: 'absolute',
+                            width: rem(16),
+                        }}
+                    />
+                </div>
+                <Group spacing={5}>
+                    <EqualizerNumberInput
+                        // why a key? Apparently without it the number input would
+                        // not update its value when the slider changed......
+                        key={displayValue}
+                        max={DB_RADIUS}
+                        min={-DB_RADIUS}
+                        precision={1}
+                        radius="xs"
+                        step={0.1}
+                        value={displayValue}
+                        variant="unstyled"
+                        width={rem(54)}
+                        onChange={(val) => {
+                            onChange(Number(val));
+                        }}
+                    />
+                    db
+                </Group>
+            </Stack>
+        </>
+    );
+};

--- a/src/renderer/features/settings/components/advanced-audio/eqalizer-slider.tsx
+++ b/src/renderer/features/settings/components/advanced-audio/eqalizer-slider.tsx
@@ -89,15 +89,15 @@ export const EqualizerSlider = ({ value, title, onChange }: VerticalSliderProps)
                         min={-DB_RADIUS}
                         precision={1}
                         radius="xs"
+                        rightSection="db"
                         step={0.1}
                         value={displayValue}
                         variant="unstyled"
-                        width={rem(54)}
+                        width={rem(74)}
                         onChange={(val) => {
                             onChange(Number(val));
                         }}
                     />
-                    db
                 </Group>
             </Stack>
         </>

--- a/src/renderer/features/settings/components/advanced-audio/equalizer.tsx
+++ b/src/renderer/features/settings/components/advanced-audio/equalizer.tsx
@@ -1,11 +1,11 @@
 import { Grid } from '@mantine/core';
 import { EqualizerSlider } from '/@/renderer/features/settings/components/advanced-audio/eqalizer-slider';
-import { AudioFrequencies, useAudioSettings, useSettingsStoreActions } from '/@/renderer/store';
+import { useAudioSettings, useSettingsStoreActions } from '/@/renderer/store';
 import isElectron from 'is-electron';
 import { useCallback } from 'react';
 import { SettingsOptions } from '/@/renderer/features/settings/components/settings-option';
 import { Button } from '/@/renderer/components';
-import { bandsToAudioFilter } from '/@/renderer/utils';
+import { AudioFrequencies, bandsToAudioFilter } from '/@/renderer/utils';
 
 const mpvPlayer = isElectron() ? window.electron.mpvPlayer : null;
 
@@ -35,8 +35,8 @@ export const Equalizer = () => {
     );
 
     const resetBand = useCallback(() => {
-        const bands = AudioFrequencies.map((info) => ({
-            ...info,
+        const bands = AudioFrequencies.map((frequency) => ({
+            frequency,
             gain: 0,
         }));
 

--- a/src/renderer/features/settings/components/advanced-audio/equalizer.tsx
+++ b/src/renderer/features/settings/components/advanced-audio/equalizer.tsx
@@ -1,0 +1,94 @@
+import { Grid } from '@mantine/core';
+import { EqualizerSlider } from '/@/renderer/features/settings/components/advanced-audio/eqalizer-slider';
+import { AudioFrequencies, useAudioSettings, useSettingsStoreActions } from '/@/renderer/store';
+import isElectron from 'is-electron';
+import { useCallback } from 'react';
+import { SettingsOptions } from '/@/renderer/features/settings/components/settings-option';
+import { Button } from '/@/renderer/components';
+import { bandsToAudioFilter } from '/@/renderer/utils';
+
+const mpvPlayer = isElectron() ? window.electron.mpvPlayer : null;
+
+export const Equalizer = () => {
+    const settings = useAudioSettings();
+    const { setSettings } = useSettingsStoreActions();
+
+    const setBandSetting = useCallback(
+        (gain: number, index: number) => {
+            const bands = [...settings.bands];
+            bands[index].gain = gain;
+
+            setSettings({
+                audio: {
+                    ...settings,
+                    bands,
+                },
+            });
+
+            if (mpvPlayer) {
+                mpvPlayer.setProperties({
+                    af: bandsToAudioFilter(bands),
+                });
+            }
+        },
+        [setSettings, settings],
+    );
+
+    const resetBand = useCallback(() => {
+        const bands = AudioFrequencies.map((info) => ({
+            ...info,
+            gain: 0,
+        }));
+
+        setSettings({
+            audio: {
+                ...settings,
+                bands,
+            },
+        });
+
+        if (mpvPlayer) {
+            mpvPlayer.setProperties({
+                af: bandsToAudioFilter(bands),
+            });
+        }
+    }, [setSettings, settings]);
+
+    return (
+        <>
+            <SettingsOptions
+                control={
+                    <Button
+                        compact
+                        variant="filled"
+                        onClick={() => resetBand()}
+                    >
+                        Reset to default
+                    </Button>
+                }
+                title="Audio Equalization"
+            />
+            <Grid
+                columns={AudioFrequencies.length}
+                gutter={20}
+                justify="center"
+            >
+                {settings.bands.map((band, idx) => (
+                    <Grid.Col
+                        key={band.frequency}
+                        lg={2}
+                        sm={3}
+                        span={4}
+                        xl={1}
+                    >
+                        <EqualizerSlider
+                            title={`${band.frequency} Hz`}
+                            value={band.gain}
+                            onChange={(gain) => setBandSetting(gain, idx)}
+                        />
+                    </Grid.Col>
+                ))}
+            </Grid>
+        </>
+    );
+};

--- a/src/renderer/features/settings/components/settings-content.tsx
+++ b/src/renderer/features/settings/components/settings-content.tsx
@@ -28,6 +28,14 @@ const HotkeysTab = lazy(() =>
     })),
 );
 
+const AdvancedAudioTab = lazy(() =>
+    import('/@/renderer/features/settings/components/advanced-audio/advanced-audio-tab').then(
+        (module) => ({
+            default: module.AdvancedAudioTab,
+        }),
+    ),
+);
+
 const TabContainer = styled.div`
     width: 100%;
     height: 100%;
@@ -53,6 +61,9 @@ export const SettingsContent = () => {
                     <Tabs.Tab value="playback">Playback</Tabs.Tab>
                     <Tabs.Tab value="hotkeys">Hotkeys</Tabs.Tab>
                     {isElectron() && <Tabs.Tab value="window">Window</Tabs.Tab>}
+                    {(isElectron() || 'AudioContext' in window) && (
+                        <Tabs.Tab value="advanced-audio">Advanced Audio settings</Tabs.Tab>
+                    )}
                 </Tabs.List>
                 <Tabs.Panel value="general">
                     <GeneralTab />
@@ -68,6 +79,9 @@ export const SettingsContent = () => {
                         <ApplicationTab />
                     </Tabs.Panel>
                 )}
+                <Tabs.Panel value="advanced-audio">
+                    <AdvancedAudioTab />
+                </Tabs.Panel>
             </Tabs>
         </TabContainer>
     );

--- a/src/renderer/hooks/use-previous.ts
+++ b/src/renderer/hooks/use-previous.ts
@@ -1,0 +1,10 @@
+import { useEffect, useRef } from 'react';
+
+// from https://stackoverflow.com/questions/53446020/how-to-compare-oldvalues-and-newvalues-on-react-hooks-useeffect
+export const usePrevious = <T extends unknown>(value: T): T | undefined => {
+    const ref = useRef<T>();
+    useEffect(() => {
+        ref.current = value;
+    });
+    return ref.current;
+};

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -110,7 +110,27 @@ export enum BindingActions {
     ZOOM_OUT = 'zoomOut',
 }
 
+export type BandInfo = {
+    frequency: number;
+    quality: number;
+};
+
+export type AudioBand = {
+    gain: number;
+} & BandInfo;
+
+export const AudioFrequencies: BandInfo[] = [
+    { frequency: 63, quality: 0.35555555555555557 }, // 20-200
+    { frequency: 400, quality: 0.6666666666666666 }, // 200-800
+    { frequency: 1250, quality: 1.0416666666666667 }, // 800-2000
+    { frequency: 2830, quality: 1.415 }, // 2000 - 4000
+    { frequency: 5600, quality: 1.4 }, // 4000-8000
+    { frequency: 12500, quality: 1.0416666666666667 }, // 8000-20000
+];
 export interface SettingsState {
+    audio: {
+        bands: AudioBand[];
+    };
     general: {
         defaultFullPlaylist: boolean;
         followSystemTheme: boolean;
@@ -208,6 +228,12 @@ const getPlatformDefaultWindowBarStyle = (): Platform => {
 const platformDefaultWindowBarStyle: Platform = getPlatformDefaultWindowBarStyle();
 
 const initialState: SettingsState = {
+    audio: {
+        bands: AudioFrequencies.map((info) => ({
+            ...info,
+            gain: 0,
+        })),
+    },
     general: {
         defaultFullPlaylist: true,
         followSystemTheme: false,
@@ -538,3 +564,5 @@ export const useMpvSettings = () =>
 export const useLyricsSettings = () => useSettingsStore((state) => state.lyrics, shallow);
 
 export const useRemoteSettings = () => useSettingsStore((state) => state.remote, shallow);
+
+export const useAudioSettings = () => useSettingsStore((state) => state.audio, shallow);

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -20,7 +20,7 @@ import {
     TableType,
     Platform,
 } from '/@/renderer/types';
-import { AudioBand, AudioFrequencies, randomString } from '/@/renderer/utils';
+import { AudioBand, AudioFrequencies, Octave, randomString } from '/@/renderer/utils';
 
 const utils = isElectron() ? window.electron.utils : null;
 
@@ -113,6 +113,7 @@ export enum BindingActions {
 export interface SettingsState {
     audio: {
         bands: AudioBand[];
+        octave: Octave;
     };
     general: {
         defaultFullPlaylist: boolean;
@@ -216,6 +217,7 @@ const initialState: SettingsState = {
             frequency,
             gain: 0,
         })),
+        octave: Octave.Third,
     },
     general: {
         defaultFullPlaylist: true,

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -20,7 +20,7 @@ import {
     TableType,
     Platform,
 } from '/@/renderer/types';
-import { randomString } from '/@/renderer/utils';
+import { AudioBand, AudioFrequencies, randomString } from '/@/renderer/utils';
 
 const utils = isElectron() ? window.electron.utils : null;
 
@@ -110,23 +110,6 @@ export enum BindingActions {
     ZOOM_OUT = 'zoomOut',
 }
 
-export type BandInfo = {
-    frequency: number;
-    quality: number;
-};
-
-export type AudioBand = {
-    gain: number;
-} & BandInfo;
-
-export const AudioFrequencies: BandInfo[] = [
-    { frequency: 63, quality: 0.35555555555555557 }, // 20-200
-    { frequency: 400, quality: 0.6666666666666666 }, // 200-800
-    { frequency: 1250, quality: 1.0416666666666667 }, // 800-2000
-    { frequency: 2830, quality: 1.415 }, // 2000 - 4000
-    { frequency: 5600, quality: 1.4 }, // 4000-8000
-    { frequency: 12500, quality: 1.0416666666666667 }, // 8000-20000
-];
 export interface SettingsState {
     audio: {
         bands: AudioBand[];
@@ -229,8 +212,8 @@ const platformDefaultWindowBarStyle: Platform = getPlatformDefaultWindowBarStyle
 
 const initialState: SettingsState = {
     audio: {
-        bands: AudioFrequencies.map((info) => ({
-            ...info,
+        bands: AudioFrequencies.map((frequency) => ({
+            frequency,
             gain: 0,
         })),
     },

--- a/src/renderer/utils/audio-info.ts
+++ b/src/renderer/utils/audio-info.ts
@@ -1,0 +1,10 @@
+export type AudioBand = {
+    frequency: number;
+    gain: number;
+};
+
+// Bands from https://ia601608.us.archive.org/27/items/gov.law.ansi.s1.11.2004/ansi.s1.11.2004.pdf#page=23
+export const AudioFrequencies = [31.5, 63, 125, 250, 500, 1000, 2000, 4000, 8000, 20000];
+
+// equivalent to 1/3 octave band
+export const AudioQuality = 4.318473;

--- a/src/renderer/utils/audio-info.ts
+++ b/src/renderer/utils/audio-info.ts
@@ -3,8 +3,28 @@ export type AudioBand = {
     gain: number;
 };
 
+export enum Octave {
+    Full = 'full',
+    Third = 'third',
+}
+
 // Bands from https://ia601608.us.archive.org/27/items/gov.law.ansi.s1.11.2004/ansi.s1.11.2004.pdf#page=23
 export const AudioFrequencies = [31.5, 63, 125, 250, 500, 1000, 2000, 4000, 8000, 20000];
 
-// equivalent to 1/3 octave band
-export const AudioQuality = 4.318473;
+const OctaveToQ = {
+    [Octave.Full]: 1.414214,
+    [Octave.Third]: 4.318473,
+};
+
+export const octaveToQFactor = (octave: Octave): number => {
+    return OctaveToQ[octave];
+};
+
+const OctaveEnumToOctave = {
+    [Octave.Full]: 1,
+    [Octave.Third]: 0.333333,
+};
+
+export const octaveEnumToFloat = (octave: Octave): number => {
+    return OctaveEnumToOctave[octave];
+};

--- a/src/renderer/utils/bands-to-audio-filter.ts
+++ b/src/renderer/utils/bands-to-audio-filter.ts
@@ -1,0 +1,10 @@
+import type { AudioBand } from '/@/renderer/store';
+
+export const bandsToAudioFilter = (bands: AudioBand[]): string => {
+    return bands
+        .map(
+            (info) =>
+                `lavfi=[equalizer=f=${info.frequency}:width_type=o:w=${info.quality}:g=${info.gain}]`,
+        )
+        .join(',');
+};

--- a/src/renderer/utils/bands-to-audio-filter.ts
+++ b/src/renderer/utils/bands-to-audio-filter.ts
@@ -1,10 +1,7 @@
-import type { AudioBand } from '/@/renderer/store';
+import { AudioBand } from '/@/renderer/utils/audio-info';
 
 export const bandsToAudioFilter = (bands: AudioBand[]): string => {
     return bands
-        .map(
-            (info) =>
-                `lavfi=[equalizer=f=${info.frequency}:width_type=o:w=${info.quality}:g=${info.gain}]`,
-        )
+        .map((info) => `lavfi=[equalizer=f=${info.frequency}:width_type=o:w=0.3333:g=${info.gain}]`)
         .join(',');
 };

--- a/src/renderer/utils/bands-to-audio-filter.ts
+++ b/src/renderer/utils/bands-to-audio-filter.ts
@@ -1,7 +1,11 @@
-import { AudioBand } from '/@/renderer/utils/audio-info';
+import { AudioBand, Octave, octaveEnumToFloat } from '/@/renderer/utils/audio-info';
 
-export const bandsToAudioFilter = (bands: AudioBand[]): string => {
+export const bandsToAudioFilter = (bands: AudioBand[], octave: Octave): string => {
+    const width = octaveEnumToFloat(octave);
     return bands
-        .map((info) => `lavfi=[equalizer=f=${info.frequency}:width_type=o:w=0.3333:g=${info.gain}]`)
+        .map(
+            (info) =>
+                `lavfi=[equalizer=f=${info.frequency}:width_type=o:w=${width}:g=${info.gain}:precision=f64]`,
+        )
         .join(',');
 };

--- a/src/renderer/utils/index.ts
+++ b/src/renderer/utils/index.ts
@@ -8,3 +8,4 @@ export * from './parse-search-params';
 export * from './format-duration-string';
 export * from './rgb-to-rgba';
 export * from './bands-to-audio-filter';
+export * from './audio-info';

--- a/src/renderer/utils/index.ts
+++ b/src/renderer/utils/index.ts
@@ -7,3 +7,4 @@ export * from './get-header-color';
 export * from './parse-search-params';
 export * from './format-duration-string';
 export * from './rgb-to-rgba';
+export * from './bands-to-audio-filter';


### PR DESCRIPTION
Values from [this message](https://discord.com/channels/922656312888811530/922656312888811535/1162427713567596666). Works for both Electron and [modern browsers](https://caniuse.com/?search=createBiquadFilter)

Notes:
- it might be nice to have more filters, but I'm not touching that. Getting the Q value wrong leads to bad distortion
- it would also be nice to have low/highshelf for web/mpv, but when I tried the filter was considerably stronger in web audio
- better visualizer/UI? Getting the number input to behave was frustrating enough...
- *please* test this. I am not confident in audio processing.