### PR TITLE
[bugfix]: Validate audio sample range, catch AudioContext error

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -510,7 +510,7 @@
         "replayGainPreamp": "{{ReplayGain}} preamp (dB)",
         "replayGainPreamp_description": "adjust the preamp gain applied to the {{ReplayGain}} values",
         "sampleRate": "sample rate",
-        "sampleRate_description": "select the output sample rate to be used if the sample frequency selected is different from that of the current media",
+        "sampleRate_description": "select the output sample rate to be used if the sample frequency selected is different from that of the current media. a value less than 8000 will use the default frequency",
         "savePlayQueue": "save play queue",
         "savePlayQueue_description": "save the play queue when the application is closed and restore it when the application is opened",
         "scrobble": "scrobble",

--- a/src/renderer/features/settings/components/playback/mpv-settings.tsx
+++ b/src/renderer/features/settings/components/playback/mpv-settings.tsx
@@ -206,11 +206,16 @@ export const MpvSettings = () => {
         {
             control: (
                 <NumberInput
-                    defaultValue={settings.mpvProperties.audioSampleRateHz}
+                    defaultValue={settings.mpvProperties.audioSampleRateHz || undefined}
+                    max={192000}
+                    min={0}
+                    placeholder="48000"
+                    rightSection="Hz"
                     width={100}
                     onBlur={(e) => {
                         const value = Number(e.currentTarget.value);
-                        handleSetMpvProperty('audioSampleRateHz', value > 0 ? value : undefined);
+                        // Setting a value of `undefined` causes an error for MPV. Use 0 instead
+                        handleSetMpvProperty('audioSampleRateHz', value >= 8000 ? value : value);
                     }}
                 />
             ),

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -251,6 +251,7 @@ export interface SettingsState {
 export interface SettingsSlice extends SettingsState {
     actions: {
         reset: () => void;
+        resetSampleRate: () => void;
         setSettings: (data: Partial<SettingsState>) => void;
         setSidebarItems: (items: SidebarItemType[]) => void;
         setTable: (type: TableType, data: DataTableProps) => void;
@@ -566,6 +567,11 @@ export const useSettingsStore = create<SettingsSlice>()(
                         } else {
                             set(initialState);
                         }
+                    },
+                    resetSampleRate: () => {
+                        set((state) => {
+                            state.playback.mpvProperties.audioSampleRateHz = 0;
+                        });
                     },
                     setSettings: (data) => {
                         set({ ...get(), ...data });


### PR DESCRIPTION
Resolves #454. 
Validation is done on the number input to provide a reasonable range (in theory it goes from [3000, 768000] but the results I saw on different browsers varied) and additional error catching is in the player in the event the range is actually invalid for the given target. 8000 was chosen as the lower bound because that was the upper bound of error range I personally saw.