### PR TITLE
Fixed incorrect docker command argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ Feishin is also available as a Docker image. The images are hosted via `ghcr.io`
 
 ```bash
 # Run the latest version
-docker run --name feishin --port 9180:9180 ghcr.io/jeffvli/feishin:latest
+docker run --name feishin -p 9180:9180 ghcr.io/jeffvli/feishin:latest
 
 # Build the image locally
 docker build -t feishin .
-docker run --name feishin --port 9180:9180 feishin
+docker run --name feishin -p 9180:9180 feishin
 ```
 
 ### Configuration


### PR DESCRIPTION
Just a slight typo I noticed in the README, the argument should be `-p` (short for --publish), instead of `--port` :)

```
-p, --publish ip:[hostPort]:containerPort | [hostPort:]containerPort
Publish a container's port, or range of ports, to the host.
```