### PR TITLE
Add a pre-defined server for the docker version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
 node_modules
+Dockerfile
+docker-compose.*

--- a/.erb/configs/webpack.config.renderer.dev.ts
+++ b/.erb/configs/webpack.config.renderer.dev.ts
@@ -16,7 +16,7 @@ import webpackPaths from './webpack.paths';
 // When an ESLint server is running, we can't set the NODE_ENV so we'll check if it's
 // at the dev webpack config is not accidentally run in a production environment
 if (process.env.NODE_ENV === 'production') {
-  checkNodeEnv('development');
+    checkNodeEnv('development');
 }
 
 const port = process.env.PORT || 4343;
@@ -28,171 +28,174 @@ const requiredByDLLConfig = module.parent!.filename.includes('webpack.config.ren
  * Warn if the DLL is not built
  */
 if (!requiredByDLLConfig && !(fs.existsSync(webpackPaths.dllPath) && fs.existsSync(manifest))) {
-  console.log(
-    chalk.black.bgYellow.bold(
-      'The DLL files are missing. Sit back while we build them for you with "npm run build-dll"',
-    ),
-  );
-  execSync('npm run postinstall');
+    console.log(
+        chalk.black.bgYellow.bold(
+            'The DLL files are missing. Sit back while we build them for you with "npm run build-dll"',
+        ),
+    );
+    execSync('npm run postinstall');
 }
 
 const configuration: webpack.Configuration = {
-  devtool: 'inline-source-map',
+    devtool: 'inline-source-map',
 
-  mode: 'development',
+    mode: 'development',
 
-  target: ['web', 'electron-renderer'],
+    target: ['web', 'electron-renderer'],
 
-  entry: [
-    `webpack-dev-server/client?http://localhost:${port}/dist`,
-    'webpack/hot/only-dev-server',
-    path.join(webpackPaths.srcRendererPath, 'index.tsx'),
-  ],
-
-  output: {
-    path: webpackPaths.distRendererPath,
-    publicPath: '/',
-    filename: 'renderer.dev.js',
-    library: {
-      type: 'umd',
-    },
-  },
-
-  module: {
-    rules: [
-      {
-        test: /\.s?css$/,
-        use: [
-          'style-loader',
-          {
-            loader: 'css-loader',
-            options: {
-              modules: {
-                localIdentName: '[name]__[local]--[hash:base64:5]',
-                exportLocalsConvention: 'camelCaseOnly',
-              },
-              sourceMap: true,
-              importLoaders: 1,
-            },
-          },
-          'sass-loader',
-        ],
-        include: /\.module\.s?(c|a)ss$/,
-      },
-      {
-        test: /\.s?css$/,
-        use: ['style-loader', 'css-loader', 'sass-loader'],
-        exclude: /\.module\.s?(c|a)ss$/,
-      },
-      // Fonts
-      {
-        test: /\.(woff|woff2|eot|ttf|otf)$/i,
-        type: 'asset/resource',
-      },
-      // Images
-      {
-        test: /\.(png|svg|jpg|jpeg|gif)$/i,
-        type: 'asset/resource',
-      },
+    entry: [
+        `webpack-dev-server/client?http://localhost:${port}/dist`,
+        'webpack/hot/only-dev-server',
+        path.join(webpackPaths.srcRendererPath, 'index.tsx'),
     ],
-  },
-  plugins: [
-    ...(requiredByDLLConfig
-      ? []
-      : [
-          new webpack.DllReferencePlugin({
-            context: webpackPaths.dllPath,
-            manifest: require(manifest),
-            sourceType: 'var',
-          }),
-        ]),
 
-    new webpack.NoEmitOnErrorsPlugin(),
-
-    /**
-     * Create global constants which can be configured at compile time.
-     *
-     * Useful for allowing different behaviour between development builds and
-     * release builds
-     *
-     * NODE_ENV should be production so that modules do not perform certain
-     * development checks
-     *
-     * By default, use 'development' as NODE_ENV. This can be overriden with
-     * 'staging', for example, by changing the ENV variables in the npm scripts
-     */
-    new webpack.EnvironmentPlugin({
-      NODE_ENV: 'development',
-    }),
-
-    new webpack.LoaderOptionsPlugin({
-      debug: true,
-    }),
-
-    new ReactRefreshWebpackPlugin(),
-
-    new HtmlWebpackPlugin({
-      filename: path.join('index.html'),
-      template: path.join(webpackPaths.srcRendererPath, 'index.ejs'),
-      minify: {
-        collapseWhitespace: true,
-        removeAttributeQuotes: true,
-        removeComments: true,
-      },
-      isBrowser: false,
-      env: process.env.NODE_ENV,
-      isDevelopment: process.env.NODE_ENV !== 'production',
-      nodeModules: webpackPaths.appNodeModulesPath,
-    }),
-  ],
-
-  node: {
-    __dirname: false,
-    __filename: false,
-  },
-
-  devServer: {
-    port,
-    compress: true,
-    hot: true,
-    headers: { 'Access-Control-Allow-Origin': '*' },
-    static: {
-      publicPath: '/',
+    output: {
+        path: webpackPaths.distRendererPath,
+        publicPath: '/',
+        filename: 'renderer.dev.js',
+        library: {
+            type: 'umd',
+        },
     },
-    historyApiFallback: {
-      verbose: true,
-    },
-    setupMiddlewares(middlewares) {
-      console.log('Starting preload.js builder...');
-      const preloadProcess = spawn('npm', ['run', 'start:preload'], {
-        shell: true,
-        stdio: 'inherit',
-      })
-        .on('close', (code: number) => process.exit(code!))
-        .on('error', (spawnError) => console.error(spawnError));
 
-      console.log('Starting remote.js builder...');
-      const remoteProcess = spawn('npm', ['run', 'start:remote'], {
-        shell: true,
-        stdio: 'inherit',
-      })
-        .on('close', (code: number) => process.exit(code!))
-        .on('error', (spawnError) => console.error(spawnError));
-
-      console.log('Starting Main Process...');
-      spawn('npm', ['run', 'start:main'], {
-        shell: true,
-        stdio: 'inherit',
-      })
-        .on('close', (code: number) => {
-          preloadProcess.kill();
-          remoteProcess.kill();
-          process.exit(code!);
-        })
-        .on('error', (spawnError) => console.error(spawnError));
-      return middlewares;
+    module: {
+        rules: [
+            {
+                test: /\.s?css$/,
+                use: [
+                    'style-loader',
+                    {
+                        loader: 'css-loader',
+                        options: {
+                            modules: {
+                                localIdentName: '[name]__[local]--[hash:base64:5]',
+                                exportLocalsConvention: 'camelCaseOnly',
+                            },
+                            sourceMap: true,
+                            importLoaders: 1,
+                        },
+                    },
+                    'sass-loader',
+                ],
+                include: /\.module\.s?(c|a)ss$/,
+            },
+            {
+                test: /\.s?css$/,
+                use: ['style-loader', 'css-loader', 'sass-loader'],
+                exclude: /\.module\.s?(c|a)ss$/,
+            },
+            // Fonts
+            {
+                test: /\.(woff|woff2|eot|ttf|otf)$/i,
+                type: 'asset/resource',
+            },
+            // Images
+            {
+                test: /\.(png|svg|jpg|jpeg|gif)$/i,
+                type: 'asset/resource',
+            },
+        ],
     },
-  },
+    plugins: [
+        ...(requiredByDLLConfig
+            ? []
+            : [
+                  new webpack.DllReferencePlugin({
+                      context: webpackPaths.dllPath,
+                      manifest: require(manifest),
+                      sourceType: 'var',
+                  }),
+              ]),
+
+        new webpack.NoEmitOnErrorsPlugin(),
+
+        /**
+         * Create global constants which can be configured at compile time.
+         *
+         * Useful for allowing different behaviour between development builds and
+         * release builds
+         *
+         * NODE_ENV should be production so that modules do not perform certain
+         * development checks
+         *
+         * By default, use 'development' as NODE_ENV. This can be overriden with
+         * 'staging', for example, by changing the ENV variables in the npm scripts
+         */
+        new webpack.EnvironmentPlugin({
+            NODE_ENV: 'development',
+        }),
+
+        new webpack.LoaderOptionsPlugin({
+            debug: true,
+        }),
+
+        new ReactRefreshWebpackPlugin(),
+
+        new HtmlWebpackPlugin({
+            filename: path.join('index.html'),
+            template: path.join(webpackPaths.srcRendererPath, 'index.ejs'),
+            minify: {
+                collapseWhitespace: true,
+                removeAttributeQuotes: true,
+                removeComments: true,
+            },
+            isBrowser: false,
+            env: process.env.NODE_ENV,
+            isDevelopment: process.env.NODE_ENV !== 'production',
+            nodeModules: webpackPaths.appNodeModulesPath,
+            templateParameters: {
+                web: false,
+            },
+        }),
+    ],
+
+    node: {
+        __dirname: false,
+        __filename: false,
+    },
+
+    devServer: {
+        port,
+        compress: true,
+        hot: true,
+        headers: { 'Access-Control-Allow-Origin': '*' },
+        static: {
+            publicPath: '/',
+        },
+        historyApiFallback: {
+            verbose: true,
+        },
+        setupMiddlewares(middlewares) {
+            console.log('Starting preload.js builder...');
+            const preloadProcess = spawn('npm', ['run', 'start:preload'], {
+                shell: true,
+                stdio: 'inherit',
+            })
+                .on('close', (code: number) => process.exit(code!))
+                .on('error', (spawnError) => console.error(spawnError));
+
+            console.log('Starting remote.js builder...');
+            const remoteProcess = spawn('npm', ['run', 'start:remote'], {
+                shell: true,
+                stdio: 'inherit',
+            })
+                .on('close', (code: number) => process.exit(code!))
+                .on('error', (spawnError) => console.error(spawnError));
+
+            console.log('Starting Main Process...');
+            spawn('npm', ['run', 'start:main'], {
+                shell: true,
+                stdio: 'inherit',
+            })
+                .on('close', (code: number) => {
+                    preloadProcess.kill();
+                    remoteProcess.kill();
+                    process.exit(code!);
+                })
+                .on('error', (spawnError) => console.error(spawnError));
+            return middlewares;
+        },
+    },
 };
 
 export default merge(baseConfig, configuration);

--- a/.erb/configs/webpack.config.renderer.prod.ts
+++ b/.erb/configs/webpack.config.renderer.prod.ts
@@ -21,114 +21,117 @@ checkNodeEnv('production');
 deleteSourceMaps();
 
 const devtoolsConfig =
-  process.env.DEBUG_PROD === 'true'
-    ? {
-        devtool: 'source-map',
-      }
-    : {};
+    process.env.DEBUG_PROD === 'true'
+        ? {
+              devtool: 'source-map',
+          }
+        : {};
 
 const configuration: webpack.Configuration = {
-  ...devtoolsConfig,
+    ...devtoolsConfig,
 
-  mode: 'production',
+    mode: 'production',
 
-  target: ['web', 'electron-renderer'],
+    target: ['web', 'electron-renderer'],
 
-  entry: [path.join(webpackPaths.srcRendererPath, 'index.tsx')],
+    entry: [path.join(webpackPaths.srcRendererPath, 'index.tsx')],
 
-  output: {
-    path: webpackPaths.distRendererPath,
-    publicPath: './',
-    filename: 'renderer.js',
-    library: {
-      type: 'umd',
+    output: {
+        path: webpackPaths.distRendererPath,
+        publicPath: './',
+        filename: 'renderer.js',
+        library: {
+            type: 'umd',
+        },
     },
-  },
 
-  module: {
-    rules: [
-      {
-        test: /\.s?(a|c)ss$/,
-        use: [
-          MiniCssExtractPlugin.loader,
-          {
-            loader: 'css-loader',
-            options: {
-              modules: {
-                localIdentName: '[name]__[local]--[hash:base64:5]',
-                exportLocalsConvention: 'camelCaseOnly',
-              },
-              sourceMap: true,
-              importLoaders: 1,
+    module: {
+        rules: [
+            {
+                test: /\.s?(a|c)ss$/,
+                use: [
+                    MiniCssExtractPlugin.loader,
+                    {
+                        loader: 'css-loader',
+                        options: {
+                            modules: {
+                                localIdentName: '[name]__[local]--[hash:base64:5]',
+                                exportLocalsConvention: 'camelCaseOnly',
+                            },
+                            sourceMap: true,
+                            importLoaders: 1,
+                        },
+                    },
+                    'sass-loader',
+                ],
+                include: /\.module\.s?(c|a)ss$/,
             },
-          },
-          'sass-loader',
+            {
+                test: /\.s?(a|c)ss$/,
+                use: [MiniCssExtractPlugin.loader, 'css-loader', 'sass-loader'],
+                exclude: /\.module\.s?(c|a)ss$/,
+            },
+            // Fonts
+            {
+                test: /\.(woff|woff2|eot|ttf|otf)$/i,
+                type: 'asset/resource',
+            },
+            // Images
+            {
+                test: /\.(png|svg|jpg|jpeg|gif)$/i,
+                type: 'asset/resource',
+            },
         ],
-        include: /\.module\.s?(c|a)ss$/,
-      },
-      {
-        test: /\.s?(a|c)ss$/,
-        use: [MiniCssExtractPlugin.loader, 'css-loader', 'sass-loader'],
-        exclude: /\.module\.s?(c|a)ss$/,
-      },
-      // Fonts
-      {
-        test: /\.(woff|woff2|eot|ttf|otf)$/i,
-        type: 'asset/resource',
-      },
-      // Images
-      {
-        test: /\.(png|svg|jpg|jpeg|gif)$/i,
-        type: 'asset/resource',
-      },
+    },
+
+    optimization: {
+        minimize: true,
+        minimizer: [
+            new TerserPlugin({
+                parallel: true,
+            }),
+            new CssMinimizerPlugin(),
+        ],
+    },
+
+    plugins: [
+        /**
+         * Create global constants which can be configured at compile time.
+         *
+         * Useful for allowing different behaviour between development builds and
+         * release builds
+         *
+         * NODE_ENV should be production so that modules do not perform certain
+         * development checks
+         */
+        new webpack.EnvironmentPlugin({
+            NODE_ENV: 'production',
+            DEBUG_PROD: false,
+        }),
+
+        new MiniCssExtractPlugin({
+            filename: 'style.css',
+        }),
+
+        new BundleAnalyzerPlugin({
+            analyzerMode: process.env.ANALYZE === 'true' ? 'server' : 'disabled',
+        }),
+
+        new HtmlWebpackPlugin({
+            filename: 'index.html',
+            template: path.join(webpackPaths.srcRendererPath, 'index.ejs'),
+            minify: {
+                collapseWhitespace: true,
+                removeAttributeQuotes: true,
+                removeComments: true,
+            },
+            isBrowser: false,
+            isDevelopment: process.env.NODE_ENV !== 'production',
+            templateParameters: {
+                web: false,
+            },
+        }),
     ],
-  },
-
-  optimization: {
-    minimize: true,
-    minimizer: [
-      new TerserPlugin({
-        parallel: true,
-      }),
-      new CssMinimizerPlugin(),
-    ],
-  },
-
-  plugins: [
-    /**
-     * Create global constants which can be configured at compile time.
-     *
-     * Useful for allowing different behaviour between development builds and
-     * release builds
-     *
-     * NODE_ENV should be production so that modules do not perform certain
-     * development checks
-     */
-    new webpack.EnvironmentPlugin({
-      NODE_ENV: 'production',
-      DEBUG_PROD: false,
-    }),
-
-    new MiniCssExtractPlugin({
-      filename: 'style.css',
-    }),
-
-    new BundleAnalyzerPlugin({
-      analyzerMode: process.env.ANALYZE === 'true' ? 'server' : 'disabled',
-    }),
-
-    new HtmlWebpackPlugin({
-      filename: 'index.html',
-      template: path.join(webpackPaths.srcRendererPath, 'index.ejs'),
-      minify: {
-        collapseWhitespace: true,
-        removeAttributeQuotes: true,
-        removeComments: true,
-      },
-      isBrowser: false,
-      isDevelopment: process.env.NODE_ENV !== 'production',
-    }),
-  ],
 };
 
 export default merge(baseConfig, configuration);

--- a/.erb/configs/webpack.config.renderer.web.ts
+++ b/.erb/configs/webpack.config.renderer.web.ts
@@ -116,6 +116,9 @@ const configuration: webpack.Configuration = {
             env: process.env.NODE_ENV,
             isDevelopment: process.env.NODE_ENV !== 'production',
             nodeModules: webpackPaths.appNodeModulesPath,
+            templateParameters: {
+                web: false, // with hot reload, we don't have NGINX injecting variables
+            },
         }),
     ],
 

--- a/.erb/configs/webpack.config.web.prod.ts
+++ b/.erb/configs/webpack.config.web.prod.ts
@@ -128,6 +128,9 @@ const configuration: webpack.Configuration = {
             },
             isBrowser: false,
             isDevelopment: process.env.NODE_ENV !== 'production',
+            templateParameters: {
+                web: true,
+            },
         }),
     ],
 };

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,10 @@ RUN npm run build:web
 FROM nginx:alpine-slim
 
 COPY --chown=nginx:nginx --from=builder /app/release/app/dist/web /usr/share/nginx/html
+COPY ./settings.js.template /settings.js.template
+RUN envsubst < /settings.js.template > /usr/share/nginx/html/settings.js
 COPY ng.conf.template /etc/nginx/templates/default.conf.template
 
 ENV PUBLIC_PATH="/"
 EXPOSE 9180
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["/bin/sh", "-c", "envsubst < /settings.js.template > /usr/share/nginx/html/settings.js && envsubst '${PUBLIC_PATH}' < /etc/nginx/templates/default.conf.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ RUN npm run build:web
 FROM nginx:alpine-slim
 
 COPY --chown=nginx:nginx --from=builder /app/release/app/dist/web /usr/share/nginx/html
-COPY ./settings.js.template /settings.js.template
+COPY ./settings.js.template /etc/nginx/templates/settings.js.template
 COPY ng.conf.template /etc/nginx/templates/default.conf.template
 
 ENV PUBLIC_PATH="/"
 EXPOSE 9180
-CMD ["/bin/sh", "-c", "envsubst < /settings.js.template > /usr/share/nginx/html/settings.js && envsubst '${PUBLIC_PATH}' < /etc/nginx/templates/default.conf.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"]
+CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ FROM nginx:alpine-slim
 
 COPY --chown=nginx:nginx --from=builder /app/release/app/dist/web /usr/share/nginx/html
 COPY ./settings.js.template /settings.js.template
-RUN envsubst < /settings.js.template > /usr/share/nginx/html/settings.js
 COPY ng.conf.template /etc/nginx/templates/default.conf.template
 
 ENV PUBLIC_PATH="/"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 # --- Builder stage
 FROM node:18-alpine as builder
 WORKDIR /app
-COPY . /app
 
+#Copy package.json first to cache node_modules
+COPY package.json package-lock.json .
 # Scripts include electron-specific dependencies, which we don't need
 RUN npm install --legacy-peer-deps --ignore-scripts
+#Copy code and build with cached modules
+COPY . .
 RUN npm run build:web
 
 # --- Production stage

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ docker run --name feishin -p 9180:9180 feishin
 
 3. _Optional_ - If you want to host Feishin on a subpath (not `/`), then pass in the following environment variable: `PUBLIC_PATH=PATH`. For example, to host on `/feishin`, pass in `PUBLIC_PATH=/feishin`.
 
+4. _Optional_ - To hard code the server url, pass the following environment variables: `SERVER_NAME`, `SERVER_TYPE` (one of `jellyfin` or `navidrome`), `SERVER_URL`. To prevent users from changing these settings, pass `SERVER_LOCK=true`. This can only be set if all three of the previous values are set.
+
 ## FAQ
 
 ### MPV is either not working or is rapidly switching between pause/play states

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,13 +2,12 @@ version: '3.5'
 services:
     feishin:
         container_name: feishin
-        image: feishin
+        image: jeffvli/feishin
         restart: unless-stopped
         ports:
             - 9180:9180
         environment:
             - SERVER_NAME=jellyfin # pre defined server name
-            - SERVER_LOCK=true # When true only username and password fields will be enabled
-            - SERVER_TYPE=jellyfin #navidrome also works
-            - SERVER_URL= #http://address:port
-
+            - SERVER_LOCK=true # When true AND name/type/url are set, only username/password can be toggled
+            - SERVER_TYPE=jellyfin # navidrome also works
+            - SERVER_URL= # http://address:port

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,14 +1,14 @@
-version: "3.5"
+version: '3.5'
 services:
-  feishin:
-    container_name: feishin
-    image: ghcr.io/jeffvli/feishin:latest
-    restart: unless-stopped
-    ports:
-      - 9180:9180
-    environment:
-    - SERVER_NAME=jellyfin # pre defined server name
-    - SERVER_LOCK=true # When true only username and password fields will be enabled
-    - SERVER_TYPE=JELLYFIN #NAVIDROME also works
-    - SERVER_URL= #http://address:port
+    feishin:
+        container_name: feishin
+        image: feishin
+        restart: unless-stopped
+        ports:
+            - 9180:9180
+        environment:
+            - SERVER_NAME=jellyfin # pre defined server name
+            - SERVER_LOCK=true # When true only username and password fields will be enabled
+            - SERVER_TYPE=navidrome #NAVIDROME also works
+            - SERVER_URL= #http://address:port
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,6 @@ services:
         environment:
             - SERVER_NAME=jellyfin # pre defined server name
             - SERVER_LOCK=true # When true only username and password fields will be enabled
-            - SERVER_TYPE=navidrome #NAVIDROME also works
+            - SERVER_TYPE=jellyfin #navidrome also works
             - SERVER_URL= #http://address:port
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,14 @@
+version: "3.5"
+services:
+  feishin:
+    container_name: feishin
+    image: ghcr.io/jeffvli/feishin:latest
+    restart: unless-stopped
+    ports:
+      - 9180:9180
+    environment:
+    - SERVER_NAME=jellyfin # pre defined server name
+    - SERVER_LOCK=true # When true only username and password fields will be enabled
+    - SERVER_TYPE=JELLYFIN #NAVIDROME also works
+    - SERVER_URL= #http://address:port
+

--- a/ng.conf.template
+++ b/ng.conf.template
@@ -18,12 +18,10 @@ server {
   }
 
   location ${PUBLIC_PATH}settings.js {
-    add_header Content-Type application/javascript;
     alias /etc/nginx/conf.d/settings.js;
   }
 
   location ${PUBLIC_PATH}/settings.js {
-    add_header Content-Type application/javascript;
     alias /etc/nginx/conf.d/settings.js;
   }
 }

--- a/ng.conf.template
+++ b/ng.conf.template
@@ -16,4 +16,14 @@ server {
     alias /usr/share/nginx/html/;
     try_files $uri $uri/ /index.html =404;
   }
+
+  location ${PUBLIC_PATH}settings.js {
+    add_header Content-Type application/javascript;
+    alias /etc/nginx/conf.d/settings.js;
+  }
+
+  location ${PUBLIC_PATH}/settings.js {
+    add_header Content-Type application/javascript;
+    alias /etc/nginx/conf.d/settings.js;
+  }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "build:remote": "cross-env NODE_ENV=production TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.remote.prod.ts",
         "build:renderer": "cross-env NODE_ENV=production TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.renderer.prod.ts",
         "build:web": "cross-env NODE_ENV=production TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.web.prod.ts",
-        "build:docker": "npm run build:web && docker build -t jeffvli/feishin .",
+        "build:docker": "docker build -t jeffvli/feishin .",
         "rebuild": "electron-rebuild --parallel --types prod,dev,optional --module-dir release/app",
         "lint": "concurrently \"npm run lint:code\" \"npm run lint:styles\"",
         "lint:code": "cross-env NODE_ENV=development eslint . --ext .js,.jsx,.ts,.tsx --fix",

--- a/settings.js.template
+++ b/settings.js.template
@@ -1,0 +1,1 @@
+"use strict";window.SERVER_URL="${SERVER_URL}";window.SERVER_NAME="${SERVER_NAME}";window.SERVER_TYPE="${SERVER_TYPE}";window.SERVER_LOCK=${SERVER_LOCK};

--- a/src/main/preload/local-settings.ts
+++ b/src/main/preload/local-settings.ts
@@ -1,6 +1,6 @@
 import { IpcRendererEvent, ipcRenderer, webFrame } from 'electron';
 import Store from 'electron-store';
-import { toServerType, type TitleTheme, ServerType } from '/@/renderer/types';
+import { toServerType, type TitleTheme } from '/@/renderer/types';
 
 const store = new Store();
 
@@ -52,9 +52,7 @@ const SERVER_TYPE = toServerType(process.env.SERVER_TYPE);
 
 const env = {
     SERVER_LOCK:
-        SERVER_TYPE !== null
-            ? process.env.SERVER_LOCK?.toLocaleLowerCase() === 'true'
-            : ServerType.JELLYFIN,
+        SERVER_TYPE !== null ? process.env.SERVER_LOCK?.toLocaleLowerCase() === 'true' : false,
     SERVER_NAME: process.env.SERVER_NAME ?? '',
     SERVER_TYPE,
     SERVER_URL: process.env.SERVER_URL ?? 'http://',

--- a/src/main/preload/local-settings.ts
+++ b/src/main/preload/local-settings.ts
@@ -1,6 +1,6 @@
 import { IpcRendererEvent, ipcRenderer, webFrame } from 'electron';
 import Store from 'electron-store';
-import type { TitleTheme } from '/@/renderer/types';
+import { toServerType, type TitleTheme, ServerType } from '/@/renderer/types';
 
 const store = new Store();
 
@@ -48,9 +48,22 @@ const themeSet = (theme: TitleTheme): void => {
     ipcRenderer.send('theme-set', theme);
 };
 
+const SERVER_TYPE = toServerType(process.env.SERVER_TYPE);
+
+const env = {
+    SERVER_LOCK:
+        SERVER_TYPE !== null
+            ? process.env.SERVER_LOCK?.toLocaleLowerCase() === 'true'
+            : ServerType.JELLYFIN,
+    SERVER_NAME: process.env.SERVER_NAME ?? '',
+    SERVER_TYPE,
+    SERVER_URL: process.env.SERVER_URL ?? 'http://',
+};
+
 export const localSettings = {
     disableMediaKeys,
     enableMediaKeys,
+    env,
     fontError,
     get,
     passwordGet,

--- a/src/renderer/features/servers/components/add-server-form.tsx
+++ b/src/renderer/features/servers/components/add-server-form.tsx
@@ -33,11 +33,11 @@ export const AddServerForm = ({ onCancel }: AddServerFormProps) => {
     const form = useForm({
         initialValues: {
             legacyAuth: false,
-            name: '',
+            name: !isElectron() ? window.SERVER_NAME : process?.env.SERVER_NAME?? '' ,
             password: '',
             savePassword: false,
-            type: ServerType.JELLYFIN,
-            url: 'http://',
+            type: !isElectron() ? window.SERVER_TYPE.toLowerCase() : process?.env.SERVER_TYPE?.toLowerCase() ?? ServerType.JELLYFIN,
+            url: !isElectron() ? window.SERVER_URL : process?.env.SERVER_URL ?? 'https://',
             username: '',
         },
     });
@@ -62,7 +62,7 @@ export const AddServerForm = ({ onCancel }: AddServerFormProps) => {
                     password: values.password,
                     username: values.username,
                 },
-                values.type,
+                values.type as ServerType,
             );
 
             if (!data) {
@@ -76,7 +76,7 @@ export const AddServerForm = ({ onCancel }: AddServerFormProps) => {
                 id: nanoid(),
                 name: values.name,
                 ndCredential: data.ndCredential,
-                type: values.type,
+                type: values.type as ServerType,
                 url: values.url.replace(/\/$/, ''),
                 userId: data.userId,
                 username: data.username,
@@ -117,6 +117,7 @@ export const AddServerForm = ({ onCancel }: AddServerFormProps) => {
             >
                 <SegmentedControl
                     data={SERVER_TYPES}
+                    disabled = {!isElectron() ? !!window.SERVER_LOCK : !!process?.env.SERVER_LOCK ?? false}
                     {...form.getInputProps('type')}
                 />
                 <Group grow>
@@ -126,6 +127,7 @@ export const AddServerForm = ({ onCancel }: AddServerFormProps) => {
                             context: 'name',
                             postProcess: 'titleCase',
                         })}
+                        disabled = {!isElectron() ? !!window.SERVER_LOCK : !!process?.env.SERVER_LOCK ?? false}
                         {...form.getInputProps('name')}
                     />
                     <TextInput
@@ -133,6 +135,7 @@ export const AddServerForm = ({ onCancel }: AddServerFormProps) => {
                             context: 'url',
                             postProcess: 'titleCase',
                         })}
+                        disabled = {!isElectron() ? !!window.SERVER_LOCK : !!process?.env.SERVER_LOCK ?? false}
                         {...form.getInputProps('url')}
                     />
                 </Group>

--- a/src/renderer/features/servers/components/add-server-form.tsx
+++ b/src/renderer/features/servers/components/add-server-form.tsx
@@ -8,7 +8,7 @@ import isElectron from 'is-electron';
 import { nanoid } from 'nanoid/non-secure';
 import { AuthenticationResponse } from '/@/renderer/api/types';
 import { useAuthStoreActions } from '/@/renderer/store';
-import { ServerType } from '/@/renderer/types';
+import { ServerType, toServerType } from '/@/renderer/types';
 import { api } from '/@/renderer/api';
 import { useTranslation } from 'react-i18next';
 
@@ -33,14 +33,20 @@ export const AddServerForm = ({ onCancel }: AddServerFormProps) => {
     const form = useForm({
         initialValues: {
             legacyAuth: false,
-            name: !isElectron() ? window.SERVER_NAME : process?.env.SERVER_NAME?? '' ,
+            name: (localSettings ? localSettings.env.SERVER_NAME : window.SERVER_NAME) ?? '',
             password: '',
             savePassword: false,
-            type: !isElectron() ? window.SERVER_TYPE?.toLowerCase() : process?.env.SERVER_TYPE?.toLowerCase() ?? ServerType.JELLYFIN,
-            url: !isElectron() ? window.SERVER_URL : process?.env.SERVER_URL ?? 'https://',
+            type:
+                (localSettings
+                    ? localSettings.env.SERVER_TYPE
+                    : toServerType(window.SERVER_TYPE)) ?? ServerType.JELLYFIN,
+            url: (localSettings ? localSettings.env.SERVER_URL : window.SERVER_URL) ?? 'https://',
             username: '',
         },
     });
+
+    const serverLock =
+        (localSettings ? !!localSettings.env.SERVER_LOCK : !!window.SERVER_LOCK) ?? false;
 
     const isSubmitDisabled = !form.values.name || !form.values.url || !form.values.username;
 
@@ -117,25 +123,25 @@ export const AddServerForm = ({ onCancel }: AddServerFormProps) => {
             >
                 <SegmentedControl
                     data={SERVER_TYPES}
-                    disabled = {!isElectron() ? !!window.SERVER_LOCK : !!process?.env.SERVER_LOCK ?? false}
+                    disabled={serverLock}
                     {...form.getInputProps('type')}
                 />
                 <Group grow>
                     <TextInput
                         data-autofocus
+                        disabled={serverLock}
                         label={t('form.addServer.input', {
                             context: 'name',
                             postProcess: 'titleCase',
                         })}
-                        disabled = {!isElectron() ? !!window.SERVER_LOCK : !!process?.env.SERVER_LOCK ?? false}
                         {...form.getInputProps('name')}
                     />
                     <TextInput
+                        disabled={serverLock}
                         label={t('form.addServer.input', {
                             context: 'url',
                             postProcess: 'titleCase',
                         })}
-                        disabled = {!isElectron() ? !!window.SERVER_LOCK : !!process?.env.SERVER_LOCK ?? false}
                         {...form.getInputProps('url')}
                     />
                 </Group>

--- a/src/renderer/features/servers/components/add-server-form.tsx
+++ b/src/renderer/features/servers/components/add-server-form.tsx
@@ -36,7 +36,7 @@ export const AddServerForm = ({ onCancel }: AddServerFormProps) => {
             name: !isElectron() ? window.SERVER_NAME : process?.env.SERVER_NAME?? '' ,
             password: '',
             savePassword: false,
-            type: !isElectron() ? window.SERVER_TYPE.toLowerCase() : process?.env.SERVER_TYPE?.toLowerCase() ?? ServerType.JELLYFIN,
+            type: !isElectron() ? window.SERVER_TYPE?.toLowerCase() : process?.env.SERVER_TYPE?.toLowerCase() ?? ServerType.JELLYFIN,
             url: !isElectron() ? window.SERVER_URL : process?.env.SERVER_URL ?? 'https://',
             username: '',
         },

--- a/src/renderer/features/servers/components/add-server-form.tsx
+++ b/src/renderer/features/servers/components/add-server-form.tsx
@@ -45,8 +45,14 @@ export const AddServerForm = ({ onCancel }: AddServerFormProps) => {
         },
     });
 
+    // server lock for web is only true if lock is true *and* all other properties are set
     const serverLock =
-        (localSettings ? !!localSettings.env.SERVER_LOCK : !!window.SERVER_LOCK) ?? false;
+        (localSettings
+            ? !!localSettings.env.SERVER_LOCK
+            : !!window.SERVER_LOCK &&
+              window.SERVER_TYPE &&
+              window.SERVER_NAME &&
+              window.SERVER_URL) || false;
 
     const isSubmitDisabled = !form.values.name || !form.values.url || !form.values.username;
 

--- a/src/renderer/index.ejs
+++ b/src/renderer/index.ejs
@@ -6,7 +6,9 @@
   <meta http-equiv="Content-Security-Policy" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Feishin</title>
+  <% if (web) { %>
   <script src="settings.js"></script>
+  <% } %>
 </head>
 
 <body>

--- a/src/renderer/index.ejs
+++ b/src/renderer/index.ejs
@@ -6,6 +6,7 @@
   <meta http-equiv="Content-Security-Policy" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Feishin</title>
+  <script src="settings.js"></script>
 </head>
 
 <body>

--- a/src/renderer/preload.d.ts
+++ b/src/renderer/preload.d.ts
@@ -12,10 +12,10 @@ import { DiscordRpc } from '/@/main/preload/discord-rpc';
 
 declare global {
     interface Window {
-        SERVER_NAME: string;
-        SERVER_LOCK: boolean;
-        SERVER_TYPE: string;
-        SERVER_URL: string;
+        SERVER_LOCK?: boolean;
+        SERVER_NAME?: string;
+        SERVER_TYPE?: string;
+        SERVER_URL?: string;
         electron: {
             browser: any;
             discordRpc: DiscordRpc;

--- a/src/renderer/preload.d.ts
+++ b/src/renderer/preload.d.ts
@@ -12,6 +12,10 @@ import { DiscordRpc } from '/@/main/preload/discord-rpc';
 
 declare global {
     interface Window {
+        SERVER_NAME: string;
+        SERVER_LOCK: boolean;
+        SERVER_TYPE: string;
+        SERVER_URL: string;
         electron: {
             browser: any;
             discordRpc: DiscordRpc;

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -60,6 +60,17 @@ export enum ServerType {
     SUBSONIC = 'subsonic',
 }
 
+export const toServerType = (value?: string): ServerType | null => {
+    switch (value?.toLowerCase()) {
+        case ServerType.JELLYFIN:
+            return ServerType.JELLYFIN;
+        case ServerType.NAVIDROME:
+            return ServerType.NAVIDROME;
+        default:
+            return null;
+    }
+};
+
 export type ServerListItem = {
     credential: string;
     id: string;


### PR DESCRIPTION
This PR solves #380. Allows for a pre defined server configuration to be setted as environments in the docker image. I also added a locked state for the UI so user won't be allowed to change the connection details to connect to other servers.

I also took the liberty to fix and optimize the docker build process for it to take advantage of node_modules caching and removed an unused compilation when calling npm run build:docker (i think this one was my fault)

My familiarity with React is nearly 0, so i might have fucked up something or may not compy with some standard. Feel free to modify any code that's off or incorrect. My development environment is not adequate for testing electron builds, only the web version. It might be broken I can't test.