### PR TITLE
[bugfix]: Replace hardcoded Jellyfin authentication DeviceId to include hostname and username

### DIFF
--- a/src/renderer/api/jellyfin/jellyfin-controller.ts
+++ b/src/renderer/api/jellyfin/jellyfin-controller.ts
@@ -100,7 +100,7 @@ const authenticate = async (
             Username: body.username,
         },
         headers: {
-            'x-emby-authorization': `MediaBrowser Client="Feishin", Device="${getHostname()}", DeviceId="Feishin", Version="${
+            'x-emby-authorization': `MediaBrowser Client="Feishin", Device="${getHostname()}", DeviceId="Feishin-${getHostname()}-${body.username}", Version="${
                 packageJson.version
             }"`,
         },


### PR DESCRIPTION
Fixes bug preventing two separate users on the same Jellyfin instance from being logged in simultaneously due to conflicting DeviceIds. See [here](https://gist.github.com/nielsvanvelzen/ea047d9028f676185832e51ffaf12a6f#device-identifiers) for information on DeviceIds. If two clients try to authenticate using the same device id then the other will have their session revoked.