### PR TITLE
Fix setting of replaygain fallback

### DIFF
--- a/src/renderer/features/settings/components/playback/mpv-settings.tsx
+++ b/src/renderer/features/settings/components/playback/mpv-settings.tsx
@@ -326,7 +326,9 @@ export const MpvSettings = () => {
                 <NumberInput
                     defaultValue={settings.mpvProperties.replayGainFallbackDB}
                     width={75}
-                    onBlur={(e) => handleSetMpvProperty('replayGainFallbackDB', e)}
+                    onBlur={(e) =>
+                        handleSetMpvProperty('replayGainFallbackDB', Number(e.currentTarget.value))
+                    }
                 />
             ),
             description: t('setting.replayGainFallback', {


### PR DESCRIPTION
Resolves #388
This uses `onBlur` (not sure why) instead of `onChange`, so the event handling has to be different