### PR TITLE
[bugfix]: default go libsecret, support changing secret store

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ docker run --name feishin -p 9180:9180 feishin
 2. After restarting the app, you will be prompted to select a server. Click the `Open menu` button and select `Manage servers`. Click the `Add server` button in the popup and fill out all applicable details. You will need to enter the full URL to your server, including the protocol and port if applicable (e.g. `https://navidrome.my-server.com` or `http://192.168.0.1:4533`).
 
 -   **Navidrome** - For the best experience, select "Save password" when creating the server and configure the `SessionTimeout` setting in your Navidrome config to a larger value (e.g. 72h).
+    -   **Linux users** - The default password store uses `libsecret`. `kwallet4/5/6` are also supported, but must be explicitly set in Settings > Window > Passwords/secret score.
 
 3. _Optional_ - If you want to host Feishin on a subpath (not `/`), then pass in the following environment variable: `PUBLIC_PATH=PATH`. For example, to host on `/feishin`, pass in `PUBLIC_PATH=/feishin`.
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -509,6 +509,8 @@
         "mpvExecutablePath_description": "sets the path to the mpv executable",
         "mpvExecutablePath_help": "one per line",
         "mpvExtraParameters": "mpv parameters",
+        "passwordStore": "passwords/secret store",
+        "passwordStore_description": "what password/secret store to use. change this if you are having issues storing passwords.",
         "playbackStyle": "playback style",
         "playbackStyle_description": "select the playback style to use for the audio player",
         "playbackStyle_optionCrossFade": "crossfade",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -57,6 +57,12 @@ if (store.get('ignore_ssl')) {
     app.commandLine.appendSwitch('ignore-certificate-errors');
 }
 
+// From https://github.com/tutao/tutanota/commit/92c6ed27625fcf367f0fbcc755d83d7ff8fde94b
+if (isLinux() && !process.argv.some((a) => a.startsWith('--password-store='))) {
+    const paswordStore = store.get('password_store', 'gnome-libsecret') as string;
+    app.commandLine.appendSwitch('password-store', paswordStore);
+}
+
 let mainWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
 let exitFromTray = false;

--- a/src/renderer/features/settings/components/general/application-settings.tsx
+++ b/src/renderer/features/settings/components/general/application-settings.tsx
@@ -94,7 +94,7 @@ export const ApplicationSettings = () => {
             localSettings.fontError(onFontError);
 
             return () => {
-                ipc!.removeAllListeners('custom-font-error');
+                ipc?.removeAllListeners('custom-font-error');
             };
         }
 

