### PR TITLE
[bugfix/enhancement]: Support Navidrome structured lyrics

### DIFF
--- a/src/renderer/api/controller.ts
+++ b/src/renderer/api/controller.ts
@@ -48,6 +48,8 @@ import type {
     SearchResponse,
     LyricsArgs,
     LyricsResponse,
+    ServerInfo,
+    ServerInfoArgs,
 } from '/@/renderer/api/types';
 import { ServerType } from '/@/renderer/types';
 import { DeletePlaylistResponse, RandomSongListArgs } from './types';
@@ -85,6 +87,7 @@ export type ControllerEndpoint = Partial<{
     getPlaylistList: (args: PlaylistListArgs) => Promise<PlaylistListResponse>;
     getPlaylistSongList: (args: PlaylistSongListArgs) => Promise<SongListResponse>;
     getRandomSongList: (args: RandomSongListArgs) => Promise<SongListResponse>;
+    getServerInfo: (args: ServerInfoArgs) => Promise<ServerInfo>;
     getSongDetail: (args: SongDetailArgs) => Promise<SongDetailResponse>;
     getSongList: (args: SongListArgs) => Promise<SongListResponse>;
     getTopSongs: (args: TopSongListArgs) => Promise<TopSongListResponse>;
@@ -129,6 +132,7 @@ const endpoints: ApiController = {
         getPlaylistList: jfController.getPlaylistList,
         getPlaylistSongList: jfController.getPlaylistSongList,
         getRandomSongList: jfController.getRandomSongList,
+        getServerInfo: jfController.getServerInfo,
         getSongDetail: jfController.getSongDetail,
         getSongList: jfController.getSongList,
         getTopSongs: jfController.getTopSongList,
@@ -165,6 +169,7 @@ const endpoints: ApiController = {
         getPlaylistList: ndController.getPlaylistList,
         getPlaylistSongList: ndController.getPlaylistSongList,
         getRandomSongList: ssController.getRandomSongList,
+        getServerInfo: ssController.getServerInfo,
         getSongDetail: ndController.getSongDetail,
         getSongList: ndController.getSongList,
         getTopSongs: ssController.getTopSongList,
@@ -198,6 +203,7 @@ const endpoints: ApiController = {
         getMusicFolderList: ssController.getMusicFolderList,
         getPlaylistDetail: undefined,
         getPlaylistList: undefined,
+        getServerInfo: ssController.getServerInfo,
         getSongDetail: undefined,
         getSongList: undefined,
         getTopSongs: ssController.getTopSongList,
@@ -481,6 +487,15 @@ const getLyrics = async (args: LyricsArgs) => {
     )?.(args);
 };
 
+const getServerInfo = async (args: ServerInfoArgs) => {
+    return (
+        apiController(
+            'getServerInfo',
+            args.apiClientProps.server?.type,
+        ) as ControllerEndpoint['getServerInfo']
+    )?.(args);
+};
+
 export const controller = {
     addToPlaylist,
     authenticate,
@@ -500,6 +515,7 @@ export const controller = {
     getPlaylistList,
     getPlaylistSongList,
     getRandomSongList,
+    getServerInfo,
     getSongDetail,
     getSongList,
     getTopSongList,

--- a/src/renderer/api/controller.ts
+++ b/src/renderer/api/controller.ts
@@ -50,6 +50,8 @@ import type {
     LyricsResponse,
     ServerInfo,
     ServerInfoArgs,
+    StructuredLyricsArgs,
+    StructuredLyric,
 } from '/@/renderer/api/types';
 import { ServerType } from '/@/renderer/types';
 import { DeletePlaylistResponse, RandomSongListArgs } from './types';
@@ -90,6 +92,7 @@ export type ControllerEndpoint = Partial<{
     getServerInfo: (args: ServerInfoArgs) => Promise<ServerInfo>;
     getSongDetail: (args: SongDetailArgs) => Promise<SongDetailResponse>;
     getSongList: (args: SongListArgs) => Promise<SongListResponse>;
+    getStructuredLyrics: (args: StructuredLyricsArgs) => Promise<StructuredLyric[]>;
     getTopSongs: (args: TopSongListArgs) => Promise<TopSongListResponse>;
     getUserList: (args: UserListArgs) => Promise<UserListResponse>;
     removeFromPlaylist: (args: RemoveFromPlaylistArgs) => Promise<RemoveFromPlaylistResponse>;
@@ -135,6 +138,7 @@ const endpoints: ApiController = {
         getServerInfo: jfController.getServerInfo,
         getSongDetail: jfController.getSongDetail,
         getSongList: jfController.getSongList,
+        getStructuredLyrics: undefined,
         getTopSongs: jfController.getTopSongList,
         getUserList: undefined,
         removeFromPlaylist: jfController.removeFromPlaylist,
@@ -172,6 +176,7 @@ const endpoints: ApiController = {
         getServerInfo: ssController.getServerInfo,
         getSongDetail: ndController.getSongDetail,
         getSongList: ndController.getSongList,
+        getStructuredLyrics: ssController.getStructuredLyrics,
         getTopSongs: ssController.getTopSongList,
         getUserList: ndController.getUserList,
         removeFromPlaylist: ndController.removeFromPlaylist,
@@ -206,6 +211,7 @@ const endpoints: ApiController = {
         getServerInfo: ssController.getServerInfo,
         getSongDetail: undefined,
         getSongList: undefined,
+        getStructuredLyrics: ssController.getStructuredLyrics,
         getTopSongs: ssController.getTopSongList,
         getUserList: undefined,
         scrobble: ssController.scrobble,
@@ -496,6 +502,15 @@ const getServerInfo = async (args: ServerInfoArgs) => {
     )?.(args);
 };
 
+const getStructuredLyrics = async (args: StructuredLyricsArgs) => {
+    return (
+        apiController(
+            'getStructuredLyrics',
+            args.apiClientProps.server?.type,
+        ) as ControllerEndpoint['getStructuredLyrics']
+    )?.(args);
+};
+
 export const controller = {
     addToPlaylist,
     authenticate,
@@ -518,6 +533,7 @@ export const controller = {
     getServerInfo,
     getSongDetail,
     getSongList,
+    getStructuredLyrics,
     getTopSongList,
     getUserList,
     removeFromPlaylist,

--- a/src/renderer/api/jellyfin/jellyfin-api.ts
+++ b/src/renderer/api/jellyfin/jellyfin-api.ts
@@ -150,6 +150,14 @@ export const contract = c.router({
             400: jfType._response.error,
         },
     },
+    getServerInfo: {
+        method: 'GET',
+        path: 'system/info',
+        responses: {
+            200: jfType._response.serverInfo,
+            400: jfType._response.error,
+        },
+    },
     getSimilarArtistList: {
         method: 'GET',
         path: 'artists/:id/similar',

--- a/src/renderer/api/jellyfin/jellyfin-controller.ts
+++ b/src/renderer/api/jellyfin/jellyfin-controller.ts
@@ -49,6 +49,8 @@ import {
     genreListSortMap,
     SongDetailArgs,
     SongDetailResponse,
+    ServerInfo,
+    ServerInfoArgs,
 } from '/@/renderer/api/types';
 import { jfApiClient } from '/@/renderer/api/jellyfin/jellyfin-api';
 import { jfNormalize } from './jellyfin-normalize';
@@ -946,6 +948,18 @@ const getSongDetail = async (args: SongDetailArgs): Promise<SongDetailResponse> 
     return jfNormalize.song(res.body, apiClientProps.server, '');
 };
 
+const getServerInfo = async (args: ServerInfoArgs): Promise<ServerInfo> => {
+    const { apiClientProps } = args;
+
+    const res = await jfApiClient(apiClientProps).getServerInfo();
+
+    if (res.status !== 200) {
+        throw new Error('Failed to get song detail');
+    }
+
+    return { id: apiClientProps.server?.id, version: res.body.Version };
+};
+
 export const jfController = {
     addToPlaylist,
     authenticate,
@@ -965,6 +979,7 @@ export const jfController = {
     getPlaylistList,
     getPlaylistSongList,
     getRandomSongList,
+    getServerInfo,
     getSongDetail,
     getSongList,
     getTopSongList,

--- a/src/renderer/api/jellyfin/jellyfin-controller.ts
+++ b/src/renderer/api/jellyfin/jellyfin-controller.ts
@@ -954,7 +954,7 @@ const getServerInfo = async (args: ServerInfoArgs): Promise<ServerInfo> => {
     const res = await jfApiClient(apiClientProps).getServerInfo();
 
     if (res.status !== 200) {
-        throw new Error('Failed to get song detail');
+        throw new Error('Failed to get server info');
     }
 
     return { id: apiClientProps.server?.id, version: res.body.Version };

--- a/src/renderer/api/jellyfin/jellyfin-types.ts
+++ b/src/renderer/api/jellyfin/jellyfin-types.ts
@@ -654,6 +654,10 @@ const lyrics = z.object({
     Lyrics: z.array(lyricText),
 });
 
+const serverInfo = z.object({
+    Version: z.string(),
+});
+
 export const jfType = {
     _enum: {
         albumArtistList: albumArtistListSort,
@@ -707,6 +711,7 @@ export const jfType = {
         removeFromPlaylist,
         scrobble,
         search,
+        serverInfo,
         song,
         songList,
         topSongsList,

--- a/src/renderer/api/subsonic/subsonic-api.ts
+++ b/src/renderer/api/subsonic/subsonic-api.ts
@@ -57,6 +57,14 @@ export const contract = c.router({
             200: ssType._response.serverInfo,
         },
     },
+    getStructuredLyrics: {
+        method: 'GET',
+        path: 'getLyricsBySongId.view',
+        query: ssType._parameters.structuredLyrics,
+        responses: {
+            200: ssType._response.structuredLyrics,
+        },
+    },
     getTopSongsList: {
         method: 'GET',
         path: 'getTopSongs.view',

--- a/src/renderer/api/subsonic/subsonic-api.ts
+++ b/src/renderer/api/subsonic/subsonic-api.ts
@@ -50,12 +50,26 @@ export const contract = c.router({
             200: ssType._response.randomSongList,
         },
     },
+    getServerInfo: {
+        method: 'GET',
+        path: 'getOpenSubsonicExtensions.view',
+        responses: {
+            200: ssType._response.serverInfo,
+        },
+    },
     getTopSongsList: {
         method: 'GET',
         path: 'getTopSongs.view',
         query: ssType._parameters.topSongsList,
         responses: {
             200: ssType._response.topSongsList,
+        },
+    },
+    ping: {
+        method: 'GET',
+        path: 'ping.view',
+        responses: {
+            200: ssType._response.ping,
         },
     },
     removeFavorite: {

--- a/src/renderer/api/subsonic/subsonic-controller.ts
+++ b/src/renderer/api/subsonic/subsonic-controller.ts
@@ -23,6 +23,8 @@ import {
     RandomSongListArgs,
     ServerInfo,
     ServerInfoArgs,
+    StructuredLyricsArgs,
+    StructuredLyric,
 } from '/@/renderer/api/types';
 import { randomString } from '/@/renderer/utils';
 
@@ -397,6 +399,51 @@ const getServerInfo = async (args: ServerInfoArgs): Promise<ServerInfo> => {
     return { features, id: apiClientProps.server?.id, version: ping.body.serverVersion };
 };
 
+export const getStructuredLyrics = async (
+    args: StructuredLyricsArgs,
+): Promise<StructuredLyric[]> => {
+    const { query, apiClientProps } = args;
+
+    const res = await ssApiClient(apiClientProps).getStructuredLyrics({
+        query: {
+            id: query.songId,
+        },
+    });
+
+    if (res.status !== 200) {
+        throw new Error('Failed to get server extensions');
+    }
+
+    const lyrics = res.body.lyricsList?.structuredLyrics;
+
+    if (!lyrics) {
+        return [];
+    }
+
+    return lyrics.map((lyric) => {
+        const baseLyric = {
+            artist: lyric.displayArtist || '',
+            lang: lyric.lang,
+            name: lyric.displayTitle || '',
+            remote: false,
+            source: apiClientProps.server?.name || 'music server',
+        };
+
+        if (lyric.synced) {
+            return {
+                ...baseLyric,
+                lyrics: lyric.line.map((line) => [line.start!, line.value]),
+                synced: true,
+            };
+        }
+        return {
+            ...baseLyric,
+            lyrics: lyric.line.map((line) => [line.value]).join('\n'),
+            synced: false,
+        };
+    });
+};
+
 export const ssController = {
     authenticate,
     createFavorite,
@@ -404,6 +451,7 @@ export const ssController = {
     getMusicFolderList,
     getRandomSongList,
     getServerInfo,
+    getStructuredLyrics,
     getTopSongList,
     removeFavorite,
     scrobble,

--- a/src/renderer/api/subsonic/subsonic-controller.ts
+++ b/src/renderer/api/subsonic/subsonic-controller.ts
@@ -411,7 +411,7 @@ export const getStructuredLyrics = async (
     });
 
     if (res.status !== 200) {
-        throw new Error('Failed to get server extensions');
+        throw new Error('Failed to get structured lyrics');
     }
 
     const lyrics = res.body.lyricsList?.structuredLyrics;

--- a/src/renderer/api/subsonic/subsonic-types.ts
+++ b/src/renderer/api/subsonic/subsonic-types.ts
@@ -206,6 +206,21 @@ const randomSongList = z.object({
     }),
 });
 
+const ping = z.object({
+    openSubsonic: z.boolean().optional(),
+    serverVersion: z.string().optional(),
+    version: z.string(),
+});
+
+const extension = z.object({
+    name: z.string(),
+    versions: z.number().array(),
+});
+
+const serverInfo = z.object({
+    openSubsonicExtensions: z.array(extension),
+});
+
 export const ssType = {
     _parameters: {
         albumList: albumListParameters,
@@ -229,10 +244,12 @@ export const ssType = {
         baseResponse,
         createFavorite,
         musicFolderList,
+        ping,
         randomSongList,
         removeFavorite,
         scrobble,
         search3,
+        serverInfo,
         setRating,
         song,
         topSongsList,

--- a/src/renderer/api/subsonic/subsonic-types.ts
+++ b/src/renderer/api/subsonic/subsonic-types.ts
@@ -221,6 +221,32 @@ const serverInfo = z.object({
     openSubsonicExtensions: z.array(extension),
 });
 
+const structuredLyricsParameters = z.object({
+    id: z.string(),
+});
+
+const lyricLine = z.object({
+    start: z.number().optional(),
+    value: z.string(),
+});
+
+const structuredLyric = z.object({
+    displayArtist: z.string().optional(),
+    displayTitle: z.string().optional(),
+    lang: z.string(),
+    line: z.array(lyricLine),
+    offset: z.number().optional(),
+    synced: z.boolean(),
+});
+
+const structuredLyrics = z.object({
+    lyricsList: z
+        .object({
+            structuredLyrics: z.array(structuredLyric).optional(),
+        })
+        .optional(),
+});
+
 export const ssType = {
     _parameters: {
         albumList: albumListParameters,
@@ -232,6 +258,7 @@ export const ssType = {
         scrobble: scrobbleParameters,
         search3: search3Parameters,
         setRating: setRatingParameters,
+        structuredLyrics: structuredLyricsParameters,
         topSongsList: topSongsListParameters,
     },
     _response: {
@@ -252,6 +279,7 @@ export const ssType = {
         serverInfo,
         setRating,
         song,
+        structuredLyrics,
         topSongsList,
     },
 };

--- a/src/renderer/api/types.ts
+++ b/src/renderer/api/types.ts
@@ -1092,17 +1092,11 @@ export type InternetProviderLyricSearchResponse = {
     source: LyricSource;
 };
 
-export type SynchronizedLyricMetadata = {
-    lyrics: SynchronizedLyricsArray;
+export type FullLyricsMetadata = {
+    lyrics: LyricsResponse;
     remote: boolean;
-} & Omit<InternetProviderLyricResponse, 'lyrics'>;
-
-export type UnsynchronizedLyricMetadata = {
-    lyrics: string;
-    remote: boolean;
-} & Omit<InternetProviderLyricResponse, 'lyrics'>;
-
-export type FullLyricsMetadata = SynchronizedLyricMetadata | UnsynchronizedLyricMetadata;
+    source: string;
+} & Omit<InternetProviderLyricResponse, 'id' | 'lyrics' | 'source'>;
 
 export type LyricOverride = Omit<InternetProviderLyricResponse, 'lyrics'>;
 
@@ -1153,3 +1147,21 @@ export type ServerInfo = {
     id?: string;
     version: string;
 };
+
+export type StructuredLyricsArgs = {
+    query: LyricsQuery;
+} & BaseEndpointArgs;
+
+export type StructuredUnsyncedLyric = {
+    lyrics: string;
+    synced: false;
+} & Omit<FullLyricsMetadata, 'lyrics'>;
+
+export type StructuredSyncedLyric = {
+    lyrics: SynchronizedLyricsArray;
+    synced: true;
+} & Omit<FullLyricsMetadata, 'lyrics'>;
+
+export type StructuredLyric = {
+    lang: string;
+} & (StructuredUnsyncedLyric | StructuredSyncedLyric);

--- a/src/renderer/api/types.ts
+++ b/src/renderer/api/types.ts
@@ -1139,3 +1139,17 @@ export type FontData = {
     postscriptName: string;
     style: string;
 };
+
+export type ServerInfoArgs = BaseEndpointArgs;
+
+export enum SubsonicExtensions {
+    FORM_POST = 'formPost',
+    SONG_LYRICS = 'songLyrics',
+    TRANSCODE_OFFSET = 'transcodeOffset',
+}
+
+export type ServerInfo = {
+    features?: Record<string, number[]>;
+    id?: string;
+    version: string;
+};

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -27,6 +27,7 @@ import { FontType, PlaybackType, PlayerStatus } from '/@/renderer/types';
 import '@ag-grid-community/styles/ag-grid.css';
 import { useDiscordRpc } from '/@/renderer/features/discord-rpc/use-discord-rpc';
 import i18n from '/@/i18n/i18n';
+import { useServerVersion } from '/@/renderer/hooks/use-server-version';
 
 ModuleRegistry.registerModules([ClientSideRowModelModule, InfiniteRowModelModule]);
 
@@ -49,6 +50,7 @@ export const App = () => {
     const remoteSettings = useRemoteSettings();
     const textStyleRef = useRef<HTMLStyleElement>();
     useDiscordRpc();
+    useServerVersion();
 
     useEffect(() => {
         if (type === FontType.SYSTEM && system) {

--- a/src/renderer/features/lyrics/lyrics-actions.tsx
+++ b/src/renderer/features/lyrics/lyrics-actions.tsx
@@ -1,4 +1,4 @@
-import { Box, Group } from '@mantine/core';
+import { Box, Center, Group, Select, SelectItem } from '@mantine/core';
 import isElectron from 'is-electron';
 import { useTranslation } from 'react-i18next';
 import { RiAddFill, RiSubtractFill } from 'react-icons/ri';
@@ -13,15 +13,22 @@ import {
 } from '/@/renderer/store';
 
 interface LyricsActionsProps {
+    index: number;
+    languages: SelectItem[];
+
     onRemoveLyric: () => void;
     onResetLyric: () => void;
     onSearchOverride: (params: LyricsOverride) => void;
+    setIndex: (idx: number) => void;
 }
 
 export const LyricsActions = ({
+    index,
+    languages,
     onRemoveLyric,
     onResetLyric,
     onSearchOverride,
+    setIndex,
 }: LyricsActionsProps) => {
     const { t } = useTranslation();
     const currentSong = useCurrentSong();
@@ -42,6 +49,18 @@ export const LyricsActions = ({
 
     return (
         <Box style={{ position: 'relative', width: '100%' }}>
+            {languages.length > 1 && (
+                <Center>
+                    <Select
+                        clearable={false}
+                        data={languages}
+                        style={{ bottom: 30, position: 'absolute' }}
+                        value={index.toString()}
+                        onChange={(value) => setIndex(parseInt(value!, 10))}
+                    />
+                </Center>
+            )}
+
             <Group position="center">
                 {isDesktop && sources.length ? (
                     <Button

--- a/src/renderer/features/lyrics/lyrics.tsx
+++ b/src/renderer/features/lyrics/lyrics.tsx
@@ -6,7 +6,7 @@ import { RiInformationFill } from 'react-icons/ri';
 import styled from 'styled-components';
 import { useSongLyricsByRemoteId, useSongLyricsBySong } from './queries/lyric-query';
 import { SynchronizedLyrics, SynchronizedLyricsProps } from './synchronized-lyrics';
-import { Select, Spinner, TextTitle } from '/@/renderer/components';
+import { Spinner, TextTitle } from '/@/renderer/components';
 import { ErrorFallback } from '/@/renderer/features/action-required';
 import {
     UnsynchronizedLyrics,
@@ -214,17 +214,10 @@ export const Lyrics = () => {
                     </AnimatePresence>
                 )}
                 <ActionsContainer>
-                    {languages.length > 1 && (
-                        <Select
-                            clearable={false}
-                            data={languages}
-                            style={{ bottom: 50, position: 'absolute' }}
-                            value={index.toString()}
-                            onChange={(value) => setIndex(parseInt(value!, 10))}
-                        />
-                    )}
-
                     <LyricsActions
+                        index={index}
+                        languages={languages}
+                        setIndex={setIndex}
                         onRemoveLyric={handleOnRemoveLyric}
                         onResetLyric={handleOnResetLyric}
                         onSearchOverride={handleOnSearchOverride}

--- a/src/renderer/features/lyrics/queries/lyric-query.ts
+++ b/src/renderer/features/lyrics/queries/lyric-query.ts
@@ -6,6 +6,7 @@ import {
     InternetProviderLyricResponse,
     FullLyricsMetadata,
     LyricGetQuery,
+    SubsonicExtensions,
 } from '/@/renderer/api/types';
 import { QueryHookArgs } from '/@/renderer/lib/react-query';
 import { getServerById, useLyricsSettings } from '/@/renderer/store';
@@ -93,16 +94,6 @@ export const useSongLyricsBySong = (
             if (!server) throw new Error('Server not found');
             if (!song) return null;
 
-            if (song.lyrics) {
-                return {
-                    artist: song.artists?.[0]?.name,
-                    lyrics: formatLyrics(song.lyrics),
-                    name: song.name,
-                    remote: false,
-                    source: server?.name ?? 'music server',
-                };
-            }
-
             if (server.type === ServerType.JELLYFIN) {
                 const jfLyrics = await api.controller
                     .getLyrics({
@@ -120,6 +111,16 @@ export const useSongLyricsBySong = (
                         source: server?.name ?? 'music server',
                     };
                 }
+            } else if (server.features && SubsonicExtensions.SONG_LYRICS in server.features) {
+                console.log(1234);
+            } else if (song.lyrics) {
+                return {
+                    artist: song.artists?.[0]?.name,
+                    lyrics: formatLyrics(song.lyrics),
+                    name: song.name,
+                    remote: false,
+                    source: server?.name ?? 'music server',
+                };
             }
 
             if (fetch) {

--- a/src/renderer/features/lyrics/queries/lyric-query.ts
+++ b/src/renderer/features/lyrics/queries/lyric-query.ts
@@ -7,6 +7,7 @@ import {
     FullLyricsMetadata,
     LyricGetQuery,
     SubsonicExtensions,
+    StructuredLyric,
 } from '/@/renderer/api/types';
 import { QueryHookArgs } from '/@/renderer/lib/react-query';
 import { getServerById, useLyricsSettings } from '/@/renderer/store';
@@ -81,7 +82,7 @@ export const useServerLyrics = (
 export const useSongLyricsBySong = (
     args: QueryHookArgs<LyricsQuery>,
     song: QueueSong | undefined,
-): UseQueryResult<FullLyricsMetadata> => {
+): UseQueryResult<FullLyricsMetadata | StructuredLyric[]> => {
     const { query } = args;
     const { fetch } = useLyricsSettings();
     const server = getServerById(song?.serverId);
@@ -90,7 +91,7 @@ export const useSongLyricsBySong = (
         cacheTime: Infinity,
         enabled: !!song && !!server,
         onError: () => {},
-        queryFn: async ({ signal }) => {
+        queryFn: async ({ signal }): Promise<FullLyricsMetadata | StructuredLyric[] | null> => {
             if (!server) throw new Error('Server not found');
             if (!song) return null;
 
@@ -112,7 +113,16 @@ export const useSongLyricsBySong = (
                     };
                 }
             } else if (server.features && SubsonicExtensions.SONG_LYRICS in server.features) {
-                console.log(1234);
+                const subsonicLyrics = await api.controller
+                    .getStructuredLyrics({
+                        apiClientProps: { server, signal },
+                        query: { songId: song.id },
+                    })
+                    .catch(console.error);
+
+                if (subsonicLyrics) {
+                    return subsonicLyrics;
+                }
             } else if (song.lyrics) {
                 return {
                     artist: song.artists?.[0]?.name,

--- a/src/renderer/features/lyrics/synchronized-lyrics.tsx
+++ b/src/renderer/features/lyrics/synchronized-lyrics.tsx
@@ -46,7 +46,7 @@ const SynchronizedLyricsContainer = styled.div<{ $gap: number }>`
     }
 `;
 
-interface SynchronizedLyricsProps extends Omit<FullLyricsMetadata, 'lyrics'> {
+export interface SynchronizedLyricsProps extends Omit<FullLyricsMetadata, 'lyrics'> {
     lyrics: SynchronizedLyricsArray;
 }
 

--- a/src/renderer/features/lyrics/unsynchronized-lyrics.tsx
+++ b/src/renderer/features/lyrics/unsynchronized-lyrics.tsx
@@ -4,7 +4,7 @@ import { LyricLine } from '/@/renderer/features/lyrics/lyric-line';
 import { FullLyricsMetadata } from '/@/renderer/api/types';
 import { useLyricsSettings } from '/@/renderer/store';
 
-interface UnsynchronizedLyricsProps extends Omit<FullLyricsMetadata, 'lyrics'> {
+export interface UnsynchronizedLyricsProps extends Omit<FullLyricsMetadata, 'lyrics'> {
     lyrics: string;
 }
 

--- a/src/renderer/features/servers/components/edit-server-form.tsx
+++ b/src/renderer/features/servers/components/edit-server-form.tsx
@@ -12,6 +12,8 @@ import { useAuthStoreActions } from '/@/renderer/store';
 import { ServerListItem, ServerType } from '/@/renderer/types';
 import { api } from '/@/renderer/api';
 import i18n from '/@/i18n/i18n';
+import { queryClient } from '/@/renderer/lib/react-query';
+import { queryKeys } from '/@/renderer/api/query-keys';
 
 const localSettings = isElectron() ? window.electron.localSettings : null;
 
@@ -111,6 +113,8 @@ export const EditServerForm = ({ isUpdate, password, server, onCancel }: EditSer
                     localSettings.passwordRemove(server.id);
                 }
             }
+
+            queryClient.invalidateQueries({ queryKey: queryKeys.server.root(server.id) });
         } catch (err: any) {
             setIsLoading(false);
             return toast.error({ message: err?.message });

--- a/src/renderer/hooks/use-server-version.ts
+++ b/src/renderer/hooks/use-server-version.ts
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+import { useAuthStoreActions, useCurrentServer } from '/@/renderer/store';
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '/@/renderer/api/query-keys';
+import { controller } from '/@/renderer/api/controller';
+
+export const useServerVersion = () => {
+    const { updateServer } = useAuthStoreActions();
+    const server = useCurrentServer();
+
+    const serverInfo = useQuery({
+        enabled: !!server,
+        queryFn: async ({ signal }) => {
+            return controller.getServerInfo({
+                apiClientProps: {
+                    server,
+                    signal,
+                },
+            });
+        },
+        queryKey: queryKeys.server.root(server?.id),
+    });
+
+    useEffect(() => {
+        if (server && server.id === serverInfo.data?.id) {
+            const { version, features } = serverInfo.data;
+            if (version !== server.version) {
+                updateServer(server.id, {
+                    features,
+                    version,
+                });
+            }
+        }
+    }, [server, serverInfo.data, updateServer]);
+};

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -62,6 +62,7 @@ export enum ServerType {
 
 export type ServerListItem = {
     credential: string;
+    features?: Record<string, number[]>;
     id: string;
     name: string;
     ndCredential?: string;
@@ -70,6 +71,7 @@ export type ServerListItem = {
     url: string;
     userId: string | null;
     username: string;
+    version?: string;
 };
 
 export enum PlayerStatus {


### PR DESCRIPTION
This PR provides support for OpenSubsonic structured lyrics (Navidrome >= 0.51.0), and also stores server version/features.

Changes:
- `useServerVersion()`: fetches server version on open, and when changed. This is essential for OS clients to know what features are supported
- `useSongLyricsBySong()`: now supports fetching from OS to retrieve all structured lyrics. If multiple lyrics are shown, a select is available

Notes:
- `offset` is currently not used (of note, it has the opposite meaning to what Feishin does)
- could probably have a better interface for language selection?
- Older versions of Navidrome should still be supported