### PR TITLE
Update scrobble-settings.tsx

### DIFF
--- a/src/renderer/features/settings/components/playback/scrobble-settings.tsx
+++ b/src/renderer/features/settings/components/playback/scrobble-settings.tsx
@@ -83,7 +83,7 @@ export const ScrobbleSettings = () => {
                     }}
                 />
             ),
-            description: t('setting.minimumScrobblePercentage', {
+            description: t('setting.minimumScrobbleSeconds', {
                 context: 'description',
                 postProcess: 'sentenceCase',
             }),


### PR DESCRIPTION
Fixing the description of the minimum seconds setting, it was just pulling the wrong copy.