### PR TITLE
[bugfix] Fixes route of most played songs on home page

### DIFF
--- a/src/renderer/features/home/routes/home-route.tsx
+++ b/src/renderer/features/home/routes/home-route.tsx
@@ -251,7 +251,16 @@ const HomeRoute = () => {
                                         property: 'name',
                                         route: {
                                             route: AppRoute.LIBRARY_ALBUMS_DETAIL,
-                                            slugs: [{ idProperty: 'id', slugProperty: 'albumId' }],
+                                            slugs: [
+                                                {
+                                                    idProperty:
+                                                        server?.type === ServerType.JELLYFIN &&
+                                                        carousel.itemType === LibraryItem.SONG
+                                                            ? 'albumId'
+                                                            : 'id',
+                                                    slugProperty: 'albumId',
+                                                },
+                                            ],
                                         },
                                     },
                                     {
@@ -272,7 +281,16 @@ const HomeRoute = () => {
                                 itemType={carousel.itemType}
                                 route={{
                                     route: AppRoute.LIBRARY_ALBUMS_DETAIL,
-                                    slugs: [{ idProperty: 'id', slugProperty: 'albumId' }],
+                                    slugs: [
+                                        {
+                                            idProperty:
+                                                server?.type === ServerType.JELLYFIN &&
+                                                carousel.itemType === LibraryItem.SONG
+                                                    ? 'albumId'
+                                                    : 'id',
+                                            slugProperty: 'albumId',
+                                        },
+                                    ],
                                 }}
                                 title={{
                                     label: (


### PR DESCRIPTION
This PR fixes #434 .

Now when Jellyfin users click on a song on the home page (note: the only songs currently listed on the home page are the most played songs), they are simply routed to a correct album page of that track.
Navidrome users are unaffected.