### PR TITLE
[bugfix]: Fix safari audio context

### DIFF
--- a/src/renderer/components/audio-player/index.tsx
+++ b/src/renderer/components/audio-player/index.tsx
@@ -81,7 +81,7 @@ export const AudioPlayer = forwardRef(
         const calculateReplayGain = useCallback(
             (song: Song): number => {
                 if (playback.replayGainMode === 'no') {
-                    return volume;
+                    return 1;
                 }
 
                 let gain: number | undefined;
@@ -99,7 +99,7 @@ export const AudioPlayer = forwardRef(
                     gain = playback.replayGainFallbackDB;
 
                     if (!gain) {
-                        return volume;
+                        return 1;
                     }
                 }
 
@@ -116,14 +116,13 @@ export const AudioPlayer = forwardRef(
                 if (playback.replayGainClip) {
                     return Math.min(expectedGain, 1 / peak);
                 }
-                return expectedGain * volume;
+                return expectedGain;
             },
             [
                 playback.replayGainClip,
                 playback.replayGainFallbackDB,
                 playback.replayGainMode,
                 playback.replayGainPreampDB,
-                volume,
             ],
         );
 
@@ -253,20 +252,18 @@ export const AudioPlayer = forwardRef(
         }, [audioDeviceId]);
 
         useEffect(() => {
-            if (webAudio && player1Source) {
-                if (player1 && currentPlayer === 1) {
-                    webAudio.gain.gain.setValueAtTime(calculateReplayGain(player1), 0);
-                }
+            if (webAudio && player1Source && player1 && currentPlayer === 1) {
+                const newVolume = calculateReplayGain(player1) * volume;
+                webAudio.gain.gain.setValueAtTime(newVolume, 0);
             }
-        }, [calculateReplayGain, currentPlayer, player1, player1Source, webAudio]);
+        }, [calculateReplayGain, currentPlayer, player1, player1Source, volume, webAudio]);
 
         useEffect(() => {
-            if (webAudio && player2Source) {
-                if (player2 && currentPlayer === 2) {
-                    webAudio.gain.gain.setValueAtTime(calculateReplayGain(player2), 0);
-                }
+            if (webAudio && player2Source && player2 && currentPlayer === 2) {
+                const newVolume = calculateReplayGain(player2) * volume;
+                webAudio.gain.gain.setValueAtTime(newVolume, 0);
             }
-        }, [calculateReplayGain, currentPlayer, player2, player2Source, webAudio]);
+        }, [calculateReplayGain, currentPlayer, player2, player2Source, volume, webAudio]);
 
         const handlePlayer1Start = useCallback(
             async (player: ReactPlayer) => {

--- a/src/renderer/components/audio-player/index.tsx
+++ b/src/renderer/components/audio-player/index.tsx
@@ -80,6 +80,7 @@ export const AudioPlayer = forwardRef(
 
         const calculateReplayGain = useCallback(
             (song: Song): number => {
+                console.log("ignoreme i'm trying to test if vercel is doing a thing", volume);
                 if (playback.replayGainMode === 'no') {
                     return volume;
                 }

--- a/src/renderer/components/audio-player/index.tsx
+++ b/src/renderer/components/audio-player/index.tsx
@@ -39,6 +39,11 @@ type WebAudio = {
     gain: GainNode;
 };
 
+// Credits: http://stackoverflow.com/questions/12150729/ddg
+// This is used so that the player will always have an <audio> element. This means that
+// player1Source and player2Source are connected BEFORE the user presses play for
+// the first time. This workaround is important for Safari, which seems to require the
+// source to be connected PRIOR to resuming audio context
 const EMPTY_SOURCE =
     'data:audio/wav;base64,UklGRjIAAABXQVZFZm10IBIAAAABAAEAQB8AAEAfAAABAAgAAABmYWN0BAAAAAAAAABkYXRhAAAAAA==';
 
@@ -266,6 +271,8 @@ export const AudioPlayer = forwardRef(
             async (player: ReactPlayer) => {
                 if (!webAudio) return;
                 if (player1Source) {
+                    // This should fire once, only if the source is real (meaning we
+                    // saw the dummy source) and the context is not ready
                     if (webAudio.context.state !== 'running') {
                         await webAudio.context.resume();
                     }

--- a/src/renderer/components/audio-player/index.tsx
+++ b/src/renderer/components/audio-player/index.tsx
@@ -81,7 +81,7 @@ export const AudioPlayer = forwardRef(
         const calculateReplayGain = useCallback(
             (song: Song): number => {
                 if (playback.replayGainMode === 'no') {
-                    return 1;
+                    return volume;
                 }
 
                 let gain: number | undefined;
@@ -99,7 +99,7 @@ export const AudioPlayer = forwardRef(
                     gain = playback.replayGainFallbackDB;
 
                     if (!gain) {
-                        return 1;
+                        return volume;
                     }
                 }
 
@@ -116,13 +116,14 @@ export const AudioPlayer = forwardRef(
                 if (playback.replayGainClip) {
                     return Math.min(expectedGain, 1 / peak);
                 }
-                return expectedGain;
+                return expectedGain * volume;
             },
             [
                 playback.replayGainClip,
                 playback.replayGainFallbackDB,
                 playback.replayGainMode,
                 playback.replayGainPreampDB,
+                volume,
             ],
         );
 
@@ -311,6 +312,9 @@ export const AudioPlayer = forwardRef(
             [player2Source, webAudio],
         );
 
+        // Bugfix for Safari: rather than use the `<audio>` volume (which doesn't work),
+        // use the GainNode to scale the volume. In this case, for compatibility with
+        // other browsers, set the `<audio>` volume to 1
         return (
             <>
                 <ReactPlayer
@@ -324,7 +328,7 @@ export const AudioPlayer = forwardRef(
                     playing={currentPlayer === 1 && status === PlayerStatus.PLAYING}
                     progressInterval={isTransitioning ? 10 : 250}
                     url={player1?.streamUrl || EMPTY_SOURCE}
-                    volume={volume}
+                    volume={webAudio ? 1 : volume}
                     width={0}
                     onEnded={handleOnEnded}
                     onProgress={
@@ -343,7 +347,7 @@ export const AudioPlayer = forwardRef(
                     playing={currentPlayer === 2 && status === PlayerStatus.PLAYING}
                     progressInterval={isTransitioning ? 10 : 250}
                     url={player2?.streamUrl || EMPTY_SOURCE}
-                    volume={volume}
+                    volume={webAudio ? 1 : volume}
                     width={0}
                     onEnded={handleOnEnded}
                     onProgress={

--- a/src/renderer/components/audio-player/index.tsx
+++ b/src/renderer/components/audio-player/index.tsx
@@ -80,7 +80,6 @@ export const AudioPlayer = forwardRef(
 
         const calculateReplayGain = useCallback(
             (song: Song): number => {
-                console.log("ignoreme i'm trying to test if vercel is doing a thing", volume);
                 if (playback.replayGainMode === 'no') {
                     return volume;
                 }


### PR DESCRIPTION
Resolves #329.

Safari is particularly picky about web audio. What seems to be the requirement is that the media element (the `<audio>` node) is connected to the audio context first, and *then* when there is user interaction you can resume the context. Previously, it required two button clicks to accomplish this.

This is fixed by providing a dummy audio source (empty WAV base64 encoded) which forces ReactPlayer to create an empty audio element that can be connected. Then, when the user makes an interaction, the audio context can be resumed properly.