### PR TITLE
AppImage: Set proper categories on desktop entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
                 "tar.xz"
             ],
             "icon": "assets/icons/icon.png",
-            "category": "Development"
+            "category": "AudioVideo;Audio;Player"
         },
         "directories": {
             "app": "release/app",


### PR DESCRIPTION
I'm not sure whether the current `Development` category was set intentionally or whether it came from some boilerplate electron-builder config, either way however this category is intended for ["An application **_for_** development"](https://specifications.freedesktop.org/menu-spec/latest/apa.html#:~:text=Development,application%20for%20development), which Feishin clearly is not.

I took the 3 most obvious categories: `Audio`, `AudioVideo` (because it is required for `Audio`), and `Player`.
These are coincidentally also the [categories used by TauonMusicBox](https://github.com/Taiko2k/TauonMusicBox/blob/b6ff078e3f661f85d365b155cefa5395de144594/extra/com.github.taiko2k.tauonmb.desktop#L23).

The desktop file is in itself not used or relevant when launching the AppImage directly (i.e. `./Feishin-XYZ.AppImage`). However it is extracted and used when integrating the AppImage using [AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher), and therefore the categories end up being used in the user's Application Launcher in that scenario.