### PR TITLE
[bugfix] Fix global hotkeys not working on startup

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -635,7 +635,7 @@ ipcMain.on(
 
         const globalMediaKeysEnabled = store.get('global_media_hotkeys') as boolean;
 
-        if (globalMediaKeysEnabled) {
+        if (globalMediaKeysEnabled !== false) {
             enableMediaKeys(mainWindow);
         }
     },

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -317,9 +317,9 @@ const createWindow = async () => {
         }
     });
 
-    const globalMediaKeysEnabled = store.get('global_media_hotkeys') as boolean;
+    const globalMediaKeysEnabled = store.get('global_media_hotkeys', true) as boolean;
 
-    if (globalMediaKeysEnabled !== false) {
+    if (globalMediaKeysEnabled) {
         enableMediaKeys(mainWindow);
     }
 
@@ -633,9 +633,9 @@ ipcMain.on(
             }
         }
 
-        const globalMediaKeysEnabled = store.get('global_media_hotkeys') as boolean;
+        const globalMediaKeysEnabled = store.get('global_media_hotkeys', true) as boolean;
 
-        if (globalMediaKeysEnabled !== false) {
+        if (globalMediaKeysEnabled) {
             enableMediaKeys(mainWindow);
         }
     },


### PR DESCRIPTION
Fixes #318, #404, and #477 which was caused just by a broken comparison. Not sure why the value is `undefined` when it's set to `true`, but    at least now the statements are consistent and global hotkeys work on startup.

(tested and working, if it doesn't work then maybe theres a deeper issue, not sure)