### PR TITLE
[enhancement]: better version checks for lyrics, Navidrome

### DIFF
--- a/src/renderer/api/features.types.ts
+++ b/src/renderer/api/features.types.ts
@@ -1,6 +1,7 @@
 export enum ServerFeature {
+    MULTIPLE_STRUCTURED_LYRICS = 'multipleStructuredLyrics',
+    SINGLE_STRUCTURED_LYRIC = 'singleStructuredLyric',
     SMART_PLAYLISTS = 'smartPlaylists',
-    SONG_LYRICS = 'songLyrics',
 }
 
-export type ServerFeatures = Record<Partial<ServerFeature>, boolean>;
+export type ServerFeatures = Partial<Record<ServerFeature, boolean>>;

--- a/src/renderer/api/jellyfin/jellyfin-controller.ts
+++ b/src/renderer/api/jellyfin/jellyfin-controller.ts
@@ -961,8 +961,7 @@ const getServerInfo = async (args: ServerInfoArgs): Promise<ServerInfo> => {
     }
 
     const features: ServerFeatures = {
-        smartPlaylists: false,
-        songLyrics: true,
+        singleStructuredLyric: true,
     };
 
     return {

--- a/src/renderer/api/subsonic/subsonic-controller.ts
+++ b/src/renderer/api/subsonic/subsonic-controller.ts
@@ -384,10 +384,7 @@ const getServerInfo = async (args: ServerInfoArgs): Promise<ServerInfo> => {
         throw new Error('Failed to ping server');
     }
 
-    const features: ServerFeatures = {
-        smartPlaylists: false,
-        songLyrics: false,
-    };
+    const features: ServerFeatures = {};
 
     if (!ping.body.openSubsonic || !ping.body.serverVersion) {
         return { features, version: ping.body.version };
@@ -400,12 +397,14 @@ const getServerInfo = async (args: ServerInfoArgs): Promise<ServerInfo> => {
     }
 
     const subsonicFeatures: Record<string, number[]> = {};
-    for (const extension of res.body.openSubsonicExtensions) {
-        subsonicFeatures[extension.name] = extension.versions;
+    if (Array.isArray(res.body.openSubsonicExtensions)) {
+        for (const extension of res.body.openSubsonicExtensions) {
+            subsonicFeatures[extension.name] = extension.versions;
+        }
     }
 
     if (subsonicFeatures[SubsonicExtensions.SONG_LYRICS]) {
-        features.songLyrics = true;
+        features.multipleStructuredLyrics = true;
     }
 
     return { features, id: apiClientProps.server?.id, version: ping.body.serverVersion };

--- a/src/renderer/api/subsonic/subsonic-types.ts
+++ b/src/renderer/api/subsonic/subsonic-types.ts
@@ -218,7 +218,7 @@ const extension = z.object({
 });
 
 const serverInfo = z.object({
-    openSubsonicExtensions: z.array(extension),
+    openSubsonicExtensions: z.array(extension).optional(),
 });
 
 const structuredLyricsParameters = z.object({
@@ -265,7 +265,6 @@ export enum SubsonicExtensions {
     SONG_LYRICS = 'songLyrics',
     TRANSCODE_OFFSET = 'transcodeOffset',
 }
-
 
 export const ssType = {
     _parameters: {

--- a/src/renderer/api/utils.ts
+++ b/src/renderer/api/utils.ts
@@ -45,5 +45,5 @@ export const hasFeature = (server: ServerListItem | null, feature: ServerFeature
         return false;
     }
 
-    return server.features[feature];
+    return server.features[feature] ?? false;
 };

--- a/src/renderer/features/lyrics/queries/lyric-query.ts
+++ b/src/renderer/features/lyrics/queries/lyric-query.ts
@@ -96,7 +96,18 @@ export const useSongLyricsBySong = (
             if (!server) throw new Error('Server not found');
             if (!song) return null;
 
-            if (server.type === ServerType.JELLYFIN) {
+            if (hasFeature(server, ServerFeature.MULTIPLE_STRUCTURED_LYRICS)) {
+                const subsonicLyrics = await api.controller
+                    .getStructuredLyrics({
+                        apiClientProps: { server, signal },
+                        query: { songId: song.id },
+                    })
+                    .catch(console.error);
+
+                if (subsonicLyrics) {
+                    return subsonicLyrics;
+                }
+            } else if (hasFeature(server, ServerFeature.SINGLE_STRUCTURED_LYRIC)) {
                 const jfLyrics = await api.controller
                     .getLyrics({
                         apiClientProps: { server, signal },
@@ -112,17 +123,6 @@ export const useSongLyricsBySong = (
                         remote: false,
                         source: server?.name ?? 'music server',
                     };
-                }
-            } else if (hasFeature(server, ServerFeature.SONG_LYRICS)) {
-                const subsonicLyrics = await api.controller
-                    .getStructuredLyrics({
-                        apiClientProps: { server, signal },
-                        query: { songId: song.id },
-                    })
-                    .catch(console.error);
-
-                if (subsonicLyrics) {
-                    return subsonicLyrics;
                 }
             } else if (song.lyrics) {
                 return {


### PR DESCRIPTION
- Actually make serverfeatures partial
- Navidrome: only set multiple structured lyrics if extension exists
- Navidrome/Subsonic: minor type checking of OS extension (Navidrome implementation detail)
- Jellyfin: add separate knob for lyrics. Note, this should also probably be behind some version check (or API endpoint check?)