### PR TITLE
[enhancement] Allow hiding disc labels on albums with only one disc

### DIFF
--- a/src/renderer/components/virtual-table/table-config-dropdown.tsx
+++ b/src/renderer/components/virtual-table/table-config-dropdown.tsx
@@ -367,6 +367,18 @@ export const TableConfigDropdown = ({ type }: TableConfigDropdownProps) => {
         });
     };
 
+    const handleUpdateDiscLabel = (e: ChangeEvent<HTMLInputElement>) => {
+        setSettings({
+            tables: {
+                ...useSettingsStore.getState().tables,
+                [type]: {
+                    ...useSettingsStore.getState().tables[type],
+                    hide1DiscLabel: e.currentTarget.checked,
+                },
+            },
+        });
+    };
+
     return (
         <>
             <Option>
@@ -378,6 +390,17 @@ export const TableConfigDropdown = ({ type }: TableConfigDropdownProps) => {
                     />
                 </Option.Control>
             </Option>
+            {type === 'albumDetail' && (
+                <Option>
+                    <Option.Label>Hide disc label for 1-disc albums</Option.Label>
+                    <Option.Control>
+                        <Switch
+                            defaultChecked={tableConfig[type]?.hide1DiscLabel}
+                            onChange={handleUpdateDiscLabel}
+                        />
+                    </Option.Control>
+                </Option>
+            )}
             {type !== 'albumDetail' && (
                 <Option>
                     <Option.Label>Follow current song</Option.Label>

--- a/src/renderer/features/albums/components/album-detail-content.tsx
+++ b/src/renderer/features/albums/components/album-detail-content.tsx
@@ -81,6 +81,7 @@ export const AlbumDetailContent = ({ tableRef, background }: AlbumDetailContentP
     const isFocused = useAppFocus();
     const currentSong = useCurrentSong();
     const { externalLinks } = useGeneralSettings();
+    const { hide1DiscLabel } = useTableSettings('albumDetail');
 
     const columnDefs = useMemo(
         () => getColumnDefs(tableConfig.columns, false, 'albumDetail'),
@@ -116,15 +117,17 @@ export const AlbumDetailContent = ({ tableRef, background }: AlbumDetailContentP
                 .filter(Boolean)
                 .join(': ');
 
-            rowData.push({
-                id: `disc-${discNumber}`,
-                name: discName,
-            });
+            if (!(uniqueDiscNumbers.size === 1 && hide1DiscLabel)) {
+                rowData.push({
+                    id: `disc-${discNumber}`,
+                    name: discName,
+                });
+            }
             rowData.push(...songsByDiscNumber);
         }
 
         return rowData;
-    }, [detailQuery.data?.songs]);
+    }, [detailQuery.data?.songs, hide1DiscLabel]);
 
     const [pagination, setPagination] = useSetState({
         artist: 0,

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -119,6 +119,7 @@ export type DataTableProps = {
     autoFit: boolean;
     columns: PersistedTableColumn[];
     followCurrentSong?: boolean;
+    hide1DiscLabel?: boolean;
     rowHeight: number;
 };
 
@@ -446,6 +447,7 @@ const initialState: SettingsState = {
                     width: 100,
                 },
             ],
+            hide1DiscLabel: true,
             rowHeight: 60,
         },
         fullScreen: {


### PR DESCRIPTION
This was a pretty quick PR based off of thatzkid's question in the discord server. As said in the title, it adds an option to the table setting component allowing you to turn off disc labels if the album you're viewing only has one disc in it.

In my opinion, this declutters the album view a bit. The feature is very useful for multi-disc albums, don't get me wrong; but I do prefer having them not be listed unless there's multiple.

As with the rest of my PRs, I'm not a TS dev. If I made some weird decision somewhere, let me know.