### PR TITLE
[feat] Add a dynamic image option to the fullscreen player

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -311,6 +311,7 @@
         "fullscreenPlayer": {
             "config": {
                 "dynamicBackground": "dynamic background",
+                "dynamicImageBlur": "image blur size",
                 "dynamicIsImage": "enable background image",
                 "followCurrentLyric": "follow current lyric",
                 "lyricAlignment": "lyric alignment",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -311,6 +311,7 @@
         "fullscreenPlayer": {
             "config": {
                 "dynamicBackground": "dynamic background",
+                "dynamicIsImage": "enable background image",
                 "followCurrentLyric": "follow current lyric",
                 "lyricAlignment": "lyric alignment",
                 "lyricGap": "lyric gap",

--- a/src/renderer/features/player/components/full-screen-player.tsx
+++ b/src/renderer/features/player/components/full-screen-player.tsx
@@ -173,7 +173,7 @@ const Controls = () => {
                             </Option.Control>
                         </Option>
                     )}
-                    {dynamicIsImage && (
+                    {dynamicBackground && dynamicIsImage && (
                         <Option>
                             <Option.Label>
                                 {t('page.fullscreenPlayer.config.dynamicImageBlur', {

--- a/src/renderer/features/player/components/full-screen-player.tsx
+++ b/src/renderer/features/player/components/full-screen-player.tsx
@@ -71,6 +71,8 @@ const BackgroundImageOverlay = styled.div`
     backdrop-filter: blur(1.5rem);
 `;
 
+const mainBackground = 'var(--main-bg)';
+
 const Controls = () => {
     const { t } = useTranslation();
     const { dynamicBackground, dynamicIsImage, expanded, opacity, useImageAspectRatio } =
@@ -388,9 +390,15 @@ const containerVariants: Variants = {
         };
     },
     open: (custom) => {
-        const { dynamicBackground, parsedBackground, windowBarStyle } = custom;
+        const { background, backgroundImage, dynamicBackground, windowBarStyle } = custom;
         return {
-            background: dynamicBackground ? parsedBackground : 'var(--main-bg)',
+            // If dynamic background is enabled:
+            //   Use the background image (if enabled, else use the default background color)
+            // Else:
+            //   Use the default background color
+            background: dynamicBackground ? backgroundImage || mainBackground : mainBackground,
+            backgroundColor: dynamicBackground ? background : mainBackground,
+            backgroundPosition: 'center',
             backgroundSize: 'cover',
             height:
                 windowBarStyle === Platform.WINDOWS || windowBarStyle === Platform.MACOS
@@ -438,17 +446,17 @@ export const FullScreenPlayer = () => {
     });
 
     const imageUrl = currentSong?.imageUrl;
-    const parsedBackground =
+    const backgroundImage =
         imageUrl && dynamicIsImage
             ? `url("${imageUrl
                   .replace(/size=\d+/g, 'size=500')
                   .replace(currentSong.id, currentSong.albumId)}") no-repeat fixed`
-            : background;
+            : null;
 
     return (
         <Container
             animate="open"
-            custom={{ dynamicBackground, parsedBackground, windowBarStyle }}
+            custom={{ background, backgroundImage, dynamicBackground, windowBarStyle }}
             exit="closed"
             initial="closed"
             transition={{ duration: 2 }}

--- a/src/renderer/features/player/components/full-screen-player.tsx
+++ b/src/renderer/features/player/components/full-screen-player.tsx
@@ -60,7 +60,11 @@ const ResponsiveContainer = styled.div`
     }
 `;
 
-const BackgroundImageOverlay = styled.div`
+interface BackgroundImageOverlayProps {
+    $blur: number;
+}
+
+const BackgroundImageOverlay = styled.div<BackgroundImageOverlayProps>`
     position: absolute;
     top: 0;
     left: 0;
@@ -68,15 +72,21 @@ const BackgroundImageOverlay = styled.div`
     width: 100%;
     height: 100%;
     background: var(--bg-header-overlay);
-    backdrop-filter: blur(1.5rem);
+    backdrop-filter: blur(${({ $blur }) => $blur}rem);
 `;
 
 const mainBackground = 'var(--main-bg)';
 
 const Controls = () => {
     const { t } = useTranslation();
-    const { dynamicBackground, dynamicIsImage, expanded, opacity, useImageAspectRatio } =
-        useFullScreenPlayerStore();
+    const {
+        dynamicBackground,
+        dynamicImageBlur,
+        dynamicIsImage,
+        expanded,
+        opacity,
+        useImageAspectRatio,
+    } = useFullScreenPlayerStore();
     const { setStore } = useFullScreenPlayerStoreActions();
     const { setSettings } = useSettingsStoreActions();
     const lyricConfig = useLyricsSettings();
@@ -159,6 +169,26 @@ const Controls = () => {
                                             dynamicIsImage: e.target.checked,
                                         })
                                     }
+                                />
+                            </Option.Control>
+                        </Option>
+                    )}
+                    {dynamicIsImage && (
+                        <Option>
+                            <Option.Label>
+                                {t('page.fullscreenPlayer.config.dynamicImageBlur', {
+                                    postProcess: 'sentenceCase',
+                                })}
+                            </Option.Label>
+                            <Option.Control>
+                                <Slider
+                                    defaultValue={dynamicImageBlur}
+                                    label={(e) => `${e} rem`}
+                                    max={6}
+                                    min={0}
+                                    step={0.5}
+                                    w="100%"
+                                    onChangeEnd={(e) => setStore({ dynamicImageBlur: Number(e) })}
                                 />
                             </Option.Control>
                         </Option>
@@ -419,7 +449,7 @@ const containerVariants: Variants = {
 };
 
 export const FullScreenPlayer = () => {
-    const { dynamicBackground, dynamicIsImage } = useFullScreenPlayerStore();
+    const { dynamicBackground, dynamicImageBlur, dynamicIsImage } = useFullScreenPlayerStore();
     const { setStore } = useFullScreenPlayerStoreActions();
     const { windowBarStyle } = useWindowSettings();
 
@@ -459,7 +489,7 @@ export const FullScreenPlayer = () => {
             variants={containerVariants}
         >
             <Controls />
-            {dynamicBackground && <BackgroundImageOverlay />}
+            {dynamicBackground && <BackgroundImageOverlay $blur={dynamicImageBlur} />}
             <ResponsiveContainer>
                 <FullScreenPlayerImage />
                 <FullScreenPlayerQueue />

--- a/src/renderer/features/player/components/full-screen-player.tsx
+++ b/src/renderer/features/player/components/full-screen-player.tsx
@@ -68,11 +68,12 @@ const BackgroundImageOverlay = styled.div`
     width: 100%;
     height: 100%;
     background: var(--bg-header-overlay);
+    backdrop-filter: blur(1.5rem);
 `;
 
 const Controls = () => {
     const { t } = useTranslation();
-    const { dynamicBackground, expanded, opacity, useImageAspectRatio } =
+    const { dynamicBackground, dynamicIsImage, expanded, opacity, useImageAspectRatio } =
         useFullScreenPlayerStore();
     const { setStore } = useFullScreenPlayerStoreActions();
     const { setSettings } = useSettingsStoreActions();
@@ -141,6 +142,25 @@ const Controls = () => {
                             />
                         </Option.Control>
                     </Option>
+                    {dynamicBackground && (
+                        <Option>
+                            <Option.Label>
+                                {t('page.fullscreenPlayer.config.dynamicIsImage', {
+                                    postProcess: 'sentenceCase',
+                                })}
+                            </Option.Label>
+                            <Option.Control>
+                                <Switch
+                                    defaultChecked={dynamicIsImage}
+                                    onChange={(e) =>
+                                        setStore({
+                                            dynamicIsImage: e.target.checked,
+                                        })
+                                    }
+                                />
+                            </Option.Control>
+                        </Option>
+                    )}
                     {dynamicBackground && (
                         <Option>
                             <Option.Label>
@@ -368,9 +388,10 @@ const containerVariants: Variants = {
         };
     },
     open: (custom) => {
-        const { dynamicBackground, background, windowBarStyle } = custom;
+        const { dynamicBackground, parsedBackground, windowBarStyle } = custom;
         return {
-            background: dynamicBackground ? background : 'var(--main-bg)',
+            background: dynamicBackground ? parsedBackground : 'var(--main-bg)',
+            backgroundSize: 'cover',
             height:
                 windowBarStyle === Platform.WINDOWS || windowBarStyle === Platform.MACOS
                     ? 'calc(100vh - 120px)'
@@ -394,7 +415,7 @@ const containerVariants: Variants = {
 };
 
 export const FullScreenPlayer = () => {
-    const { dynamicBackground } = useFullScreenPlayerStore();
+    const { dynamicBackground, dynamicIsImage } = useFullScreenPlayerStore();
     const { setStore } = useFullScreenPlayerStoreActions();
     const { windowBarStyle } = useWindowSettings();
 
@@ -416,10 +437,18 @@ export const FullScreenPlayer = () => {
         srcLoaded: true,
     });
 
+    const imageUrl = currentSong?.imageUrl;
+    const parsedBackground =
+        imageUrl && dynamicIsImage
+            ? `url("${imageUrl
+                  .replace(/size=\d+/g, 'size=500')
+                  .replace(currentSong.id, currentSong.albumId)}") no-repeat fixed`
+            : background;
+
     return (
         <Container
             animate="open"
-            custom={{ background, dynamicBackground, windowBarStyle }}
+            custom={{ dynamicBackground, parsedBackground, windowBarStyle }}
             exit="closed"
             initial="closed"
             transition={{ duration: 2 }}

--- a/src/renderer/features/player/components/full-screen-player.tsx
+++ b/src/renderer/features/player/components/full-screen-player.tsx
@@ -425,6 +425,7 @@ const containerVariants: Variants = {
             background: dynamicBackground ? backgroundImage : mainBackground,
             backgroundColor: dynamicBackground ? background : mainBackground,
             backgroundPosition: 'center',
+            backgroundRepeat: 'no-repeat',
             backgroundSize: 'cover',
             height:
                 windowBarStyle === Platform.WINDOWS || windowBarStyle === Platform.MACOS
@@ -474,9 +475,7 @@ export const FullScreenPlayer = () => {
     const imageUrl = currentSong?.imageUrl;
     const backgroundImage =
         imageUrl && dynamicIsImage
-            ? `url("${imageUrl
-                  .replace(/size=\d+/g, 'size=500')
-                  .replace(currentSong.id, currentSong.albumId)}") no-repeat fixed`
+            ? `url("${imageUrl.replace(/size=\d+/g, 'size=500')}`
             : mainBackground;
 
     return (

--- a/src/renderer/features/player/components/full-screen-player.tsx
+++ b/src/renderer/features/player/components/full-screen-player.tsx
@@ -392,11 +392,7 @@ const containerVariants: Variants = {
     open: (custom) => {
         const { background, backgroundImage, dynamicBackground, windowBarStyle } = custom;
         return {
-            // If dynamic background is enabled:
-            //   Use the background image (if enabled, else use the default background color)
-            // Else:
-            //   Use the default background color
-            background: dynamicBackground ? backgroundImage || mainBackground : mainBackground,
+            background: dynamicBackground ? backgroundImage : mainBackground,
             backgroundColor: dynamicBackground ? background : mainBackground,
             backgroundPosition: 'center',
             backgroundSize: 'cover',
@@ -451,7 +447,7 @@ export const FullScreenPlayer = () => {
             ? `url("${imageUrl
                   .replace(/size=\d+/g, 'size=500')
                   .replace(currentSong.id, currentSong.albumId)}") no-repeat fixed`
-            : null;
+            : mainBackground;
 
     return (
         <Container

--- a/src/renderer/store/full-screen-player.store.ts
+++ b/src/renderer/store/full-screen-player.store.ts
@@ -6,6 +6,7 @@ import { immer } from 'zustand/middleware/immer';
 interface FullScreenPlayerState {
     activeTab: string | 'queue' | 'related' | 'lyrics';
     dynamicBackground?: boolean;
+    dynamicIsImage?: boolean;
     expanded: boolean;
     opacity: number;
     useImageAspectRatio: boolean;
@@ -28,6 +29,7 @@ export const useFullScreenPlayerStore = create<FullScreenPlayerSlice>()(
                 },
                 activeTab: 'queue',
                 dynamicBackground: true,
+                dynamicIsImage: false,
                 expanded: false,
                 opacity: 60,
                 useImageAspectRatio: false,

--- a/src/renderer/store/full-screen-player.store.ts
+++ b/src/renderer/store/full-screen-player.store.ts
@@ -6,6 +6,7 @@ import { immer } from 'zustand/middleware/immer';
 interface FullScreenPlayerState {
     activeTab: string | 'queue' | 'related' | 'lyrics';
     dynamicBackground?: boolean;
+    dynamicImageBlur: number;
     dynamicIsImage?: boolean;
     expanded: boolean;
     opacity: number;
@@ -29,6 +30,7 @@ export const useFullScreenPlayerStore = create<FullScreenPlayerSlice>()(
                 },
                 activeTab: 'queue',
                 dynamicBackground: true,
+                dynamicImageBlur: 1.5,
                 dynamicIsImage: false,
                 expanded: false,
                 opacity: 60,


### PR DESCRIPTION
Reuses the existing div and assigns the `background` attribute accordingly based on whether or not the feature is enabled; does not interfere with the existing dynamic background (still works as expected). Additionally includes an option to tweak the amount of blur applied to the background (currently in rem, could be pixels if needed).

A couple problems with this PR:
- (unsure of how to fix) With the feature enabled, opening and closing the fullscreen player will mess with the background. For example, if you have the fullscreen player closed and then open it the background will move fine, however once it hits the top of the screen it snaps into place rather jarringly.
- For the background image, it replaces the `id` with `albumId` in order to best utilize electron's built-in caching. The downfall of this is that Navidrome might not always have album art FOR an album id (ex. if you have two songs both with different arts and then don't have a `cover.jpg` specified). To fix this, there *could* be some sort of custom caching to prevent the image from changing every time (as the id changes so the images are forced to reload), but I couldn't come up with a clean method of doing such a thing at the time.
- This hasn't actually been tested on Jellyfin, I figured it would work although now that I think about it replacing the ID might only affect Navidrome.

Ignoring those, the feature is in pretty good shape.  
Couple of screenshots:

![image](https://github.com/jeffvli/feishin/assets/35084023/e518acbf-938a-44d6-ba88-7913d64dcba8)
![image](https://github.com/jeffvli/feishin/assets/35084023/a214776e-2edf-4ea2-af44-032e0763542a)
![image](https://github.com/jeffvli/feishin/assets/35084023/c30ac6fa-9f39-4f63-8b13-342ad298b90f)
