### PR TITLE
[bugfix]: Fix add to playlist success message

### DIFF
--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -559,7 +559,7 @@
             "error_savePassword": "při ukládání hesla se vyskytla chyba"
         },
         "addToPlaylist": {
-            "success": "přidáno {{message}} $t(entity.song_other) do {{numOfPlaylists}} $t(entity.playlist_other)",
+            "success": "přidáno {{message}} $t(entity.track_other) do {{numOfPlaylists}} $t(entity.playlist_other)",
             "title": "přidat do $t(entity.playlist_one)",
             "input_skipDuplicates": "přeskočit duplicity",
             "input_playlists": "$t(entity.playlist_other)"

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -191,7 +191,7 @@
             "error_savePassword": "Beim Versuch, das Passwort zu speichern, ist ein Fehler aufgetreten"
         },
         "addToPlaylist": {
-            "success": "{{message}} $t(entity.song_other) zu {{numOfPlaylists}} $t(entity.playlist_other) hinzugefügt",
+            "success": "{{message}} $t(entity.track_other) zu {{numOfPlaylists}} $t(entity.playlist_other) hinzugefügt",
             "title": "Zu $t(entity.playlist_one) hinzufügen",
             "input_skipDuplicates": "Duplikate überspringen",
             "input_playlists": "$t(entity.playlist_other)"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -216,7 +216,7 @@
         "addToPlaylist": {
             "input_playlists": "$t(entity.playlist_other)",
             "input_skipDuplicates": "skip duplicates",
-            "success": "added {{message}} $t(entity.song_other) to {{numOfPlaylists}} $t(entity.playlist_other)",
+            "success": "added $t(entity.trackWithCount, {\"count\": {{message}} }) to $t(entity.playlistWithCount, {\"count\": {{numOfPlaylists}} })",
             "title": "add to $t(entity.playlist_one)"
         },
         "createPlaylist": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -491,7 +491,7 @@
             "error_savePassword": "un error ocurrió cuando se intentó guardar la contraseña"
         },
         "addToPlaylist": {
-            "success": "añadido {{message}} $t(entity.song_other) a {{numOfPlaylists}} $t(entity.playlist_other)",
+            "success": "añadido {{message}} $t(entity.track_other) a {{numOfPlaylists}} $t(entity.playlist_other)",
             "title": "añadir a $t(entity.playlist_one)",
             "input_skipDuplicates": "saltar duplicados",
             "input_playlists": "$t(entity.playlist_other)"

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -483,7 +483,7 @@
             "error_savePassword": "une erreur s’est produite lors de la tentative de sauvegarde du mot de passe"
         },
         "addToPlaylist": {
-            "success": "{{message}} $t(entity.song_other) ajouté à {{numOfPlaylists}} $t(entity.playlist_other)",
+            "success": "{{message}} $t(entity.track_other) ajouté à {{numOfPlaylists}} $t(entity.playlist_other)",
             "title": "ajouter à $t(entity.playlist_one)",
             "input_skipDuplicates": "sauter les doublons",
             "input_playlists": "$t(entity.playlist_other)"

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -487,7 +487,7 @@
             "error_savePassword": "si è verificato un errore quando si è provato a salvare la password"
         },
         "addToPlaylist": {
-            "success": "aggiunto {{message}} $t(entity.song_other) a {{numOfPlaylists}} $t(entity.playlist_other)",
+            "success": "aggiunto {{message}} $t(entity.track_other) a {{numOfPlaylists}} $t(entity.playlist_other)",
             "title": "aggiungi a $t(entity.playlist_one)",
             "input_skipDuplicates": "salta duplicati",
             "input_playlists": "$t(entity.playlist_other)"

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -553,7 +553,7 @@
             "error_savePassword": "パスワードを保存する際にエラーが発生しました"
         },
         "addToPlaylist": {
-            "success": "{{message}} $t(entity.song_other) を {{numOfPlaylists}} $t(entity.playlist_other) に追加しました",
+            "success": "{{message}} $t(entity.track_other) を {{numOfPlaylists}} $t(entity.playlist_other) に追加しました",
             "title": "$t(entity.playlist_one) に追加",
             "input_skipDuplicates": "重複をスキップ",
             "input_playlists": "$t(entity.playlist_other)"

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -242,7 +242,7 @@
             "error_savePassword": "wystąpił błąd podczas próby zapisania hasła"
         },
         "addToPlaylist": {
-            "success": "dodano {{message}} $t(entity.song_other) do {{numOfPlaylists}} $t(entity.playlist_other)",
+            "success": "dodano {{message}} $t(entity.track_other) do {{numOfPlaylists}} $t(entity.playlist_other)",
             "title": "dodano do $t(entity.playlist_one)",
             "input_skipDuplicates": "pomiń duplikaty",
             "input_playlists": "$t(entity.playlist_other)"

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -434,7 +434,7 @@
             "error_savePassword": "произошла ошибка во время попытки сохранения пароля"
         },
         "addToPlaylist": {
-            "success": "добавлено(а) {{message}} $t(entity.song_other) в {{numOfPlaylists}} $t(entity.playlist_other)",
+            "success": "добавлено(а) {{message}} $t(entity.track_other) в {{numOfPlaylists}} $t(entity.playlist_other)",
             "title": "добавить в $t(entity.playlist_one)",
             "input_skipDuplicates": "пропустить дубликаты",
             "input_playlists": "$t(entity.playlist_other)"

--- a/src/i18n/locales/sr.json
+++ b/src/i18n/locales/sr.json
@@ -559,7 +559,7 @@
             "error_savePassword": "došlo je do greške prilikom pokušaja čuvanja lozinke"
         },
         "addToPlaylist": {
-            "success": "dodato {{message}} $t(entity.song_other) u {{numOfPlaylists}} $t(entity.playlist_other)",
+            "success": "dodato {{message}} $t(entity.track_other) u {{numOfPlaylists}} $t(entity.playlist_other)",
             "title": "dodaj u $t(entity.playlist_one)",
             "input_skipDuplicates": "preskoči duplikate",
             "input_playlists": "$t(entity.playlist_other)"

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -190,7 +190,7 @@
             "error_savePassword": "ett fel uppstod när lösenordet skulle sparas"
         },
         "addToPlaylist": {
-            "success": "tillade {{message}} $t(entity.song_other) til {{numOfPlaylists}} $t(entity.playlist_other)",
+            "success": "tillade {{message}} $t(entity.track_other) til {{numOfPlaylists}} $t(entity.playlist_other)",
             "title": "lägg till i $t(entity.playlist_one)",
             "input_skipDuplicates": "hoppa över dubbletter",
             "input_playlists": "$t(entity.playlist_other)"

--- a/src/i18n/locales/zh-Hans.json
+++ b/src/i18n/locales/zh-Hans.json
@@ -495,7 +495,7 @@
             "input_url": "url"
         },
         "addToPlaylist": {
-            "success": "添加 {{message}} $t(entity.song_other) 到 {{numOfPlaylists}} $t(entity.playlist_other)",
+            "success": "添加 {{message}} $t(entity.track_other) 到 {{numOfPlaylists}} $t(entity.playlist_other)",
             "title": "添加到$t(entity.playlist_one)",
             "input_skipDuplicates": "跳过重复",
             "input_playlists": "$t(entity.playlist_other)"

--- a/src/renderer/features/playlists/components/add-to-playlist-context-modal.tsx
+++ b/src/renderer/features/playlists/components/add-to-playlist-context-modal.tsx
@@ -191,12 +191,12 @@ export const AddToPlaylistContextModal = ({
         const addMessage =
             values.skipDuplicates &&
             allSongIds.length * values.playlistId.length !== totalUniquesAdded
-                ? `${Math.floor(totalUniquesAdded / values.playlistId.length)}`
+                ? Math.floor(totalUniquesAdded / values.playlistId.length)
                 : allSongIds.length;
 
         setIsLoading(false);
         toast.success({
-            message: t('form.addToPlaylist', {
+            message: t('form.addToPlaylist.success', {
                 message: addMessage,
                 numOfPlaylists: values.playlistId.length,
                 postProcess: 'sentenceCase',


### PR DESCRIPTION
The prior code used `form.addToPlaylist`, not `.success`. Also fixes English pluralization and uses the correct `entity.track` as opposed to `entity.song` for other languages (I am not sure if the en syntax could be applied to other languages, so I will just leave pluralization as-is for now).
Resolves #438