### PR TITLE
Implement Navidrome sharing

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -256,7 +256,7 @@
             "allowDownloading": "allow downloading",
             "description": "description",
             "setExpiration": "set expiration",
-            "success": "share link copied to clipboard",
+            "success": "share link copied to clipboard (or click here to open)",
             "expireInvalid": "expiration must be in the future",
             "createFailed": "failed to create share (is sharing enabled?)"
         },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -98,6 +98,7 @@
         "setting": "setting",
         "setting_one": "setting",
         "setting_other": "settings",
+        "share": "share",
         "size": "size",
         "sortOrder": "order",
         "title": "title",
@@ -251,6 +252,11 @@
             "input_optionMatchAll": "match all",
             "input_optionMatchAny": "match any"
         },
+        "shareItem": {
+            "allowDownloading": "allow downloading",
+            "description": "description",
+            "success": "share link copied to clipboard"
+        },
         "updateServer": {
             "success": "server updated successfully",
             "title": "update server"
@@ -306,7 +312,8 @@
             "removeFromFavorites": "$t(action.removeFromFavorites)",
             "removeFromPlaylist": "$t(action.removeFromPlaylist)",
             "removeFromQueue": "$t(action.removeFromQueue)",
-            "setRating": "$t(action.setRating)"
+            "setRating": "$t(action.setRating)",
+            "shareItem": "share item"
         },
         "fullscreenPlayer": {
             "config": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -255,7 +255,10 @@
         "shareItem": {
             "allowDownloading": "allow downloading",
             "description": "description",
-            "success": "share link copied to clipboard"
+            "setExpiration": "set expiration",
+            "success": "share link copied to clipboard",
+            "expireInvalid": "expiration must be in the future",
+            "createFailed": "failed to create share (is sharing enabled?)"
         },
         "updateServer": {
             "success": "server updated successfully",

--- a/src/renderer/api/controller.ts
+++ b/src/renderer/api/controller.ts
@@ -8,6 +8,7 @@ import type {
     AlbumArtistDetailArgs,
     AlbumArtistListArgs,
     SetRatingArgs,
+    ShareItemArgs,
     GenreListArgs,
     CreatePlaylistArgs,
     DeletePlaylistArgs,
@@ -55,6 +56,7 @@ import type {
     SimilarSongsArgs,
     Song,
     ServerType,
+    ShareItemResponse,
 } from '/@/renderer/api/types';
 import { DeletePlaylistResponse, RandomSongListArgs } from './types';
 import { ndController } from '/@/renderer/api/navidrome/navidrome-controller';
@@ -102,6 +104,7 @@ export type ControllerEndpoint = Partial<{
     scrobble: (args: ScrobbleArgs) => Promise<ScrobbleResponse>;
     search: (args: SearchArgs) => Promise<SearchResponse>;
     setRating: (args: SetRatingArgs) => Promise<RatingResponse>;
+    shareItem: (args: ShareItemArgs) => Promise<ShareItemResponse>;
     updatePlaylist: (args: UpdatePlaylistArgs) => Promise<UpdatePlaylistResponse>;
 }>;
 
@@ -149,6 +152,7 @@ const endpoints: ApiController = {
         scrobble: jfController.scrobble,
         search: jfController.search,
         setRating: undefined,
+        shareItem: undefined,
         updatePlaylist: jfController.updatePlaylist,
     },
     navidrome: {
@@ -188,6 +192,7 @@ const endpoints: ApiController = {
         scrobble: ssController.scrobble,
         search: ssController.search3,
         setRating: ssController.setRating,
+        shareItem: ndController.shareItem,
         updatePlaylist: ndController.updatePlaylist,
     },
     subsonic: {
@@ -223,6 +228,7 @@ const endpoints: ApiController = {
         scrobble: ssController.scrobble,
         search: ssController.search3,
         setRating: undefined,
+        shareItem: undefined,
         updatePlaylist: undefined,
     },
 };
@@ -457,6 +463,15 @@ const updateRating = async (args: SetRatingArgs) => {
     )?.(args);
 };
 
+const shareItem = async (args: ShareItemArgs) => {
+    return (
+        apiController(
+            'shareItem',
+            args.apiClientProps.server?.type,
+        ) as ControllerEndpoint['shareItem']
+    )?.(args);
+};
+
 const getTopSongList = async (args: TopSongListArgs) => {
     return (
         apiController(
@@ -555,6 +570,7 @@ export const controller = {
     removeFromPlaylist,
     scrobble,
     search,
+    shareItem,
     updatePlaylist,
     updateRating,
 };

--- a/src/renderer/api/features-types.ts
+++ b/src/renderer/api/features-types.ts
@@ -4,6 +4,7 @@ export enum ServerFeature {
     LYRICS_MULTIPLE_STRUCTURED = 'lyricsMultipleStructured',
     LYRICS_SINGLE_STRUCTURED = 'lyricsSingleStructured',
     PLAYLISTS_SMART = 'playlistsSmart',
+    SHARING_ALBUM_SONG = 'sharingAlbumSong',
 }
 
 export type ServerFeatures = Partial<Record<ServerFeature, boolean>>;

--- a/src/renderer/api/navidrome/navidrome-api.ts
+++ b/src/renderer/api/navidrome/navidrome-api.ts
@@ -163,6 +163,7 @@ export const contract = c.router({
         path: 'share',
         responses: {
             200: resultWithHeaders(ndType._response.shareItem),
+            404: resultWithHeaders(ndType._response.error),
             500: resultWithHeaders(ndType._response.error),
         },
     },

--- a/src/renderer/api/navidrome/navidrome-api.ts
+++ b/src/renderer/api/navidrome/navidrome-api.ts
@@ -157,6 +157,15 @@ export const contract = c.router({
             500: resultWithHeaders(ndType._response.error),
         },
     },
+    shareItem: {
+        body: ndType._parameters.shareItem,
+        method: 'POST',
+        path: 'share',
+        responses: {
+            200: resultWithHeaders(ndType._response.shareItem),
+            500: resultWithHeaders(ndType._response.error),
+        },
+    },
     updatePlaylist: {
         body: ndType._parameters.updatePlaylist,
         method: 'PUT',

--- a/src/renderer/api/navidrome/navidrome-controller.ts
+++ b/src/renderer/api/navidrome/navidrome-controller.ts
@@ -484,9 +484,11 @@ const removeFromPlaylist = async (
     return null;
 };
 
+// The order should be in decreasing version, as the highest version match
+// will automatically consider all lower versions matched
 const VERSION_INFO: Array<[string, Record<string, number[]>]> = [
-    ['0.48.0', { [ServerFeature.PLAYLISTS_SMART]: [1] }],
     ['0.49.3', { [ServerFeature.SHARING_ALBUM_SONG]: [1] }],
+    ['0.48.0', { [ServerFeature.PLAYLISTS_SMART]: [1] }],
 ];
 
 const getFeatures = (version: string): Record<string, number[]> => {
@@ -545,7 +547,7 @@ const getServerInfo = async (args: ServerInfoArgs): Promise<ServerInfo> => {
     const features: ServerFeatures = {
         lyricsMultipleStructured: !!navidromeFeatures[SubsonicExtensions.SONG_LYRICS],
         playlistsSmart: !!navidromeFeatures[NavidromeExtensions.SMART_PLAYLISTS],
-        sharingAlbumSong: !!navidromeFeatures[NavidromeExtensions.SHARING],
+        sharingAlbumSong: !!navidromeFeatures[ServerFeature.SHARING_ALBUM_SONG],
     };
 
     return { features, id: apiClientProps.server?.id, version: ping.body.serverVersion! };

--- a/src/renderer/api/navidrome/navidrome-controller.ts
+++ b/src/renderer/api/navidrome/navidrome-controller.ts
@@ -47,6 +47,8 @@ import {
     genreListSortMap,
     ServerInfo,
     ServerInfoArgs,
+    ShareItemArgs,
+    ShareItemResponse,
 } from '../types';
 import { hasFeature } from '/@/renderer/api/utils';
 import { ServerFeature, ServerFeatures } from '/@/renderer/api/features-types';
@@ -547,6 +549,27 @@ const getServerInfo = async (args: ServerInfoArgs): Promise<ServerInfo> => {
     return { features, id: apiClientProps.server?.id, version: ping.body.serverVersion! };
 };
 
+const shareItem = async (args: ShareItemArgs): Promise<ShareItemResponse> => {
+    const { body, apiClientProps } = args;
+
+    const res = await ndApiClient(apiClientProps).shareItem({
+        body: {
+            description: body.description,
+            downloadable: body.downloadable,
+            resourceIds: body.resourceIds,
+            resourceType: body.resourceType,
+        },
+    });
+
+    if (res.status !== 200) {
+        throw new Error('Failed to share item');
+    }
+
+    return {
+        id: res.body.data.id,
+    };
+};
+
 export const ndController = {
     addToPlaylist,
     authenticate,
@@ -565,5 +588,6 @@ export const ndController = {
     getSongList,
     getUserList,
     removeFromPlaylist,
+    shareItem,
     updatePlaylist,
 };

--- a/src/renderer/api/navidrome/navidrome-controller.ts
+++ b/src/renderer/api/navidrome/navidrome-controller.ts
@@ -486,6 +486,7 @@ const removeFromPlaylist = async (
 
 const VERSION_INFO: Array<[string, Record<string, number[]>]> = [
     ['0.48.0', { [ServerFeature.PLAYLISTS_SMART]: [1] }],
+    ['0.49.3', { [ServerFeature.SHARING_ALBUM_SONG]: [1] }],
 ];
 
 const getFeatures = (version: string): Record<string, number[]> => {
@@ -544,6 +545,7 @@ const getServerInfo = async (args: ServerInfoArgs): Promise<ServerInfo> => {
     const features: ServerFeatures = {
         lyricsMultipleStructured: !!navidromeFeatures[SubsonicExtensions.SONG_LYRICS],
         playlistsSmart: !!navidromeFeatures[NavidromeExtensions.SMART_PLAYLISTS],
+        sharingAlbumSong: !!navidromeFeatures[NavidromeExtensions.SHARING],
     };
 
     return { features, id: apiClientProps.server?.id, version: ping.body.serverVersion! };
@@ -556,6 +558,7 @@ const shareItem = async (args: ShareItemArgs): Promise<ShareItemResponse> => {
         body: {
             description: body.description,
             downloadable: body.downloadable,
+            expires: body.expires,
             resourceIds: body.resourceIds,
             resourceType: body.resourceType,
         },

--- a/src/renderer/api/navidrome/navidrome-types.ts
+++ b/src/renderer/api/navidrome/navidrome-types.ts
@@ -356,7 +356,6 @@ const shareItemParameters = z.object({
 });
 
 export enum NavidromeExtensions {
-    SHARING = 'sharing',
     SMART_PLAYLISTS = 'smartPlaylists',
 }
 

--- a/src/renderer/api/navidrome/navidrome-types.ts
+++ b/src/renderer/api/navidrome/navidrome-types.ts
@@ -350,11 +350,13 @@ const shareItem = z.object({
 const shareItemParameters = z.object({
     description: z.string(),
     downloadable: z.boolean(),
+    expires: z.number(),
     resourceIds: z.string(),
     resourceType: z.string(),
 });
 
 export enum NavidromeExtensions {
+    SHARING = 'sharing',
     SMART_PLAYLISTS = 'smartPlaylists',
 }
 

--- a/src/renderer/api/navidrome/navidrome-types.ts
+++ b/src/renderer/api/navidrome/navidrome-types.ts
@@ -343,6 +343,17 @@ const removeFromPlaylistParameters = z.object({
     id: z.array(z.string()),
 });
 
+const shareItem = z.object({
+    id: z.string(),
+});
+
+const shareItemParameters = z.object({
+    description: z.string(),
+    downloadable: z.boolean(),
+    resourceIds: z.string(),
+    resourceType: z.string(),
+});
+
 export enum NavidromeExtensions {
     SMART_PLAYLISTS = 'smartPlaylists',
 }
@@ -365,6 +376,7 @@ export const ndType = {
         genreList: genreListParameters,
         playlistList: playlistListParameters,
         removeFromPlaylist: removeFromPlaylistParameters,
+        shareItem: shareItemParameters,
         songList: songListParameters,
         updatePlaylist: updatePlaylistParameters,
         userList: userListParameters,
@@ -386,6 +398,7 @@ export const ndType = {
         playlistSong,
         playlistSongList,
         removeFromPlaylist,
+        shareItem,
         song,
         songList,
         updatePlaylist,

--- a/src/renderer/api/types.ts
+++ b/src/renderer/api/types.ts
@@ -766,6 +766,18 @@ export type RatingQuery = {
 
 export type SetRatingArgs = { query: RatingQuery; serverId?: string } & BaseEndpointArgs;
 
+// Sharing
+export type ShareItemResponse = { id: string } | undefined;
+
+export type ShareItemBody = {
+    description: string;
+    downloadable: boolean;
+    resourceIds: string;
+    resourceType: string;
+};
+
+export type ShareItemArgs = { body: ShareItemBody; serverId?: string } & BaseEndpointArgs;
+
 // Add to playlist
 export type AddToPlaylistResponse = null | undefined;
 

--- a/src/renderer/api/types.ts
+++ b/src/renderer/api/types.ts
@@ -772,6 +772,7 @@ export type ShareItemResponse = { id: string } | undefined;
 export type ShareItemBody = {
     description: string;
     downloadable: boolean;
+    expires: number;
     resourceIds: string;
     resourceType: string;
 };

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -21,6 +21,7 @@ import { ContextMenuProvider } from '/@/renderer/features/context-menu';
 import { useHandlePlayQueueAdd } from '/@/renderer/features/player/hooks/use-handle-playqueue-add';
 import { PlayQueueHandlerContext } from '/@/renderer/features/player';
 import { AddToPlaylistContextModal } from '/@/renderer/features/playlists';
+import { ShareItemContextModal } from '/@/renderer/features/sharing';
 import { getMpvProperties } from '/@/renderer/features/settings/components/playback/mpv-settings';
 import { PlayerState, usePlayerStore, useQueueControls } from '/@/renderer/store';
 import { FontType, PlaybackType, PlayerStatus } from '/@/renderer/types';
@@ -259,7 +260,11 @@ export const App = () => {
                         transition: 'fade',
                     },
                 }}
-                modals={{ addToPlaylist: AddToPlaylistContextModal, base: BaseContextModal }}
+                modals={{
+                    addToPlaylist: AddToPlaylistContextModal,
+                    base: BaseContextModal,
+                    shareItem: ShareItemContextModal,
+                }}
             >
                 <PlayQueueHandlerContext.Provider value={providerValue}>
                     <ContextMenuProvider>

--- a/src/renderer/features/context-menu/context-menu-items.tsx
+++ b/src/renderer/features/context-menu/context-menu-items.tsx
@@ -18,7 +18,8 @@ export const SONG_CONTEXT_MENU_ITEMS: SetContextMenuItems = [
     { divider: true, id: 'addToPlaylist' },
     { id: 'addToFavorites' },
     { divider: true, id: 'removeFromFavorites' },
-    { children: true, disabled: false, id: 'setRating' },
+    { children: true, disabled: false, divider: true, id: 'setRating' },
+    { id: 'shareItem' },
 ];
 
 export const PLAYLIST_SONG_CONTEXT_MENU_ITEMS: SetContextMenuItems = [
@@ -49,7 +50,8 @@ export const ALBUM_CONTEXT_MENU_ITEMS: SetContextMenuItems = [
     { divider: true, id: 'addToPlaylist' },
     { id: 'addToFavorites' },
     { id: 'removeFromFavorites' },
-    { children: true, disabled: false, id: 'setRating' },
+    { children: true, disabled: false, divider: true, id: 'setRating' },
+    { id: 'shareItem' },
 ];
 
 export const GENRE_CONTEXT_MENU_ITEMS: SetContextMenuItems = [

--- a/src/renderer/features/context-menu/context-menu-provider.tsx
+++ b/src/renderer/features/context-menu/context-menu-provider.tsx
@@ -25,6 +25,7 @@ import {
     RiPlayListAddFill,
     RiStarFill,
     RiCloseCircleLine,
+    RiShareForwardFill,
 } from 'react-icons/ri';
 import { AnyLibraryItems, LibraryItem, ServerType, AnyLibraryItem } from '/@/renderer/api/types';
 import {
@@ -600,6 +601,22 @@ export const ContextMenuProvider = ({ children }: ContextMenuProviderProps) => {
         }
     }, [ctx.dataNodes, moveToTopOfQueue, playbackType]);
 
+    const handleShareItem = useCallback(() => {
+        if (!ctx.dataNodes && !ctx.data) return;
+
+        const uniqueIds = ctx.data.map((node) => node.id);
+
+        openContextModal({
+            innerProps: {
+                itemIds: uniqueIds,
+                resourceType: ctx.data[0].itemType,
+            },
+            modal: 'shareItem',
+            size: 'md',
+            title: t('page.contextMenu.shareItem', { postProcess: 'sentenceCase' }),
+        });
+    }, [ctx.data, ctx.dataNodes, t]);
+
     const handleRemoveSelected = useCallback(() => {
         const uniqueIds = ctx.dataNodes?.map((row) => row.data.uniqueId);
         if (!uniqueIds?.length) return;
@@ -775,6 +792,12 @@ export const ContextMenuProvider = ({ children }: ContextMenuProviderProps) => {
                 onClick: () => {},
                 rightIcon: <RiArrowRightSFill size="1.2rem" />,
             },
+            shareItem: {
+                id: 'shareItem',
+                label: t('page.contextMenu.shareItem', { postProcess: 'sentenceCase' }),
+                leftIcon: <RiShareForwardFill size="1.1rem" />,
+                onClick: handleShareItem,
+            },
         };
     }, [
         handleAddToFavorites,
@@ -788,6 +811,7 @@ export const ContextMenuProvider = ({ children }: ContextMenuProviderProps) => {
         handleRemoveSelected,
         handleUpdateRating,
         openDeletePlaylistModal,
+        handleShareItem,
         t,
     ]);
 

--- a/src/renderer/features/context-menu/context-menu-provider.tsx
+++ b/src/renderer/features/context-menu/context-menu-provider.tsx
@@ -11,6 +11,8 @@ import {
 import { closeAllModals, openContextModal, openModal } from '@mantine/modals';
 import { AnimatePresence } from 'framer-motion';
 import isElectron from 'is-electron';
+import { ServerFeature } from '/@/renderer/api/features-types';
+import { hasFeature } from '/@/renderer/api/utils';
 import { useTranslation } from 'react-i18next';
 import {
     RiAddBoxFill,
@@ -793,6 +795,10 @@ export const ContextMenuProvider = ({ children }: ContextMenuProviderProps) => {
                 rightIcon: <RiArrowRightSFill size="1.2rem" />,
             },
             shareItem: {
+                disabled: !(
+                    server?.type === ServerType.NAVIDROME &&
+                    hasFeature(server, ServerFeature.SHARING_ALBUM_SONG)
+                ),
                 id: 'shareItem',
                 label: t('page.contextMenu.shareItem', { postProcess: 'sentenceCase' }),
                 leftIcon: <RiShareForwardFill size="1.1rem" />,
@@ -812,6 +818,7 @@ export const ContextMenuProvider = ({ children }: ContextMenuProviderProps) => {
         handleUpdateRating,
         openDeletePlaylistModal,
         handleShareItem,
+        server,
         t,
     ]);
 

--- a/src/renderer/features/context-menu/context-menu-provider.tsx
+++ b/src/renderer/features/context-menu/context-menu-provider.tsx
@@ -79,7 +79,7 @@ const ContextMenuContext = createContext<ContextMenuContextProps>({
     },
 });
 
-const JELLYFIN_IGNORED_MENU_ITEMS: ContextMenuItemType[] = ['setRating'];
+const JELLYFIN_IGNORED_MENU_ITEMS: ContextMenuItemType[] = ['setRating', 'shareItem'];
 // const NAVIDROME_IGNORED_MENU_ITEMS: ContextMenuItemType[] = [];
 // const SUBSONIC_IGNORED_MENU_ITEMS: ContextMenuItemType[] = [];
 
@@ -795,10 +795,7 @@ export const ContextMenuProvider = ({ children }: ContextMenuProviderProps) => {
                 rightIcon: <RiArrowRightSFill size="1.2rem" />,
             },
             shareItem: {
-                disabled: !(
-                    server?.type === ServerType.NAVIDROME &&
-                    hasFeature(server, ServerFeature.SHARING_ALBUM_SONG)
-                ),
+                disabled: !hasFeature(server, ServerFeature.SHARING_ALBUM_SONG),
                 id: 'shareItem',
                 label: t('page.contextMenu.shareItem', { postProcess: 'sentenceCase' }),
                 leftIcon: <RiShareForwardFill size="1.1rem" />,
@@ -858,7 +855,10 @@ export const ContextMenuProvider = ({ children }: ContextMenuProviderProps) => {
                                                     >
                                                         <HoverCard.Target>
                                                             <ContextMenuButton
-                                                                disabled={item.disabled}
+                                                                disabled={
+                                                                    contextMenuItems[item.id]
+                                                                        .disabled
+                                                                }
                                                                 leftIcon={
                                                                     contextMenuItems[item.id]
                                                                         .leftIcon
@@ -895,7 +895,9 @@ export const ContextMenuProvider = ({ children }: ContextMenuProviderProps) => {
                                                     </HoverCard>
                                                 ) : (
                                                     <ContextMenuButton
-                                                        disabled={item.disabled}
+                                                        disabled={
+                                                            contextMenuItems[item.id].disabled
+                                                        }
                                                         leftIcon={
                                                             contextMenuItems[item.id].leftIcon
                                                         }

--- a/src/renderer/features/context-menu/events.ts
+++ b/src/renderer/features/context-menu/events.ts
@@ -28,6 +28,7 @@ export type ContextMenuItemType =
     | 'addToFavorites'
     | 'removeFromFavorites'
     | 'setRating'
+    | 'shareItem'
     | 'deletePlaylist'
     | 'createPlaylist'
     | 'moveToBottomOfQueue'

--- a/src/renderer/features/sharing/components/share-item-context-modal.tsx
+++ b/src/renderer/features/sharing/components/share-item-context-modal.tsx
@@ -1,0 +1,88 @@
+import { Box, Group, Stack, TextInput } from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { closeModal, ContextModalProps } from '@mantine/modals';
+import { Button, Switch, toast } from '/@/renderer/components';
+import { useCurrentServer } from '/@/renderer/store';
+import { useTranslation } from 'react-i18next';
+import { useShareItem } from '../mutations/share-item-mutation';
+
+export const ShareItemContextModal = ({
+    id,
+    innerProps,
+}: ContextModalProps<{
+    itemIds: string[];
+    resourceType: string;
+}>) => {
+    const { t } = useTranslation();
+    const { itemIds, resourceType } = innerProps;
+    const server = useCurrentServer();
+
+    const shareItemMutation = useShareItem({});
+
+    const form = useForm({
+        initialValues: {
+            allowDownloading: false,
+            description: '',
+        },
+    });
+
+    const handleSubmit = form.onSubmit(async (values) => {
+        shareItemMutation.mutate({
+            body: {
+                description: values.description,
+                downloadable: values.allowDownloading,
+                resourceIds: itemIds.join(),
+                resourceType,
+            },
+            serverId: server?.id,
+        });
+
+        toast.success({
+            message: t('form.shareItem.success', {
+                postProcess: 'sentenceCase',
+            }),
+        });
+        closeModal(id);
+        return null;
+    });
+
+    return (
+        <Box p="1rem">
+            <form onSubmit={handleSubmit}>
+                <Stack>
+                    <TextInput
+                        label={t('form.shareItem.description', {
+                            postProcess: 'titleCase',
+                        })}
+                        {...form.getInputProps('description')}
+                    />
+                    <Switch
+                        defaultChecked={false}
+                        label={t('form.shareItem.allowDownloading', {
+                            postProcess: 'titleCase',
+                        })}
+                        {...form.getInputProps('allowDownloading')}
+                    />
+                    <Group position="right">
+                        <Group>
+                            <Button
+                                size="md"
+                                variant="subtle"
+                                onClick={() => closeModal(id)}
+                            >
+                                {t('common.cancel', { postProcess: 'titleCase' })}
+                            </Button>
+                            <Button
+                                size="md"
+                                type="submit"
+                                variant="filled"
+                            >
+                                {t('common.share', { postProcess: 'titleCase' })}
+                            </Button>
+                        </Group>
+                    </Group>
+                </Stack>
+            </form>
+        </Box>
+    );
+};

--- a/src/renderer/features/sharing/components/share-item-context-modal.tsx
+++ b/src/renderer/features/sharing/components/share-item-context-modal.tsx
@@ -63,11 +63,25 @@ export const ShareItemContextModal = ({
                 onSuccess: (_data) => {
                     if (!server) throw new Error('Server not found');
                     if (!_data?.id) throw new Error('Failed to share item');
-                    navigator.clipboard.writeText(`${server.url}/share/${_data.id}`);
+
+                    const shareUrl = `${server.url}/share/${_data.id}`;
+
+                    navigator.clipboard.writeText(shareUrl);
                     toast.success({
+                        autoClose: 5000,
+                        id: 'share-item-toast',
                         message: t('form.shareItem.success', {
                             postProcess: 'sentenceCase',
                         }),
+                        onClick: (a) => {
+                            if (!(a.target instanceof HTMLElement)) return;
+
+                            // Make sure we weren't clicking close (otherwise clicking close /also/ opens the url)
+                            if (a.target.nodeName !== 'svg') {
+                                window.open(shareUrl);
+                                toast.hide('share-item-toast');
+                            }
+                        },
                     });
                 },
             },

--- a/src/renderer/features/sharing/index.ts
+++ b/src/renderer/features/sharing/index.ts
@@ -1,0 +1,2 @@
+export * from './components/share-item-context-modal';
+export * from './mutations/share-item-mutation';

--- a/src/renderer/features/sharing/mutations/share-item-mutation.ts
+++ b/src/renderer/features/sharing/mutations/share-item-mutation.ts
@@ -19,12 +19,6 @@ export const useShareItem = (args: MutationHookArgs) => {
             if (!server) throw new Error('Server not found');
             return api.controller.shareItem({ ...args, apiClientProps: { server } });
         },
-        onSuccess: (_data, variables) => {
-            if (!_data?.id) throw new Error('Failed to share item');
-            const server = getServerById(variables.serverId);
-            if (!server) throw new Error('Server not found');
-            navigator.clipboard.writeText(`${server.url}/share/${_data.id}`);
-        },
         ...options,
     });
 };

--- a/src/renderer/features/sharing/mutations/share-item-mutation.ts
+++ b/src/renderer/features/sharing/mutations/share-item-mutation.ts
@@ -1,0 +1,30 @@
+import { useMutation } from '@tanstack/react-query';
+import { AnyLibraryItems, ShareItemResponse, ShareItemArgs } from '/@/renderer/api/types';
+import { AxiosError } from 'axios';
+import { api } from '/@/renderer/api';
+import { MutationHookArgs } from '/@/renderer/lib/react-query';
+import { getServerById } from '/@/renderer/store';
+
+export const useShareItem = (args: MutationHookArgs) => {
+    const { options } = args || {};
+
+    return useMutation<
+        ShareItemResponse,
+        AxiosError,
+        Omit<ShareItemArgs, 'server' | 'apiClientProps'>,
+        { previous: { items: AnyLibraryItems } | undefined }
+    >({
+        mutationFn: (args) => {
+            const server = getServerById(args.serverId);
+            if (!server) throw new Error('Server not found');
+            return api.controller.shareItem({ ...args, apiClientProps: { server } });
+        },
+        onSuccess: (_data, variables) => {
+            if (!_data?.id) throw new Error('Failed to share item');
+            const server = getServerById(variables.serverId);
+            if (!server) throw new Error('Server not found');
+            navigator.clipboard.writeText(`${server.url}/share/${_data.id}`);
+        },
+        ...options,
+    });
+};


### PR DESCRIPTION
PR that adds an option for sharing an album or songs via Navidrome (nothing else yet), resolves #80.  
There are more then likely *a lot* of issues with how I did this, if you have any feedback on it please lmk (considering I've still barely touched React in my life).

Two nitpicks:
- Right now, this PR selects `resourceType` based on the first item you've selected. This *should* be fine since I'm assuming you can't magically select two items of different types within Feishin (ie. selecting an album <ins>and</ins> a song at the same time).
- Additionally, there seems to be a lack of margin on TextInput fields (not that bad but it's a bit squished):

![image](https://github.com/jeffvli/feishin/assets/35084023/e9519cfd-0085-4e6a-8863-0173b80bbaaa)

Anyways, as stated in the beginning, any feedback would be very much appreciated.