### PR TITLE
[bugfix/enhancement] Order artist's Top Songs by play count

### DIFF
--- a/src/renderer/api/jellyfin/jellyfin-controller.ts
+++ b/src/renderer/api/jellyfin/jellyfin-controller.ts
@@ -374,7 +374,7 @@ const getTopSongList = async (args: TopSongListArgs): Promise<SongListResponse> 
             IncludeItemTypes: 'Audio',
             Limit: query.limit,
             Recursive: true,
-            SortBy: 'CommunityRating,SortName',
+            SortBy: 'PlayCount,SortName',
             SortOrder: 'Descending',
             UserId: apiClientProps.server?.userId,
         },


### PR DESCRIPTION
This tiny, tiny PR changes the way the Top Songs on the Jellyfin artist page are sorted (and thereby chosen) from `CommunityRating` to `PlayCount`, and thereby fixes #410 .

Please let me know if there is anything I have missed regarding contributing to Feishin.
Thanks for maintaining this awesome software!