### PR TITLE
[bugfix]: Add a fallback image to the dynamic background url

### DIFF
--- a/src/renderer/features/player/components/full-screen-player.tsx
+++ b/src/renderer/features/player/components/full-screen-player.tsx
@@ -472,12 +472,10 @@ export const FullScreenPlayer = () => {
         srcLoaded: true,
     });
 
-    const imageUrl = currentSong?.imageUrl;
+    const imageUrl = currentSong?.imageUrl && currentSong.imageUrl.replace(/size=\d+/g, 'size=500');
     const backgroundImage =
         imageUrl && dynamicIsImage
-            ? `url("${imageUrl
-                  .replace(/size=\d+/g, 'size=500')
-                  .replace(currentSong.id, currentSong.albumId)}`
+            ? `url("${imageUrl.replace(currentSong.id, currentSong.albumId)}"), url("${imageUrl}")`
             : mainBackground;
 
     return (


### PR DESCRIPTION
Small changes to fix my previous PR that added dynamic background images (https://github.com/jeffvli/feishin/pull/526).
This just adds the non-replaced image url as an extra background argument, so that way if you have an album with missing art, the song art will attempt to be displayed instead.

Also adds a missing `")` for the CSS url property, not sure why it wasn't there already.