### PR TITLE
[bugfix]: Macos trusted accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ Rewrite of [Sonixd](https://github.com/jeffvli/sonixd).
 
 Download the [latest desktop client](https://github.com/jeffvli/feishin/releases). The desktop client is the recommended way to use Feishin. It supports both the MPV and web player backends, as well as includes built-in fetching for lyrics.
 
+#### MacOS Notes
+
 If you're using a device running macOS 12 (Monterey) or higher, [check here](https://github.com/jeffvli/feishin/issues/104#issuecomment-1553914730) for instructions on how to remove the app from quarantine.
+
+For media keys to work, you will be prompted to allow Feishin to be a Trusted Accessibility Client. After allowing, you will need to restart Feishin for the privacy settings to take effect.
 
 ### Web and Docker
 


### PR DESCRIPTION
Resolves #476. For MacOS, to capture media keys the application has to be a trusted accessibility client.