### PR TITLE
[feat]  Create "Add current track" button in playlist view

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -17,6 +17,7 @@
         "setRating": "set rating",
         "toggleSmartPlaylistEditor": "toggle $t(entity.smartPlaylist) editor",
         "viewPlaylists": "view $t(entity.playlist_other)",
+        "addCurrentSong": "$t(common.add) $t(common.currentSong)",
         "openIn": {
             "lastfm": "Open in Last.fm",
             "musicbrainz": "Open in MusicBrainz"

--- a/src/renderer/features/sidebar/components/sidebar-playlist-list.tsx
+++ b/src/renderer/features/sidebar/components/sidebar-playlist-list.tsx
@@ -202,16 +202,17 @@ export const SidebarPlaylistList = ({ data }: SidebarPlaylistListProps) => {
                             title: t('error.genericError', { postProcess: 'sentenceCase' }),
                         });
                     },
+                    onSuccess: () => {
+                        toast.success({
+                            message: t('form.addToPlaylist.success', {
+                                message: 1,
+                                numOfPlaylists: 1,
+                                postProcess: 'sentenceCase',
+                            }),
+                        });
+                    },
                 },
             );
-
-            toast.success({
-                message: t('form.addToPlaylist.success', {
-                    message: 1,
-                    numOfPlaylists: 1,
-                    postProcess: 'sentenceCase',
-                }),
-            });
         },
         [addToPlaylistMutation, currentSong, serverID, t],
     );

--- a/src/renderer/features/sidebar/components/sidebar-playlist-list.tsx
+++ b/src/renderer/features/sidebar/components/sidebar-playlist-list.tsx
@@ -2,19 +2,19 @@ import { useCallback, useMemo, useState } from 'react';
 import { Box, Flex, Group } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import { useTranslation } from 'react-i18next';
-import { RiAddBoxFill, RiAddCircleFill, RiPlayFill } from 'react-icons/ri';
+import { RiAddBoxFill, RiAddCircleFill, RiPlayFill, RiPlayListAddFill } from 'react-icons/ri';
 import { generatePath } from 'react-router';
 import { Link } from 'react-router-dom';
 import { LibraryItem, Playlist } from '/@/renderer/api/types';
-import { Button, Text } from '/@/renderer/components';
+import { Button, Text, toast } from '/@/renderer/components';
 import { usePlayQueueAdd } from '/@/renderer/features/player';
-import { usePlaylistList } from '/@/renderer/features/playlists';
+import { useAddToPlaylist, usePlaylistList } from '/@/renderer/features/playlists';
 import { AppRoute } from '/@/renderer/router/routes';
 import { Play } from '/@/renderer/types';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { FixedSizeList, ListChildComponentProps } from 'react-window';
 import { useHideScrollbar } from '/@/renderer/hooks';
-import { useCurrentServer, useGeneralSettings } from '/@/renderer/store';
+import { useCurrentServer, useGeneralSettings, useCurrentSong } from '/@/renderer/store';
 
 interface SidebarPlaylistListProps {
     data: ReturnType<typeof usePlaylistList>['data'];
@@ -84,6 +84,24 @@ const PlaylistRow = ({ index, data, style }: ListChildComponentProps) => {
                     right="0"
                     spacing="sm"
                 >
+                    {!data?.items?.[index].rules && ( // hide button on smart playlists
+                        <Button
+                            compact
+                            size="md"
+                            tooltip={{
+                                label: t('action.addCurrentSong', { postProcess: 'sentenceCase' }),
+                                openDelay: 500,
+                            }}
+                            variant="default"
+                            onClick={() => {
+                                if (!data?.items?.[index].id) return;
+                                data.handleAdd(data?.items[index]);
+                            }}
+                        >
+                            <RiPlayListAddFill />
+                        </Button>
+                    )}
+
                     <Button
                         compact
                         size="md"
@@ -136,10 +154,16 @@ const PlaylistRow = ({ index, data, style }: ListChildComponentProps) => {
 };
 
 export const SidebarPlaylistList = ({ data }: SidebarPlaylistListProps) => {
+    const { t } = useTranslation();
+
     const { isScrollbarHidden, hideScrollbarElementProps } = useHideScrollbar(0);
     const handlePlayQueueAdd = usePlayQueueAdd();
+    const addToPlaylistMutation = useAddToPlaylist({});
+
     const { defaultFullPlaylist } = useGeneralSettings();
-    const { type, username } = useCurrentServer() || {};
+    const { id: serverID, type, username } = useCurrentServer() || {};
+
+    const currentSong = useCurrentSong();
 
     const [rect, setRect] = useState({
         height: 0,
@@ -161,8 +185,43 @@ export const SidebarPlaylistList = ({ data }: SidebarPlaylistListProps) => {
         [handlePlayQueueAdd],
     );
 
+    const handleAddCurrent = useCallback(
+        (playlist: Playlist) => {
+            if (!currentSong) return;
+
+            addToPlaylistMutation.mutate(
+                {
+                    body: { songId: [currentSong.id] },
+                    query: { id: playlist.id },
+                    serverId: serverID,
+                },
+                {
+                    onError: (err) => {
+                        toast.error({
+                            message: `[${playlist?.name}] ${err.message}`,
+                            title: t('error.genericError', { postProcess: 'sentenceCase' }),
+                        });
+                    },
+                },
+            );
+
+            toast.success({
+                message: t('form.addToPlaylist.success', {
+                    message: 1,
+                    numOfPlaylists: 1,
+                    postProcess: 'sentenceCase',
+                }),
+            });
+        },
+        [addToPlaylistMutation, currentSong, serverID, t],
+    );
+
     const memoizedItemData = useMemo(() => {
-        const base = { defaultFullPlaylist, handlePlay: handlePlayPlaylist };
+        const base = {
+            defaultFullPlaylist,
+            handleAdd: handleAddCurrent,
+            handlePlay: handlePlayPlaylist,
+        };
 
         if (!type || !username || !data?.items) {
             return { ...base, items: data?.items };
@@ -185,7 +244,7 @@ export const SidebarPlaylistList = ({ data }: SidebarPlaylistListProps) => {
         }
 
         return { ...base, items: owned.concat(shared) };
-    }, [data?.items, defaultFullPlaylist, handlePlayPlaylist, type, username]);
+    }, [data?.items, defaultFullPlaylist, handleAddCurrent, handlePlayPlaylist, type, username]);
 
     return (
         <Flex


### PR DESCRIPTION
I'm enjoying using Feishin as my music player for my library. I thought it would be nice to add a "Add current track" button to the playlist sidebar. That way, when a song is playing, I can quickly add it to as many playlists as I feel like it belongs in.

![demo](https://github.com/jeffvli/feishin/assets/22407192/b937be34-08f9-490e-9638-03160900492e)

Currently, I have it hiding the button if the playlist has rules (ie, a smart playlist). You can add a song to a shared playlist, but if you don't have (admin) permission, it throws an error toast. 

This also allows adding duplicates of a song to a playlist, so a toggle somewhere to disable duplicates could be a nice feature.

I'm not a React dev and haven't really contributed to open source, so if there's any issues please let me know! I think I did a decent job, but I'm always looking for ways to make my code better.