--- a/src/renderer/features/settings/components/window/password-settings.tsx
+++ b/src/renderer/features/settings/components/window/password-settings.tsx
@@ -11,10 +11,10 @@ import { Select } from '/@/renderer/components';
 const localSettings = isElectron() ? window.electron.localSettings : null;
 
 const PASSWORD_SETTINGS: SelectItem[] = [
-    { label: 'Gnome (libsecret)', value: 'gnome_libsecret' },
-    { label: 'KDE 4', value: 'kwallet' },
-    { label: 'KDE 5', value: 'kwallet5' },
-    { label: 'KDE 6', value: 'kwallet6' },
+    { label: 'libsecret', value: 'gnome_libsecret' },
+    { label: 'KDE 4 (kwallet4)', value: 'kwallet' },
+    { label: 'KDE 5 (kwallet5)', value: 'kwallet5' },
+    { label: 'KDE 6 (kwallet6)', value: 'kwallet6' },
 ];
 
 export const PasswordSettings = () => {

--- a/src/renderer/features/settings/components/window/password-settings.tsx
+++ b/src/renderer/features/settings/components/window/password-settings.tsx
@@ -1,0 +1,56 @@
+import { SelectItem } from '@mantine/core';
+import isElectron from 'is-electron';
+import { useTranslation } from 'react-i18next';
+import { useSettingsStoreActions, useGeneralSettings } from '../../../../store/settings.store';
+import {
+    SettingsSection,
+    SettingOption,
+} from '/@/renderer/features/settings/components/settings-section';
+import { Select } from '/@/renderer/components';
+
+const localSettings = isElectron() ? window.electron.localSettings : null;
+
+const PASSWORD_SETTINGS: SelectItem[] = [
+    { label: 'Gnome (libsecret)', value: 'gnome_libsecret' },
+    { label: 'KDE 4', value: 'kwallet' },
+    { label: 'KDE 5', value: 'kwallet5' },
+    { label: 'KDE 6', value: 'kwallet6' },
+];
+
+export const PasswordSettings = () => {
+    const { t } = useTranslation();
+    const settings = useGeneralSettings();
+    const { setSettings } = useSettingsStoreActions();
+
+    const updateOptions: SettingOption[] = [
+        {
+            control: (
+                <Select
+                    aria-label={t('setting.passwordStore')}
+                    clearable={false}
+                    data={PASSWORD_SETTINGS}
+                    defaultValue={settings.passwordStore ?? 'gnome_libsecret'}
+                    disabled={!isElectron()}
+                    onChange={(e) => {
+                        if (!e) return;
+                        localSettings?.set('password_store', e);
+                        setSettings({
+                            general: {
+                                ...settings,
+                                passwordStore: e,
+                            },
+                        });
+                    }}
+                />
+            ),
+            description: t('setting.passwordStore', {
+                context: 'description',
+                postProcess: 'sentenceCase',
+            }),
+            isHidden: !isElectron(),
+            title: t('setting.passwordStore', { postProcess: 'sentenceCase' }),
+        },
+    ];
+
+    return <SettingsSection options={updateOptions} />;
+};

--- a/src/renderer/features/settings/components/window/window-tab.tsx
+++ b/src/renderer/features/settings/components/window/window-tab.tsx
@@ -2,6 +2,10 @@ import { Divider, Stack } from '@mantine/core';
 import { UpdateSettings } from '/@/renderer/features/settings/components/window/update-settings';
 import { WindowSettings } from '/@/renderer/features/settings/components/window/window-settings';
 import { DiscordSettings } from '/@/renderer/features/settings/components/window/discord-settings';
+import isElectron from 'is-electron';
+import { PasswordSettings } from '/@/renderer/features/settings/components/window/password-settings';
+
+const utils = isElectron() ? window.electron.utils : null;
 
 export const WindowTab = () => {
     return (
@@ -11,6 +15,12 @@ export const WindowTab = () => {
             <DiscordSettings />
             <Divider />
             <UpdateSettings />
+            {utils?.isLinux() && (
+                <>
+                    <Divider />
+                    <PasswordSettings />
+                </>
+            )}
         </Stack>
     );
 };

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -174,6 +174,7 @@ export interface SettingsState {
         externalLinks: boolean;
         followSystemTheme: boolean;
         language: string;
+        passwordStore?: string;
         playButtonBehavior: Play;
         resume: boolean;
         showQueueDrawerButton: boolean;
@@ -288,6 +289,7 @@ const initialState: SettingsState = {
         externalLinks: true,
         followSystemTheme: false,
         language: 'en',
+        passwordStore: undefined,
         playButtonBehavior: Play.NOW,
         resume: false,
         showQueueDrawerButton: false,
@@ -600,7 +602,7 @@ export const useSettingsStore = create<SettingsSlice>()(
                 return merge(currentState, persistedState);
             },
             name: 'store_settings',
-            version: 7,
+            version: 8,
         },
     ),
 );


### PR DESCRIPTION
For some Linux systems, Electron safe storage is unable to detect the Gnome backend. Default to gnome-libsecret, and allow for changing the secret as needed. Resolves #393

Thanks https://github.com/tutao/tutanota/commit/92c6ed27625fcf367f0fbcc755d83d7ff8fde94b for inspiration!