### PR TITLE
Fix 'undefined' in window title when song has no artist name

### DIFF
--- a/src/renderer/layouts/window-bar.tsx
+++ b/src/renderer/layouts/window-bar.tsx
@@ -222,7 +222,9 @@ export const WindowBar = () => {
     const statusString = playerStatus === PlayerStatus.PAUSED ? '(Paused) ' : '';
     const queueString = length ? `(${index + 1} / ${length}) ` : '';
     const title = length
-        ? `${statusString}${queueString}${currentSong?.name} — ${currentSong?.artistName}`
+        ? currentSong?.artistName
+            ? `${statusString}${queueString}${currentSong?.name} — ${currentSong?.artistName}`
+            : `${statusString}${queueString}${currentSong?.name}`
         : 'Feishin';
     document.title = title;
 


### PR DESCRIPTION
Fixes a bug where playing a track with no specified artist would show 'undefined' in the title bar

Before:
![before_feishin_title_fix](https://github.com/jeffvli/feishin/assets/37050201/78efedcd-141d-4526-ac03-203fe650ba8c)
After:
![after_feishin_title_fix](https://github.com/jeffvli/feishin/assets/37050201/b12bded7-9f12-42ca-b902-08310843c026)
