### PR TITLE
[bugfix]: defer restore queue until mpv exists

### DIFF
--- a/src/main/preload/mpv-player.ts
+++ b/src/main/preload/mpv-player.ts
@@ -2,11 +2,11 @@ import { ipcRenderer, IpcRendererEvent } from 'electron';
 import { PlayerData, PlayerState } from '/@/renderer/store';
 
 const initialize = (data: { extraParameters?: string[]; properties?: Record<string, any> }) => {
-    ipcRenderer.send('player-initialize', data);
+    return ipcRenderer.invoke('player-initialize', data);
 };
 
 const restart = (data: { extraParameters?: string[]; properties?: Record<string, any> }) => {
-    ipcRenderer.send('player-restart', data);
+    return ipcRenderer.invoke('player-restart', data);
 };
 
 const isRunning = () => {

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -108,7 +108,7 @@ export const App = () => {
                     ...getMpvProperties(useSettingsStore.getState().playback.mpvProperties),
                 };
 
-                mpvPlayer?.initialize({
+                await mpvPlayer?.initialize({
                     extraParameters,
                     properties,
                 });


### PR DESCRIPTION
Resolves #432.

Previously, there was a race condition where the frontend would initialize mpv and then send commands (restoring the queue), but mpv itself was not ready leading to strange behavior. This PR makes the initialization (and reset, although not used anywhere) blocking until MPV is started (or the start fails, at which point any operations are not really useful /shrug/).