### PR TITLE
Build docker container for arm

### DIFF
--- a/.github/workflows/publish-docker-auto.yml
+++ b/.github/workflows/publish-docker-auto.yml
@@ -37,6 +37,10 @@ jobs:
                       type=semver,pattern={{version}}
                       type=semver,pattern={{major}}.{{minor}}
                       type=semver,pattern={{major}}
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
+            - name: Setup Docker buildx
+              uses: docker/setup-buildx-action@v3
             - name: Build and push Docker image
               uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
               with:
@@ -44,3 +48,10 @@ jobs:
                   push: true
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
+                  platforms: |
+                    linux/amd64
+                    linux/arm/v6
+                    linux/arm/v7
+                    linux/arm64/v8
+                    linux/ppc64le
+                    linux/s390x

--- a/.github/workflows/publish-docker-auto.yml
+++ b/.github/workflows/publish-docker-auto.yml
@@ -50,8 +50,5 @@ jobs:
                   labels: ${{ steps.meta.outputs.labels }}
                   platforms: |
                     linux/amd64
-                    linux/arm/v6
                     linux/arm/v7
                     linux/arm64/v8
-                    linux/ppc64le
-                    linux/s390x

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -29,6 +29,10 @@ jobs:
                   images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
                   tags: |
                       type=raw,value=latest,enable={{is_default_branch}}
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
+            - name: Setup Docker buildx
+              uses: docker/setup-buildx-action@v3
             - name: Build and push Docker image
               uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
               with:
@@ -36,3 +40,10 @@ jobs:
                   push: true
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
+                  platforms: |
+                    linux/amd64
+                    linux/arm/v6
+                    linux/arm/v7
+                    linux/arm64/v8
+                    linux/ppc64le
+                    linux/s390x

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -42,8 +42,5 @@ jobs:
                   labels: ${{ steps.meta.outputs.labels }}
                   platforms: |
                     linux/amd64
-                    linux/arm/v6
                     linux/arm/v7
                     linux/arm64/v8
-                    linux/ppc64le
-                    linux/s390x


### PR DESCRIPTION
Both the node and nginx base images support more than amd64. I personally run my navidrome container on arm64 device and would like to run feishin on the same hardware. Other architectures are also supported but when I tried to build them it took 2+ hours so I limited it to the more popular ones.