### PR TITLE
nginx inject variables

### DIFF
--- a/.erb/configs/webpack.config.renderer.dev.ts
+++ b/.erb/configs/webpack.config.renderer.dev.ts
@@ -143,6 +143,9 @@ const configuration: webpack.Configuration = {
       env: process.env.NODE_ENV,
       isDevelopment: process.env.NODE_ENV !== 'production',
       nodeModules: webpackPaths.appNodeModulesPath,
+      templateParameters: {
+        web: false,
+      }
     }),
   ],
 

--- a/.erb/configs/webpack.config.renderer.prod.ts
+++ b/.erb/configs/webpack.config.renderer.prod.ts
@@ -127,6 +127,9 @@ const configuration: webpack.Configuration = {
       },
       isBrowser: false,
       isDevelopment: process.env.NODE_ENV !== 'production',
+      templateParameters: {
+        web: false,
+      }
     }),
   ],
 };

--- a/.erb/configs/webpack.config.renderer.web.ts
+++ b/.erb/configs/webpack.config.renderer.web.ts
@@ -116,6 +116,9 @@ const configuration: webpack.Configuration = {
             env: process.env.NODE_ENV,
             isDevelopment: process.env.NODE_ENV !== 'production',
             nodeModules: webpackPaths.appNodeModulesPath,
+            templateParameters: {
+                web: false, // with hot reload, we don't have NGINX injecting variables
+            },
         }),
     ],
 

--- a/.erb/configs/webpack.config.web.prod.ts
+++ b/.erb/configs/webpack.config.web.prod.ts
@@ -128,6 +128,9 @@ const configuration: webpack.Configuration = {
             },
             isBrowser: false,
             isDevelopment: process.env.NODE_ENV !== 'production',
+            templateParameters: {
+                web: true,
+            },
         }),
     ],
 };

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ FROM nginx:alpine-slim
 COPY --chown=nginx:nginx --from=builder /app/release/app/dist/web /usr/share/nginx/html
 COPY ng.conf.template /etc/nginx/templates/default.conf.template
 
-ENV PUBLIC_PATH="/"
+ENV PUBLIC_PATH="/" FS_SERVER_NAME="" FS_SERVER_URL="" FS_SERVER_TYPE="" FS_SERVER_USERNAME="" FS_SERVER_PASSWORD=""
 EXPOSE 9180
 CMD ["nginx", "-g", "daemon off;"]

--- a/ng.conf.template
+++ b/ng.conf.template
@@ -12,6 +12,11 @@ server {
   gzip_types        text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
   gzip_comp_level   9;
 
+  location ${PUBLIC_PATH}settings.js {
+    add_header Content-Type application/javascript;
+    return 200 '"use strict";window.FS_SERVER_NAME="${FS_SERVER_NAME}";window.FS_SERVER_URL="${FS_SERVER_URL}";window.FS_SERVER_TYPE="${FS_SERVER_TYPE}";window.FS_SERVER_USERNAME="${FS_SERVER_USERNAME}";window.FS_SERVER_PASSWORD="${FS_SERVER_PASSWORD}"';
+  }
+
   location ${PUBLIC_PATH} {
     alias /usr/share/nginx/html/;
     try_files $uri $uri/ /index.html =404;

--- a/src/renderer/index.ejs
+++ b/src/renderer/index.ejs
@@ -5,6 +5,9 @@
   <meta charset="utf-8" />
   <meta http-equiv="Content-Security-Policy" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <% if (web) { %>
+    <script src="settings.js"></script>
+  <% } %>
   <title>Feishin</title>
 </head>
 


### PR DESCRIPTION
Sample demonstrating webpack/docker/nginx changes to inject variables for js. You would still need to use `window.FS_SERVER_NAME` and so on as a fallback to `process.env.FS_SERVER_NAME`