### PR TITLE
Use startIndex in Jellyfin getPlaylistSongList

### DIFF
--- a/src/renderer/api/jellyfin/jellyfin-controller.ts
+++ b/src/renderer/api/jellyfin/jellyfin-controller.ts
@@ -538,7 +538,7 @@ const getPlaylistSongList = async (args: PlaylistSongListArgs): Promise<SongList
             Limit: query.limit,
             SortBy: query.sortBy ? songListSortMap.jellyfin[query.sortBy] : undefined,
             SortOrder: query.sortOrder ? sortOrderMap.jellyfin[query.sortOrder] : undefined,
-            StartIndex: 0,
+            StartIndex: query.startIndex,
             UserId: apiClientProps.server?.userId,
         },
     });


### PR DESCRIPTION
Fixes Jellyfin playlists with more than 300 songs.