### PR TITLE
[feature]: initial attempt at caching songs

### DIFF
--- a/src/main/features/core/player/index.ts
+++ b/src/main/features/core/player/index.ts
@@ -28,7 +28,7 @@ const getPath = async (song: Song): Promise<string> => {
 
     try {
         const filePath = join(path, `${song.serverId}-${song.id}`);
-        access(filePath, constants.R_OK);
+        await access(filePath, constants.F_OK);
         return `file://${filePath}`;
     } catch (error) {
         return song.streamUrl;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -24,6 +24,7 @@ import {
     BrowserWindowConstructorOptions,
     protocol,
     net,
+    dialog,
 } from 'electron';
 import electronLocalShortcut from 'electron-localshortcut';
 import log from 'electron-log';
@@ -662,6 +663,26 @@ ipcMain.on(
         }
     },
 );
+
+ipcMain.handle('cache-open-dialog', async (): Promise<string | null> => {
+    const window = getMainWindow();
+    if (window) {
+        const response = await dialog.showOpenDialog(window, {
+            defaultPath: app.getPath('userData'),
+            properties: ['openDirectory', 'showHiddenFiles'],
+        });
+        if (response.canceled) {
+            return null;
+        }
+
+        return response.filePaths[0];
+    }
+    return null;
+});
+
+ipcMain.handle('cache-open-path', async (_event, path: string) => {
+    return shell.openPath(path);
+});
 
 app.on('before-quit', () => {
     getMpvInstance()?.stop();

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,5 +1,6 @@
 import { contextBridge } from 'electron';
 import { browser } from './preload/browser';
+import { cache } from './preload/cache';
 import { discordRpc } from './preload/discord-rpc';
 import { ipc } from './preload/ipc';
 import { localSettings } from './preload/local-settings';
@@ -11,6 +12,7 @@ import { utils } from './preload/utils';
 
 contextBridge.exposeInMainWorld('electron', {
     browser,
+    cache,
     discordRpc,
     ipc,
     localSettings,

--- a/src/main/preload/cache.ts
+++ b/src/main/preload/cache.ts
@@ -3,6 +3,7 @@ import { access, lstat, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { Song } from '/@/renderer/api/types';
 import { localSettings } from '/@/main/preload/local-settings';
+import { ipcRenderer } from 'electron';
 
 let cachePath: string;
 
@@ -42,10 +43,20 @@ export const setCachePath = (path: string): void => {
     localSettings.set('cache.path', path);
 };
 
+export const openCacheDialog = (): Promise<string | null> => {
+    return ipcRenderer.invoke('cache-open-dialog');
+};
+
+export const openCachePath = (path: string) => {
+    ipcRenderer.invoke('cache-open-path', path);
+};
+
 export const cache = {
     cacheFile,
     getPath,
     isValidDirectory,
+    openCacheDialog,
+    openCachePath,
     setCachePath,
 };
 

--- a/src/main/preload/cache.ts
+++ b/src/main/preload/cache.ts
@@ -1,0 +1,44 @@
+import { existsSync } from 'fs';
+import { lstat, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { Song } from '/@/renderer/api/types';
+import { localSettings } from '/@/main/preload/local-settings';
+
+let cachePath: string;
+
+const cacheFile = async (song: Song) => {
+    const filePath = join(cachePath, `${song.serverId}-${song.id}`);
+    const response = await fetch(song.streamUrl);
+    const buffer = await response.arrayBuffer();
+    return writeFile(filePath, Buffer.from(buffer));
+};
+
+export const getPath = (song: Song, prefix: string): string => {
+    const filePath = join(cachePath, `${song.serverId}-${song.id}`);
+    if (existsSync(filePath)) {
+        return `${prefix}://${filePath}`;
+    }
+    return song.streamUrl;
+};
+
+export const isValidDirectory = async (path: string): Promise<boolean> => {
+    try {
+        return (await lstat(path)).isDirectory();
+    } catch (error) {
+        return false;
+    }
+};
+
+export const setCachePath = (path: string): void => {
+    cachePath = path;
+    localSettings.set('cache.path', path);
+};
+
+export const cache = {
+    cacheFile,
+    getPath,
+    isValidDirectory,
+    setCachePath,
+};
+
+export type Cache = typeof cache;

--- a/src/main/preload/local-settings.ts
+++ b/src/main/preload/local-settings.ts
@@ -1,3 +1,4 @@
+import { dirname, join } from 'path';
 import { IpcRendererEvent, ipcRenderer, webFrame } from 'electron';
 import Store from 'electron-store';
 
@@ -51,6 +52,7 @@ export const localSettings = {
     passwordGet,
     passwordRemove,
     passwordSet,
+    path: join(dirname(store.path), 'cache'),
     restart,
     set,
     setZoomFactor,

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -50,3 +50,8 @@ export const hotkeyToElectronAccelerator = (hotkey: string) => {
 
     return accelerator;
 };
+
+export type MediaCache = {
+    enabled?: boolean;
+    path?: string;
+};

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -11,6 +11,7 @@ import { useTheme } from './hooks';
 import { IsUpdatedDialog } from './is-updated-dialog';
 import { AppRouter } from './router/app-router';
 import {
+    useCacheSettings,
     useHotkeySettings,
     usePlaybackSettings,
     useRemoteSettings,
@@ -35,6 +36,7 @@ const mpvPlayer = isElectron() ? window.electron.mpvPlayer : null;
 const mpvPlayerListener = isElectron() ? window.electron.mpvPlayerListener : null;
 const ipc = isElectron() ? window.electron.ipc : null;
 const remote = isElectron() ? window.electron.remote : null;
+const cache = isElectron() ? window.electron.cache : null;
 
 export const App = () => {
     const theme = useTheme();
@@ -46,6 +48,7 @@ export const App = () => {
     const { clearQueue, restoreQueue } = useQueueControls();
     const remoteSettings = useRemoteSettings();
     const textStyleRef = useRef<HTMLStyleElement>();
+    const cacheSettings = useCacheSettings();
     useDiscordRpc();
 
     useEffect(() => {
@@ -87,6 +90,12 @@ export const App = () => {
         const root = document.documentElement;
         root.style.setProperty('--primary-color', accent);
     }, [accent]);
+
+    useEffect(() => {
+        if (cache) {
+            cache.setCachePath(cacheSettings.path);
+        }
+    }, [cacheSettings.path]);
 
     const providerValue = useMemo(() => {
         return { handlePlayQueueAdd };

--- a/src/renderer/features/settings/components/playback/cache-settings.tsx
+++ b/src/renderer/features/settings/components/playback/cache-settings.tsx
@@ -1,18 +1,71 @@
 import { Stack } from '@mantine/core';
-import { Button, Switch } from '/@/renderer/components';
+import { Button, ConfirmModal, Switch, Text } from '/@/renderer/components';
 import {
     SettingOption,
     SettingsSection,
 } from '/@/renderer/features/settings/components/settings-section';
-import { useCacheSettings, useSettingsStoreActions } from '/@/renderer/store';
-import { RiExternalLinkLine } from 'react-icons/ri';
+import {
+    useCacheSettings,
+    usePlaybackSettings,
+    usePlayerStore,
+    useSettingsStoreActions,
+} from '/@/renderer/store';
+import { closeAllModals, openModal } from '@mantine/modals';
+import { RiDeleteBin2Line, RiExternalLinkLine, RiRefreshLine } from 'react-icons/ri';
+import { useCallback, useEffect, useState } from 'react';
+import { PlaybackType } from '/@/renderer/types';
 
 const cache = window.electron.cache;
 const localSettings = window.electron.localSettings;
+const mpvPlayer = window.electron.mpvPlayer;
 
 export const CacheSettings = () => {
+    const playback = usePlaybackSettings();
     const settings = useCacheSettings();
     const { setSettings } = useSettingsStoreActions();
+    const [fileInfo, setFileInfo] = useState<[number, number]>([0, 0]);
+
+    const refreshSize = useCallback(async () => {
+        try {
+            const info = await cache.getSize();
+            setFileInfo(info);
+        } catch (err) {
+            console.error(err);
+        }
+    }, []);
+
+    const clearCache = useCallback(async () => {
+        try {
+            cache.purgeFiles().catch(console.error);
+            closeAllModals();
+            setFileInfo([0, 0]);
+
+            if (playback.type === PlaybackType.LOCAL) {
+                const queueData = usePlayerStore.getState().actions.getPlayerData();
+                mpvPlayer!.setQueue(queueData);
+            }
+        } catch (err) {
+            console.error(err);
+        }
+    }, [playback.type]);
+
+    useEffect(() => {
+        refreshSize().catch(console.error);
+    }, [refreshSize]);
+
+    const openDeleteCacheModal = () => {
+        openModal({
+            children: (
+                <ConfirmModal onConfirm={clearCache}>
+                    <Text>
+                        Are you sure you want to clear downloads? Note: if using MPV, this will
+                        restart the current track
+                    </Text>
+                </ConfirmModal>
+            ),
+            title: 'Clear cache?',
+        });
+    };
 
     const cacheOptions: SettingOption[] = [
         {
@@ -67,6 +120,33 @@ export const CacheSettings = () => {
             ),
             description: 'Path to store tracks',
             title: 'Cache location',
+        },
+        {
+            control: (
+                <Button
+                    rightIcon={<RiRefreshLine />}
+                    variant="outline"
+                    onClick={() => refreshSize()}
+                >
+                    Refresh
+                </Button>
+            ),
+            description: `${fileInfo[0]} file(s), ${fileInfo[1]} byte(s)`,
+            title: 'Cache size',
+        },
+        {
+            control: (
+                <Button
+                    fullWidth
+                    rightIcon={<RiDeleteBin2Line />}
+                    variant="outline"
+                    onClick={() => openDeleteCacheModal()}
+                >
+                    Clear cache
+                </Button>
+            ),
+            description: 'Remove all cached tracks',
+            title: 'Clear Cache',
         },
     ];
 

--- a/src/renderer/features/settings/components/playback/cache-settings.tsx
+++ b/src/renderer/features/settings/components/playback/cache-settings.tsx
@@ -1,0 +1,66 @@
+import { Switch, TextInput, toast } from '/@/renderer/components';
+import {
+    SettingOption,
+    SettingsSection,
+} from '/@/renderer/features/settings/components/settings-section';
+import { useCacheSettings, useSettingsStoreActions } from '/@/renderer/store';
+
+const cache = window.electron.cache;
+const localSettings = window.electron.localSettings;
+
+export const CacheSettings = () => {
+    const settings = useCacheSettings();
+    const { setSettings } = useSettingsStoreActions();
+
+    const cacheOptions: SettingOption[] = [
+        {
+            control: (
+                <Switch
+                    aria-label="Enable song caching"
+                    defaultChecked={settings.enabled}
+                    onChange={(e) => {
+                        const enabled = e.currentTarget.checked;
+                        setSettings({
+                            cache: {
+                                ...settings,
+                                enabled,
+                            },
+                        });
+                        localSettings.set('cache.enabled', enabled);
+                    }}
+                />
+            ),
+            description: 'Enable or disable downloading songs offline',
+            title: 'Enable song caching',
+        },
+        {
+            control: (
+                <TextInput
+                    defaultValue={settings.path}
+                    w={300}
+                    onChange={async (e) => {
+                        const path = e.currentTarget.value;
+
+                        if (await cache.isValidDirectory(path)) {
+                            setSettings({
+                                cache: {
+                                    ...settings,
+                                    path,
+                                },
+                            });
+                        } else {
+                            toast.error({
+                                message: `${path} is not a directory or does not exist`,
+                                title: 'Invalid path',
+                            });
+                        }
+                    }}
+                />
+            ),
+            description: 'Path to store tracks',
+            title: 'Cache location',
+        },
+    ];
+
+    return <SettingsSection options={cacheOptions} />;
+};

--- a/src/renderer/features/settings/components/playback/cache-settings.tsx
+++ b/src/renderer/features/settings/components/playback/cache-settings.tsx
@@ -1,9 +1,11 @@
-import { Switch, TextInput, toast } from '/@/renderer/components';
+import { Stack } from '@mantine/core';
+import { Button, Switch } from '/@/renderer/components';
 import {
     SettingOption,
     SettingsSection,
 } from '/@/renderer/features/settings/components/settings-section';
 import { useCacheSettings, useSettingsStoreActions } from '/@/renderer/store';
+import { RiExternalLinkLine } from 'react-icons/ri';
 
 const cache = window.electron.cache;
 const localSettings = window.electron.localSettings;
@@ -35,27 +37,33 @@ export const CacheSettings = () => {
         },
         {
             control: (
-                <TextInput
-                    defaultValue={settings.path}
-                    w={300}
-                    onChange={async (e) => {
-                        const path = e.currentTarget.value;
-
-                        if (await cache.isValidDirectory(path)) {
-                            setSettings({
-                                cache: {
-                                    ...settings,
-                                    path,
-                                },
-                            });
-                        } else {
-                            toast.error({
-                                message: `${path} is not a directory or does not exist`,
-                                title: 'Invalid path',
-                            });
-                        }
-                    }}
-                />
+                <Stack>
+                    <Button
+                        variant="filled"
+                        onClick={async () => {
+                            const path = await cache.openCacheDialog();
+                            if (path) {
+                                setSettings({
+                                    cache: {
+                                        ...settings,
+                                        path,
+                                    },
+                                });
+                            }
+                        }}
+                    >
+                        Set cache path
+                    </Button>
+                    <Button
+                        rightIcon={<RiExternalLinkLine />}
+                        variant="default"
+                        onClick={() => {
+                            cache.openCachePath(settings.path);
+                        }}
+                    >
+                        {settings.path}
+                    </Button>
+                </Stack>
             ),
             description: 'Path to store tracks',
             title: 'Cache location',

--- a/src/renderer/features/settings/components/playback/playback-tab.tsx
+++ b/src/renderer/features/settings/components/playback/playback-tab.tsx
@@ -4,6 +4,7 @@ import { AudioSettings } from '/@/renderer/features/settings/components/playback
 import { ScrobbleSettings } from '/@/renderer/features/settings/components/playback/scrobble-settings';
 import isElectron from 'is-electron';
 import { LyricSettings } from '/@/renderer/features/settings/components/playback/lyric-settings';
+import { CacheSettings } from '/@/renderer/features/settings/components/playback/cache-settings';
 
 const MpvSettings = lazy(() =>
     import('/@/renderer/features/settings/components/playback/mpv-settings').then((module) => {
@@ -27,6 +28,8 @@ export const PlaybackTab = () => {
                 </>
             )}
             <LyricSettings />
+            <Divider />
+            {isElectron() && <CacheSettings />}
         </Stack>
     );
 };

--- a/src/renderer/preload.d.ts
+++ b/src/renderer/preload.d.ts
@@ -9,11 +9,13 @@ import { Utils } from '/@/main/preload/utils';
 import { LocalSettings } from '/@/main/preload/local-settings';
 import { Ipc } from '/@/main/preload/ipc';
 import { DiscordRpc } from '/@/main/preload/discord-rpc';
+import { Cache } from '/@/main/preload/cache';
 
 declare global {
     interface Window {
         electron: {
             browser: any;
+            cache: Cache;
             discordRpc: DiscordRpc;
             ipc?: Ipc;
             ipcRenderer: {

--- a/src/renderer/store/player.store.ts
+++ b/src/renderer/store/player.store.ts
@@ -988,6 +988,7 @@ export const usePlayerControls = () =>
     usePlayerStore(
         (state) => ({
             autoNext: state.actions.autoNext,
+            getPlayerData: state.actions.getPlayerData,
             next: state.actions.next,
             pause: state.actions.pause,
             play: state.actions.play,

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -24,6 +24,7 @@ import {
 import { randomString } from '/@/renderer/utils';
 
 const utils = isElectron() ? window.electron.utils : null;
+const settingPath = isElectron() ? window.electron.localSettings.path : '';
 
 export type SidebarItemType = {
     disabled: boolean;
@@ -118,6 +119,10 @@ export enum BindingActions {
 }
 
 export interface SettingsState {
+    cache: {
+        enabled: boolean;
+        path: string;
+    };
     discord: {
         clientId: string;
         enableIdle: boolean;
@@ -229,6 +234,10 @@ const getPlatformDefaultWindowBarStyle = (): Platform => {
 const platformDefaultWindowBarStyle: Platform = getPlatformDefaultWindowBarStyle();
 
 const initialState: SettingsState = {
+    cache: {
+        enabled: false,
+        path: settingPath,
+    },
     discord: {
         clientId: '1165957668758900787',
         enableIdle: false,
@@ -586,3 +595,5 @@ export const useRemoteSettings = () => useSettingsStore((state) => state.remote,
 export const useFontSettings = () => useSettingsStore((state) => state.font, shallow);
 
 export const useDiscordSetttings = () => useSettingsStore((state) => state.discord, shallow);
+
+export const useCacheSettings = () => useSettingsStore((state) => state.cache, shallow);


### PR DESCRIPTION
This is a *rough* draft of supporting caching songs.

Notes:
- The custom `feishin-cache` protocol can be avoided entirely by disabling web security (allowing loading `file://` URLs). I'd rather not force this. It _should_ be safe from directory traversal attempts, but not confident there...
- The content type is `application/octet-stream`. Somehow this still appears to work for web player (MPV is completely fine it seems)

TODO:
- Essential
  - [x] Cache when using MPV backend. I'm not actually sure the correct place to fetch the download...
  - [x] When using web backend, support seeking. Using the custom protocol, attempting to seek just moves the track back to 0. Could this be resolved by disabling web security and just using `file://`? Probably.
  - [x] Safe cache clearing mechanism. This would need to invalidate MPV/web queue.
  - [x] Proper directory chooser. The [current version of Mantine doesn't support directory chooser](https://github.com/orgs/mantinedev/discussions/3476). I guess a manual `<input>` would also work here
- Nice to have
  - [x] Show the size of the cache
  - [ ] Enable background fetch of multiple tracks (ideally using Web Workers; would require node in web worker probably...)
- Nice to have but hard to do (probably)
  - [ ] Cache status. This would probably require file system watching as well (if the user deletes one/more files).
  - [ ] Caching in the browser (Service Workers). This is _probably_ possible, since it appears that `fetch` can in fact get the entire file (when done properly?). Would also want to request persistent storage, so the quotas could be much higher.
 