### PR TITLE
[enhancement]: Support toggling Album/Track view for gneres

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -282,6 +282,8 @@
             "moreFromGeneric": "more from {{item}}"
         },
         "albumList": {
+            "genreAlbums": "\"{{genre}}\" $t(entity.album_other)",
+            "showTracks": "show $t(entity.track_other)",
             "title": "$t(entity.album_other)"
         },
         "appMenu": {
@@ -384,6 +386,7 @@
         "trackList": {
             "artistTracks": "Tracks by {{artist}}",
             "genreTracks": "\"{{genre}}\" $t(entity.track_other)",
+            "showAlbums": "show $t(entity.album_other)",
             "title": "$t(entity.track_other)"
         }
     },
@@ -474,6 +477,8 @@
         "gaplessAudio": "gapless audio",
         "gaplessAudio_description": "sets the gapless audio setting for mpv",
         "gaplessAudio_optionWeak": "weak (recommended)",
+        "genreBehavior": "genre page default behavior",
+        "genreBahvior_description": "determines whether clicking on a genre opens by default in track or album list",
         "globalMediaHotkeys": "global media hotkeys",
         "globalMediaHotkeys_description": "enable or disable the usage of your system media hotkeys to control playback",
         "homeConfiguration": "home page configuration",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -282,6 +282,7 @@
             "moreFromGeneric": "more from {{item}}"
         },
         "albumList": {
+            "artistAlbums": "Albums by {{artist}}",
             "genreAlbums": "\"{{genre}}\" $t(entity.album_other)",
             "showTracks": "show $t(entity.track_other)",
             "title": "$t(entity.album_other)"
@@ -478,7 +479,7 @@
         "gaplessAudio_description": "sets the gapless audio setting for mpv",
         "gaplessAudio_optionWeak": "weak (recommended)",
         "genreBehavior": "genre page default behavior",
-        "genreBahvior_description": "determines whether clicking on a genre opens by default in track or album list",
+        "genreBehavior_description": "determines whether clicking on a genre opens by default in track or album list",
         "globalMediaHotkeys": "global media hotkeys",
         "globalMediaHotkeys_description": "enable or disable the usage of your system media hotkeys to control playback",
         "homeConfiguration": "home page configuration",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -284,7 +284,6 @@
         "albumList": {
             "artistAlbums": "Albums by {{artist}}",
             "genreAlbums": "\"{{genre}}\" $t(entity.album_other)",
-            "showTracks": "show $t(entity.track_other)",
             "title": "$t(entity.album_other)"
         },
         "appMenu": {
@@ -339,6 +338,8 @@
             "upNext": "up next"
         },
         "genreList": {
+            "showAlbums": "show $t(entity.genre_one) $t(entity.album_other)",
+            "showTracks": "show $t(entity.genre_one) $t(entity.track_other)",
             "title": "$t(entity.genre_other)"
         },
         "globalSearch": {
@@ -387,7 +388,6 @@
         "trackList": {
             "artistTracks": "Tracks by {{artist}}",
             "genreTracks": "\"{{genre}}\" $t(entity.track_other)",
-            "showAlbums": "show $t(entity.album_other)",
             "title": "$t(entity.track_other)"
         }
     },

--- a/src/renderer/components/virtual-table/cells/genre-cell.tsx
+++ b/src/renderer/components/virtual-table/cells/genre-cell.tsx
@@ -4,10 +4,11 @@ import { generatePath, Link } from 'react-router-dom';
 import type { AlbumArtist, Artist } from '/@/renderer/api/types';
 import { Text } from '/@/renderer/components/text';
 import { CellContainer } from '/@/renderer/components/virtual-table/cells/generic-cell';
-import { AppRoute } from '/@/renderer/router/routes';
 import { Separator } from '/@/renderer/components/separator';
+import { useGenreRoute } from '/@/renderer/hooks/use-genre-route';
 
 export const GenreCell = ({ value, data }: ICellRendererParams) => {
+    const genrePath = useGenreRoute();
     return (
         <CellContainer $position="left">
             <Text
@@ -24,9 +25,7 @@ export const GenreCell = ({ value, data }: ICellRendererParams) => {
                             component={Link}
                             overflow="hidden"
                             size="md"
-                            to={generatePath(AppRoute.LIBRARY_GENRES_SONGS, {
-                                genreId: item.id,
-                            })}
+                            to={generatePath(genrePath, { genreId: item.id })}
                         >
                             {item.name || '—'}
                         </Text>

--- a/src/renderer/features/albums/components/album-detail-content.tsx
+++ b/src/renderer/features/albums/components/album-detail-content.tsx
@@ -45,6 +45,7 @@ import {
 } from '/@/renderer/store/settings.store';
 import { Play } from '/@/renderer/types';
 import { replaceURLWithHTMLLinks } from '/@/renderer/utils/linkify';
+import { useGenreRoute } from '/@/renderer/hooks/use-genre-route';
 
 const isFullWidthRow = (node: RowNode) => {
     return node.id?.startsWith('disc-');
@@ -81,6 +82,7 @@ export const AlbumDetailContent = ({ tableRef, background }: AlbumDetailContentP
     const isFocused = useAppFocus();
     const currentSong = useCurrentSong();
     const { externalLinks } = useGeneralSettings();
+    const genreRoute = useGenreRoute();
 
     const columnDefs = useMemo(
         () => getColumnDefs(tableConfig.columns, false, 'albumDetail'),
@@ -389,7 +391,7 @@ export const AlbumDetailContent = ({ tableRef, background }: AlbumDetailContentP
                                     component={Link}
                                     radius={0}
                                     size="md"
-                                    to={generatePath(AppRoute.LIBRARY_GENRES_SONGS, {
+                                    to={generatePath(genreRoute, {
                                         genreId: genre.id,
                                     })}
                                     variant="outline"

--- a/src/renderer/features/albums/components/album-list-header.tsx
+++ b/src/renderer/features/albums/components/album-list-header.tsx
@@ -13,11 +13,13 @@ import { AlbumListFilter, useCurrentServer, usePlayButtonBehavior } from '/@/ren
 import { titleCase } from '/@/renderer/utils';
 import { RiMusicLine } from 'react-icons/ri';
 import { generatePath } from 'react-router';
-import { Link } from 'react-router-dom';
+import { Link, createSearchParams } from 'react-router-dom';
 import { AppRoute } from '/@/renderer/router/routes';
 import { useDisplayRefresh } from '/@/renderer/hooks/use-display-refresh';
 
 interface AlbumListHeaderProps {
+    albumArtist: string | null;
+    albumArtistId?: string;
     genreId?: string;
     gridRef: MutableRefObject<VirtualInfiniteGridRef | null>;
     itemCount?: number;
@@ -26,6 +28,8 @@ interface AlbumListHeaderProps {
 }
 
 export const AlbumListHeader = ({
+    albumArtist,
+    albumArtistId,
     genreId,
     itemCount,
     gridRef,
@@ -58,6 +62,17 @@ export const AlbumListHeader = ({
         genreRef.current = genreId;
     }, [filter, genreId, refresh, tableRef]);
 
+    const tracksLink = albumArtistId
+        ? `${generatePath(AppRoute.LIBRARY_ALBUM_ARTISTS_DETAIL_SONGS, {
+              albumArtistId,
+          })}?${createSearchParams({
+              artistId: albumArtistId,
+              artistName: albumArtist || '',
+          })}`
+        : genreId
+        ? generatePath(AppRoute.LIBRARY_GENRES_SONGS, { genreId })
+        : null;
+
     return (
         <Stack
             ref={cq.ref}
@@ -81,15 +96,13 @@ export const AlbumListHeader = ({
                         >
                             {itemCount}
                         </LibraryHeaderBar.Badge>
-                        {genreId && (
+                        {tracksLink && (
                             <Button
                                 compact
                                 component={Link}
                                 radius={0}
                                 size="md"
-                                to={generatePath(AppRoute.LIBRARY_GENRES_SONGS, {
-                                    genreId,
-                                })}
+                                to={tracksLink}
                                 tooltip={{
                                     label: t('page.albumList.showTracks', {
                                         postProcess: 'sentenceCase',

--- a/src/renderer/features/albums/components/album-list-header.tsx
+++ b/src/renderer/features/albums/components/album-list-header.tsx
@@ -4,22 +4,16 @@ import { Flex, Group, Stack } from '@mantine/core';
 import debounce from 'lodash/debounce';
 import { useTranslation } from 'react-i18next';
 import { LibraryItem } from '/@/renderer/api/types';
-import { Button, PageHeader, SearchInput } from '/@/renderer/components';
+import { PageHeader, SearchInput } from '/@/renderer/components';
 import { VirtualInfiniteGridRef } from '/@/renderer/components/virtual-grid';
 import { AlbumListHeaderFilters } from '/@/renderer/features/albums/components/album-list-header-filters';
 import { FilterBar, LibraryHeaderBar } from '/@/renderer/features/shared';
 import { useContainerQuery } from '/@/renderer/hooks';
 import { AlbumListFilter, useCurrentServer, usePlayButtonBehavior } from '/@/renderer/store';
 import { titleCase } from '/@/renderer/utils';
-import { RiMusicLine } from 'react-icons/ri';
-import { generatePath } from 'react-router';
-import { Link, createSearchParams } from 'react-router-dom';
-import { AppRoute } from '/@/renderer/router/routes';
 import { useDisplayRefresh } from '/@/renderer/hooks/use-display-refresh';
 
 interface AlbumListHeaderProps {
-    albumArtist: string | null;
-    albumArtistId?: string;
     genreId?: string;
     gridRef: MutableRefObject<VirtualInfiniteGridRef | null>;
     itemCount?: number;
@@ -28,8 +22,6 @@ interface AlbumListHeaderProps {
 }
 
 export const AlbumListHeader = ({
-    albumArtist,
-    albumArtistId,
     genreId,
     itemCount,
     gridRef,
@@ -62,17 +54,6 @@ export const AlbumListHeader = ({
         genreRef.current = genreId;
     }, [filter, genreId, refresh, tableRef]);
 
-    const tracksLink = albumArtistId
-        ? `${generatePath(AppRoute.LIBRARY_ALBUM_ARTISTS_DETAIL_SONGS, {
-              albumArtistId,
-          })}?${createSearchParams({
-              artistId: albumArtistId,
-              artistName: albumArtist || '',
-          })}`
-        : genreId
-        ? generatePath(AppRoute.LIBRARY_GENRES_SONGS, { genreId })
-        : null;
-
     return (
         <Stack
             ref={cq.ref}
@@ -96,23 +77,6 @@ export const AlbumListHeader = ({
                         >
                             {itemCount}
                         </LibraryHeaderBar.Badge>
-                        {tracksLink && (
-                            <Button
-                                compact
-                                component={Link}
-                                radius={0}
-                                size="md"
-                                to={tracksLink}
-                                tooltip={{
-                                    label: t('page.albumList.showTracks', {
-                                        postProcess: 'sentenceCase',
-                                    }),
-                                }}
-                                variant="filled"
-                            >
-                                <RiMusicLine />
-                            </Button>
-                        )}
                     </LibraryHeaderBar>
                     <Group>
                         <SearchInput

--- a/src/renderer/features/albums/routes/album-list-route.tsx
+++ b/src/renderer/features/albums/routes/album-list-route.tsx
@@ -150,8 +150,6 @@ const AlbumListRoute = () => {
         <AnimatedPage>
             <ListContext.Provider value={providerValue}>
                 <AlbumListHeader
-                    albumArtist={artist}
-                    albumArtistId={albumArtistId}
                     genreId={genreId}
                     gridRef={gridRef}
                     itemCount={itemCount}

--- a/src/renderer/features/albums/routes/album-list-route.tsx
+++ b/src/renderer/features/albums/routes/album-list-route.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useMemo, useRef } from 'react';
 import type { AgGridReact as AgGridReactType } from '@ag-grid-community/react/lib/agGridReact';
 import isEmpty from 'lodash/isEmpty';
+import { useTranslation } from 'react-i18next';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { api } from '/@/renderer/api';
 import { queryKeys } from '/@/renderer/api/query-keys';
-import { LibraryItem } from '/@/renderer/api/types';
+import { GenreListSort, LibraryItem, SortOrder } from '/@/renderer/api/types';
 import { VirtualInfiniteGridRef } from '/@/renderer/components/virtual-grid';
 import { ListContext } from '/@/renderer/context/list-context';
 import { AlbumListContent } from '/@/renderer/features/albums/components/album-list-content';
@@ -15,19 +16,32 @@ import { AnimatedPage } from '/@/renderer/features/shared';
 import { queryClient } from '/@/renderer/lib/react-query';
 import { useCurrentServer, useListFilterByKey } from '/@/renderer/store';
 import { Play } from '/@/renderer/types';
+import { useGenreList } from '/@/renderer/features/genres';
+import { titleCase } from '/@/renderer/utils';
 
 const AlbumListRoute = () => {
+    const { t } = useTranslation();
     const gridRef = useRef<VirtualInfiniteGridRef | null>(null);
     const tableRef = useRef<AgGridReactType | null>(null);
     const server = useCurrentServer();
     const [searchParams] = useSearchParams();
-    const { albumArtistId } = useParams();
+    const { albumArtistId, genreId } = useParams();
     const pageKey = albumArtistId ? `albumArtistAlbum` : 'album';
     const handlePlayQueueAdd = usePlayQueueAdd();
 
     const customFilters = useMemo(() => {
         const value = {
             ...(albumArtistId && { artistIds: [albumArtistId] }),
+            ...(genreId && {
+                _custom: {
+                    jellyfin: {
+                        GenreIds: genreId,
+                    },
+                    navidrome: {
+                        genre_id: genreId,
+                    },
+                },
+            }),
         };
 
         if (isEmpty(value)) {
@@ -35,12 +49,34 @@ const AlbumListRoute = () => {
         }
 
         return value;
-    }, [albumArtistId]);
+    }, [albumArtistId, genreId]);
 
     const albumListFilter = useListFilterByKey({
         filter: customFilters,
         key: pageKey,
     });
+
+    const genreList = useGenreList({
+        options: {
+            cacheTime: 1000 * 60 * 60,
+            enabled: !!genreId,
+        },
+        query: {
+            sortBy: GenreListSort.NAME,
+            sortOrder: SortOrder.ASC,
+            startIndex: 0,
+        },
+        serverId: server?.id,
+    });
+
+    const genreTitle = useMemo(() => {
+        if (!genreList.data) return '';
+        const genre = genreList.data.items.find((g) => g.id === genreId);
+
+        if (!genre) return 'Unknown';
+
+        return genre?.name;
+    }, [genreId, genreList.data]);
 
     const itemCountCheck = useAlbumList({
         options: {
@@ -98,19 +134,27 @@ const AlbumListRoute = () => {
         return {
             customFilters,
             handlePlay,
-            id: albumArtistId ?? undefined,
+            id: albumArtistId ?? genreId,
             pageKey,
         };
-    }, [albumArtistId, customFilters, handlePlay, pageKey]);
+    }, [albumArtistId, customFilters, genreId, handlePlay, pageKey]);
+
+    const artist = searchParams.get('artistName');
+    const title = artist
+        ? t('page.trackList.artistTracks', { artist })
+        : genreId
+        ? t('page.albumList.genreAlbums', { genre: titleCase(genreTitle) })
+        : undefined;
 
     return (
         <AnimatedPage>
             <ListContext.Provider value={providerValue}>
                 <AlbumListHeader
+                    genreId={genreId}
                     gridRef={gridRef}
                     itemCount={itemCount}
                     tableRef={tableRef}
-                    title={searchParams.get('artistName') || undefined}
+                    title={title}
                 />
                 <AlbumListContent
                     gridRef={gridRef}

--- a/src/renderer/features/albums/routes/album-list-route.tsx
+++ b/src/renderer/features/albums/routes/album-list-route.tsx
@@ -141,7 +141,7 @@ const AlbumListRoute = () => {
 
     const artist = searchParams.get('artistName');
     const title = artist
-        ? t('page.trackList.artistTracks', { artist })
+        ? t('page.albumList.artistAlbums', { artist })
         : genreId
         ? t('page.albumList.genreAlbums', { genre: titleCase(genreTitle) })
         : undefined;
@@ -150,6 +150,8 @@ const AlbumListRoute = () => {
         <AnimatedPage>
             <ListContext.Provider value={providerValue}>
                 <AlbumListHeader
+                    albumArtist={artist}
+                    albumArtistId={albumArtistId}
                     genreId={genreId}
                     gridRef={gridRef}
                     itemCount={itemCount}

--- a/src/renderer/features/artists/components/album-artist-detail-content.tsx
+++ b/src/renderer/features/artists/components/album-artist-detail-content.tsx
@@ -37,13 +37,10 @@ import { LibraryBackgroundOverlay } from '/@/renderer/features/shared/components
 import { useContainerQuery } from '/@/renderer/hooks';
 import { AppRoute } from '/@/renderer/router/routes';
 import { useCurrentServer } from '/@/renderer/store';
-import {
-    GenreTarget,
-    useGeneralSettings,
-    usePlayButtonBehavior,
-} from '/@/renderer/store/settings.store';
+import { useGeneralSettings, usePlayButtonBehavior } from '/@/renderer/store/settings.store';
 import { CardRow, Play, TableColumn } from '/@/renderer/types';
 import { sanitize } from '/@/renderer/utils/sanitize';
+import { useGenreRoute } from '/@/renderer/hooks/use-genre-route';
 
 const ContentContainer = styled.div`
     position: relative;
@@ -68,11 +65,12 @@ interface AlbumArtistDetailContentProps {
 
 export const AlbumArtistDetailContent = ({ background }: AlbumArtistDetailContentProps) => {
     const { t } = useTranslation();
-    const { externalLinks, genreTarget } = useGeneralSettings();
+    const { externalLinks } = useGeneralSettings();
     const { albumArtistId } = useParams() as { albumArtistId: string };
     const cq = useContainerQuery();
     const handlePlayQueueAdd = usePlayQueueAdd();
     const server = useCurrentServer();
+    const genrePath = useGenreRoute();
 
     const detailQuery = useAlbumArtistDetail({
         query: { id: albumArtistId },
@@ -418,14 +416,9 @@ export const AlbumArtistDetailContent = ({ background }: AlbumArtistDetailConten
                                     component={Link}
                                     radius="md"
                                     size="md"
-                                    to={generatePath(
-                                        genreTarget === GenreTarget.ALBUM
-                                            ? AppRoute.LIBRARY_GENRES_ALBUMS
-                                            : AppRoute.LIBRARY_GENRES_SONGS,
-                                        {
-                                            genreId: genre.id,
-                                        },
-                                    )}
+                                    to={generatePath(genrePath, {
+                                        genreId: genre.id,
+                                    })}
                                     variant="outline"
                                 >
                                     {genre.name}

--- a/src/renderer/features/artists/components/album-artist-detail-content.tsx
+++ b/src/renderer/features/artists/components/album-artist-detail-content.tsx
@@ -37,7 +37,11 @@ import { LibraryBackgroundOverlay } from '/@/renderer/features/shared/components
 import { useContainerQuery } from '/@/renderer/hooks';
 import { AppRoute } from '/@/renderer/router/routes';
 import { useCurrentServer } from '/@/renderer/store';
-import { useGeneralSettings, usePlayButtonBehavior } from '/@/renderer/store/settings.store';
+import {
+    GenreTarget,
+    useGeneralSettings,
+    usePlayButtonBehavior,
+} from '/@/renderer/store/settings.store';
 import { CardRow, Play, TableColumn } from '/@/renderer/types';
 import { sanitize } from '/@/renderer/utils/sanitize';
 
@@ -64,7 +68,7 @@ interface AlbumArtistDetailContentProps {
 
 export const AlbumArtistDetailContent = ({ background }: AlbumArtistDetailContentProps) => {
     const { t } = useTranslation();
-    const { externalLinks } = useGeneralSettings();
+    const { externalLinks, genreTarget } = useGeneralSettings();
     const { albumArtistId } = useParams() as { albumArtistId: string };
     const cq = useContainerQuery();
     const handlePlayQueueAdd = usePlayQueueAdd();
@@ -414,9 +418,14 @@ export const AlbumArtistDetailContent = ({ background }: AlbumArtistDetailConten
                                     component={Link}
                                     radius="md"
                                     size="md"
-                                    to={generatePath(AppRoute.LIBRARY_GENRES_SONGS, {
-                                        genreId: genre.id,
-                                    })}
+                                    to={generatePath(
+                                        genreTarget === GenreTarget.ALBUM
+                                            ? AppRoute.LIBRARY_GENRES_ALBUMS
+                                            : AppRoute.LIBRARY_GENRES_SONGS,
+                                        {
+                                            genreId: genre.id,
+                                        },
+                                    )}
                                     variant="outline"
                                 >
                                     {genre.name}

--- a/src/renderer/features/genres/components/genre-list-grid-view.tsx
+++ b/src/renderer/features/genres/components/genre-list-grid-view.tsx
@@ -13,9 +13,9 @@ import {
 } from '/@/renderer/components/virtual-grid';
 import { useListContext } from '/@/renderer/context/list-context';
 import { usePlayQueueAdd } from '/@/renderer/features/player';
-import { AppRoute } from '/@/renderer/router/routes';
 import { useCurrentServer, useListStoreActions, useListStoreByKey } from '/@/renderer/store';
 import { CardRow, ListDisplayType } from '/@/renderer/types';
+import { useGenreRoute } from '/@/renderer/hooks/use-genre-route';
 
 export const GenreListGridView = ({ gridRef, itemCount }: any) => {
     const queryClient = useQueryClient();
@@ -24,6 +24,7 @@ export const GenreListGridView = ({ gridRef, itemCount }: any) => {
     const { pageKey, id } = useListContext();
     const { grid, display, filter } = useListStoreByKey({ key: pageKey });
     const { setGrid } = useListStoreActions();
+    const genrePath = useGenreRoute();
 
     const [searchParams, setSearchParams] = useSearchParams();
     const scrollOffset = searchParams.get('scrollOffset');
@@ -137,7 +138,7 @@ export const GenreListGridView = ({ gridRef, itemCount }: any) => {
                         loading={itemCount === undefined || itemCount === null}
                         minimumBatchSize={40}
                         route={{
-                            route: AppRoute.LIBRARY_GENRES_SONGS,
+                            route: genrePath,
                             slugs: [{ idProperty: 'id', slugProperty: 'genreId' }],
                         }}
                         width={width}

--- a/src/renderer/features/genres/components/genre-list-header-filters.tsx
+++ b/src/renderer/features/genres/components/genre-list-header-filters.tsx
@@ -3,7 +3,14 @@ import type { AgGridReact as AgGridReactType } from '@ag-grid-community/react/li
 import { Divider, Flex, Group, Stack } from '@mantine/core';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { RiFolder2Fill, RiMoreFill, RiRefreshLine, RiSettings3Fill } from 'react-icons/ri';
+import {
+    RiAlbumLine,
+    RiFolder2Fill,
+    RiMoreFill,
+    RiMusic2Line,
+    RiRefreshLine,
+    RiSettings3Fill,
+} from 'react-icons/ri';
 import { queryKeys } from '/@/renderer/api/query-keys';
 import { GenreListSort, LibraryItem, ServerType, SortOrder } from '/@/renderer/api/types';
 import { Button, DropdownMenu, MultiSelect, Slider, Switch, Text } from '/@/renderer/components';
@@ -15,9 +22,12 @@ import { useContainerQuery } from '/@/renderer/hooks';
 import { useListFilterRefresh } from '/@/renderer/hooks/use-list-filter-refresh';
 import {
     GenreListFilter,
+    GenreTarget,
     useCurrentServer,
+    useGeneralSettings,
     useListStoreActions,
     useListStoreByKey,
+    useSettingsStoreActions,
 } from '/@/renderer/store';
 import { ListDisplayType, TableColumn } from '/@/renderer/types';
 import i18n from '/@/i18n/i18n';
@@ -52,6 +62,8 @@ export const GenreListHeaderFilters = ({ gridRef, tableRef }: GenreListHeaderFil
     const { setFilter, setTable, setGrid, setDisplayType } = useListStoreActions();
     const { display, filter, table, grid } = useListStoreByKey({ key: pageKey });
     const cq = useContainerQuery();
+    const { genreTarget } = useGeneralSettings();
+    const { setGenreBehavior } = useSettingsStoreActions();
 
     const { handleRefreshTable, handleRefreshGrid } = useListFilterRefresh({
         itemType: LibraryItem.GENRE,
@@ -208,6 +220,11 @@ export const GenreListHeaderFilters = ({ gridRef, tableRef }: GenreListHeaderFil
         return filter.musicFolderId !== undefined;
     }, [filter.musicFolderId]);
 
+    const handleGenreToggle = useCallback(() => {
+        const newState = genreTarget === GenreTarget.ALBUM ? GenreTarget.TRACK : GenreTarget.ALBUM;
+        setGenreBehavior(newState);
+    }, [genreTarget, setGenreBehavior]);
+
     return (
         <Flex justify="space-between">
             <Group
@@ -309,6 +326,23 @@ export const GenreListHeaderFilters = ({ gridRef, tableRef }: GenreListHeaderFil
                             {t('common.refresh', { postProcess: 'titleCase' })}
                         </DropdownMenu.Item>
                     </DropdownMenu.Dropdown>
+                    <Divider orientation="vertical" />
+                    <Button
+                        compact
+                        size="md"
+                        tooltip={{
+                            label: t(
+                                genreTarget === GenreTarget.ALBUM
+                                    ? 'page.genreList.showAlbums'
+                                    : 'page.genreList.showTracks',
+                                { postProcess: 'sentenceCase' },
+                            ),
+                        }}
+                        variant="subtle"
+                        onClick={handleGenreToggle}
+                    >
+                        {genreTarget === GenreTarget.ALBUM ? <RiAlbumLine /> : <RiMusic2Line />}
+                    </Button>
                 </DropdownMenu>
             </Group>
             <Group

--- a/src/renderer/features/genres/components/genre-list-header.tsx
+++ b/src/renderer/features/genres/components/genre-list-header.tsx
@@ -31,13 +31,9 @@ export const GenreListHeader = ({ itemCount, gridRef, tableRef }: GenreListHeade
 
     const handleSearch = debounce((e: ChangeEvent<HTMLInputElement>) => {
         const updatedFilters = search(e) as GenreListFilter;
-
-        const filterWithCustom = {
-            ...updatedFilters,
-        };
-
-        refresh(filterWithCustom);
+        refresh(updatedFilters);
     }, 500);
+
     return (
         <Stack
             ref={cq.ref}

--- a/src/renderer/features/genres/components/genre-list-header.tsx
+++ b/src/renderer/features/genres/components/genre-list-header.tsx
@@ -5,19 +5,12 @@ import debounce from 'lodash/debounce';
 import { LibraryItem } from '/@/renderer/api/types';
 import { PageHeader, SearchInput } from '/@/renderer/components';
 import { VirtualInfiniteGridRef } from '/@/renderer/components/virtual-grid';
-import { useListContext } from '/@/renderer/context/list-context';
 import { GenreListHeaderFilters } from '/@/renderer/features/genres/components/genre-list-header-filters';
 import { FilterBar, LibraryHeaderBar } from '/@/renderer/features/shared';
 import { useContainerQuery } from '/@/renderer/hooks';
-import { useListFilterRefresh } from '/@/renderer/hooks/use-list-filter-refresh';
-import {
-    GenreListFilter,
-    useCurrentServer,
-    useListStoreActions,
-    useListStoreByKey,
-} from '/@/renderer/store';
-import { ListDisplayType } from '/@/renderer/types';
+import { GenreListFilter, useCurrentServer } from '/@/renderer/store';
 import { useTranslation } from 'react-i18next';
+import { useDisplayRefresh } from '/@/renderer/hooks/use-display-refresh';
 
 interface GenreListHeaderProps {
     gridRef: MutableRefObject<VirtualInfiniteGridRef | null>;
@@ -29,33 +22,21 @@ export const GenreListHeader = ({ itemCount, gridRef, tableRef }: GenreListHeade
     const { t } = useTranslation();
     const cq = useContainerQuery();
     const server = useCurrentServer();
-    const { pageKey } = useListContext();
-    const { display, filter } = useListStoreByKey({ key: pageKey });
-    const { setFilter, setTablePagination } = useListStoreActions();
-
-    const { handleRefreshGrid, handleRefreshTable } = useListFilterRefresh({
+    const { filter, refresh, search } = useDisplayRefresh({
+        gridRef,
         itemType: LibraryItem.GENRE,
         server,
+        tableRef,
     });
 
     const handleSearch = debounce((e: ChangeEvent<HTMLInputElement>) => {
-        const searchTerm = e.target.value === '' ? undefined : e.target.value;
-        const updatedFilters = setFilter({
-            data: { searchTerm },
-            itemType: LibraryItem.GENRE,
-            key: pageKey,
-        }) as GenreListFilter;
+        const updatedFilters = search(e) as GenreListFilter;
 
         const filterWithCustom = {
             ...updatedFilters,
         };
 
-        if (display === ListDisplayType.TABLE || display === ListDisplayType.TABLE_PAGINATED) {
-            handleRefreshTable(tableRef, filterWithCustom);
-            setTablePagination({ data: { currentPage: 0 }, key: pageKey });
-        } else {
-            handleRefreshGrid(gridRef, filterWithCustom);
-        }
+        refresh(filterWithCustom);
     }, 500);
     return (
         <Stack

--- a/src/renderer/features/genres/components/genre-list-table-view.tsx
+++ b/src/renderer/features/genres/components/genre-list-table-view.tsx
@@ -9,7 +9,7 @@ import { useCurrentServer } from '/@/renderer/store';
 import { MutableRefObject, useCallback } from 'react';
 import { RowDoubleClickedEvent } from '@ag-grid-community/core';
 import { generatePath, useNavigate } from 'react-router';
-import { AppRoute } from '/@/renderer/router/routes';
+import { useGenreRoute } from '/@/renderer/hooks/use-genre-route';
 
 interface GenreListTableViewProps {
     itemCount?: number;
@@ -20,6 +20,7 @@ export const GenreListTableView = ({ tableRef, itemCount }: GenreListTableViewPr
     const server = useCurrentServer();
     const { pageKey, customFilters } = useListContext();
     const navigate = useNavigate();
+    const genrePath = useGenreRoute();
 
     const tableProps = useVirtualTable({
         contextMenu: GENRE_CONTEXT_MENU_ITEMS,
@@ -36,9 +37,9 @@ export const GenreListTableView = ({ tableRef, itemCount }: GenreListTableViewPr
             const { data } = e;
             if (!data) return;
 
-            navigate(generatePath(AppRoute.LIBRARY_GENRES_SONGS, { genreId: data.id }));
+            navigate(generatePath(genrePath, { genreId: data.id }));
         },
-        [navigate],
+        [genrePath, navigate],
     );
 
     return (

--- a/src/renderer/features/item-details/components/item-details-modal.tsx
+++ b/src/renderer/features/item-details/components/item-details-modal.tsx
@@ -14,6 +14,7 @@ import { generatePath } from 'react-router';
 import { Link } from 'react-router-dom';
 import { AppRoute } from '/@/renderer/router/routes';
 import { Separator } from '/@/renderer/components/separator';
+import { useGenreRoute } from '/@/renderer/hooks/use-genre-route';
 
 export type ItemDetailsModalProps = {
     item: Album | AlbumArtist | Song;
@@ -83,8 +84,10 @@ const formatComment = (item: Album | Song) =>
 
 const formatDate = (key: string | null) => (key ? dayjs(key).fromNow() : '');
 
-const formatGenre = (item: Album | AlbumArtist | Song) =>
-    item.genres?.map((genre, index) => (
+const FormatGenre = (item: Album | AlbumArtist | Song) => {
+    const genreRoute = useGenreRoute();
+
+    return item.genres?.map((genre, index) => (
         <span key={genre.id}>
             {index > 0 && <Separator />}
             <Text
@@ -92,19 +95,14 @@ const formatGenre = (item: Album | AlbumArtist | Song) =>
                 component={Link}
                 overflow="visible"
                 size="md"
-                to={
-                    genre.id
-                        ? generatePath(AppRoute.LIBRARY_GENRES_SONGS, {
-                              genreId: genre.id,
-                          })
-                        : ''
-                }
+                to={genre.id ? generatePath(genreRoute, { genreId: genre.id }) : ''}
                 weight={500}
             >
                 {genre.name || '—'}
             </Text>
         </span>
     ));
+};
 
 const formatRating = (item: Album | AlbumArtist | Song) =>
     item.userRating !== null ? (
@@ -120,7 +118,7 @@ const BoolField = (key: boolean) =>
 const AlbumPropertyMapping: ItemDetailRow<Album>[] = [
     { key: 'name', label: 'common.title' },
     { label: 'entity.albumArtist_one', render: formatArtists(true) },
-    { label: 'entity.genre_other', render: formatGenre },
+    { label: 'entity.genre_other', render: FormatGenre },
     {
         label: 'common.duration',
         render: (album) => album.duration && formatDurationString(album.duration),
@@ -166,7 +164,7 @@ const AlbumPropertyMapping: ItemDetailRow<Album>[] = [
 
 const AlbumArtistPropertyMapping: ItemDetailRow<AlbumArtist>[] = [
     { key: 'name', label: 'common.name' },
-    { label: 'entity.genre_other', render: formatGenre },
+    { label: 'entity.genre_other', render: FormatGenre },
     {
         label: 'common.duration',
         render: (artist) => artist.duration && formatDurationString(artist.duration),
@@ -240,7 +238,7 @@ const SongPropertyMapping: ItemDetailRow<Song>[] = [
     { key: 'discNumber', label: 'common.disc' },
     { key: 'trackNumber', label: 'common.trackNumber' },
     { key: 'releaseYear', label: 'filter.releaseYear' },
-    { label: 'entity.genre_other', render: formatGenre },
+    { label: 'entity.genre_other', render: FormatGenre },
     {
         label: 'common.duration',
         render: (song) => formatDurationString(song.duration),

--- a/src/renderer/features/settings/components/general/control-settings.tsx
+++ b/src/renderer/features/settings/components/general/control-settings.tsx
@@ -4,6 +4,7 @@ import isElectron from 'is-electron';
 import { Select, Tooltip, NumberInput, Switch, Slider } from '/@/renderer/components';
 import { SettingsSection } from '/@/renderer/features/settings/components/settings-section';
 import {
+    GenreTarget,
     SideQueueType,
     useGeneralSettings,
     useSettingsStoreActions,
@@ -340,6 +341,41 @@ export const ControlSettings = () => {
                 postProcess: 'sentenceCase',
             }),
             title: t('setting.externalLinks', { postProcess: 'sentenceCase' }),
+        },
+        {
+            control: (
+                <Select
+                    data={[
+                        {
+                            label: t('entity.album_other', {
+                                postProcess: 'titleCase',
+                            }),
+                            value: GenreTarget.ALBUM,
+                        },
+                        {
+                            label: t('entity.track_other', {
+                                postProcess: 'titleCase',
+                            }),
+                            value: GenreTarget.TRACK,
+                        },
+                    ]}
+                    defaultValue={settings.genreTarget}
+                    onChange={(e) =>
+                        setSettings({
+                            general: {
+                                ...settings,
+                                genreTarget: e as GenreTarget,
+                            },
+                        })
+                    }
+                />
+            ),
+            description: t('setting.genreBehavior', {
+                context: 'description',
+                postProcess: 'sentenceCase',
+            }),
+            isHidden: false,
+            title: t('setting.genreBehavior', { postProcess: 'sentenceCase' }),
         },
     ];
 

--- a/src/renderer/features/songs/components/song-list-header.tsx
+++ b/src/renderer/features/songs/components/song-list-header.tsx
@@ -3,22 +3,17 @@ import type { AgGridReact as AgGridReactType } from '@ag-grid-community/react/li
 import { Flex, Group, Stack } from '@mantine/core';
 import debounce from 'lodash/debounce';
 import { useTranslation } from 'react-i18next';
-import { RiAlbumLine } from 'react-icons/ri';
-import { Link, createSearchParams, generatePath } from 'react-router-dom';
 import { LibraryItem } from '/@/renderer/api/types';
-import { Button, PageHeader, SearchInput } from '/@/renderer/components';
+import { PageHeader, SearchInput } from '/@/renderer/components';
 import { FilterBar, LibraryHeaderBar } from '/@/renderer/features/shared';
 import { SongListHeaderFilters } from '/@/renderer/features/songs/components/song-list-header-filters';
 import { useContainerQuery } from '/@/renderer/hooks';
 import { SongListFilter, useCurrentServer } from '/@/renderer/store';
 import { usePlayButtonBehavior } from '/@/renderer/store/settings.store';
 import { VirtualInfiniteGridRef } from '/@/renderer/components/virtual-grid';
-import { AppRoute } from '/@/renderer/router/routes';
 import { useDisplayRefresh } from '/@/renderer/hooks/use-display-refresh';
 
 interface SongListHeaderProps {
-    albumArtist: string | null;
-    albumArtistId?: string;
     genreId?: string;
     gridRef: MutableRefObject<VirtualInfiniteGridRef | null>;
     itemCount?: number;
@@ -27,8 +22,6 @@ interface SongListHeaderProps {
 }
 
 export const SongListHeader = ({
-    albumArtist,
-    albumArtistId,
     genreId,
     gridRef,
     title,
@@ -68,17 +61,6 @@ export const SongListHeader = ({
 
     const playButtonBehavior = usePlayButtonBehavior();
 
-    const albumsLink = albumArtistId
-        ? `${generatePath(AppRoute.LIBRARY_ALBUM_ARTISTS_DETAIL_DISCOGRAPHY, {
-              albumArtistId,
-          })}?${createSearchParams({
-              artistId: albumArtistId,
-              artistName: albumArtist || '',
-          })}`
-        : genreId
-        ? generatePath(AppRoute.LIBRARY_GENRES_ALBUMS, { genreId })
-        : null;
-
     return (
         <Stack
             ref={cq.ref}
@@ -101,23 +83,6 @@ export const SongListHeader = ({
                         >
                             {itemCount}
                         </LibraryHeaderBar.Badge>
-                        {albumsLink && (
-                            <Button
-                                compact
-                                component={Link}
-                                radius={0}
-                                size="md"
-                                to={albumsLink}
-                                tooltip={{
-                                    label: t('page.trackList.showAlbums', {
-                                        postProcess: 'sentenceCase',
-                                    }),
-                                }}
-                                variant="filled"
-                            >
-                                <RiAlbumLine />
-                            </Button>
-                        )}
                     </LibraryHeaderBar>
                     <Group>
                         <SearchInput

--- a/src/renderer/features/songs/components/song-list-header.tsx
+++ b/src/renderer/features/songs/components/song-list-header.tsx
@@ -4,7 +4,7 @@ import { Flex, Group, Stack } from '@mantine/core';
 import debounce from 'lodash/debounce';
 import { useTranslation } from 'react-i18next';
 import { RiAlbumLine } from 'react-icons/ri';
-import { Link, generatePath } from 'react-router-dom';
+import { Link, createSearchParams, generatePath } from 'react-router-dom';
 import { LibraryItem } from '/@/renderer/api/types';
 import { Button, PageHeader, SearchInput } from '/@/renderer/components';
 import { FilterBar, LibraryHeaderBar } from '/@/renderer/features/shared';
@@ -17,6 +17,8 @@ import { AppRoute } from '/@/renderer/router/routes';
 import { useDisplayRefresh } from '/@/renderer/hooks/use-display-refresh';
 
 interface SongListHeaderProps {
+    albumArtist: string | null;
+    albumArtistId?: string;
     genreId?: string;
     gridRef: MutableRefObject<VirtualInfiniteGridRef | null>;
     itemCount?: number;
@@ -25,6 +27,8 @@ interface SongListHeaderProps {
 }
 
 export const SongListHeader = ({
+    albumArtist,
+    albumArtistId,
     genreId,
     gridRef,
     title,
@@ -64,6 +68,17 @@ export const SongListHeader = ({
 
     const playButtonBehavior = usePlayButtonBehavior();
 
+    const albumsLink = albumArtistId
+        ? `${generatePath(AppRoute.LIBRARY_ALBUM_ARTISTS_DETAIL_DISCOGRAPHY, {
+              albumArtistId,
+          })}?${createSearchParams({
+              artistId: albumArtistId,
+              artistName: albumArtist || '',
+          })}`
+        : genreId
+        ? generatePath(AppRoute.LIBRARY_GENRES_ALBUMS, { genreId })
+        : null;
+
     return (
         <Stack
             ref={cq.ref}
@@ -86,15 +101,13 @@ export const SongListHeader = ({
                         >
                             {itemCount}
                         </LibraryHeaderBar.Badge>
-                        {genreId && (
+                        {albumsLink && (
                             <Button
                                 compact
                                 component={Link}
                                 radius={0}
                                 size="md"
-                                to={generatePath(AppRoute.LIBRARY_GENRES_ALBUMS, {
-                                    genreId,
-                                })}
+                                to={albumsLink}
                                 tooltip={{
                                     label: t('page.trackList.showAlbums', {
                                         postProcess: 'sentenceCase',

--- a/src/renderer/features/songs/routes/song-list-route.tsx
+++ b/src/renderer/features/songs/routes/song-list-route.tsx
@@ -145,6 +145,7 @@ const TrackListRoute = () => {
         <AnimatedPage>
             <ListContext.Provider value={providerValue}>
                 <SongListHeader
+                    genreId={genreId}
                     gridRef={gridRef}
                     itemCount={itemCount}
                     tableRef={tableRef}

--- a/src/renderer/features/songs/routes/song-list-route.tsx
+++ b/src/renderer/features/songs/routes/song-list-route.tsx
@@ -145,8 +145,6 @@ const TrackListRoute = () => {
         <AnimatedPage>
             <ListContext.Provider value={providerValue}>
                 <SongListHeader
-                    albumArtist={artist}
-                    albumArtistId={albumArtistId}
                     genreId={genreId}
                     gridRef={gridRef}
                     itemCount={itemCount}

--- a/src/renderer/features/songs/routes/song-list-route.tsx
+++ b/src/renderer/features/songs/routes/song-list-route.tsx
@@ -145,6 +145,8 @@ const TrackListRoute = () => {
         <AnimatedPage>
             <ListContext.Provider value={providerValue}>
                 <SongListHeader
+                    albumArtist={artist}
+                    albumArtistId={albumArtistId}
                     genreId={genreId}
                     gridRef={gridRef}
                     itemCount={itemCount}

--- a/src/renderer/hooks/use-display-refresh.ts
+++ b/src/renderer/hooks/use-display-refresh.ts
@@ -1,0 +1,68 @@
+import { ChangeEvent, MutableRefObject, useCallback } from 'react';
+import type { AgGridReact as AgGridReactType } from '@ag-grid-community/react/lib/agGridReact';
+import {
+    UseHandleListFilterChangeProps,
+    useListFilterRefresh,
+} from '/@/renderer/hooks/use-list-filter-refresh';
+import { useListContext } from '/@/renderer/context/list-context';
+import { ListDisplayType } from '/@/renderer/types';
+import { VirtualInfiniteGridRef } from '/@/renderer/components/virtual-grid';
+import { useListStoreActions, useListStoreByKey } from '/@/renderer/store';
+
+export type UseDisplayRefreshProps = {
+    gridRef: MutableRefObject<VirtualInfiniteGridRef | null>;
+    tableRef: MutableRefObject<AgGridReactType | null>;
+} & UseHandleListFilterChangeProps;
+
+export const useDisplayRefresh = ({
+    isClientSideSort,
+    gridRef,
+    itemType,
+    server,
+    tableRef,
+}: UseDisplayRefreshProps) => {
+    const { customFilters, pageKey, handlePlay } = useListContext();
+    const { display, filter } = useListStoreByKey({ key: pageKey });
+
+    const { handleRefreshGrid, handleRefreshTable } = useListFilterRefresh({
+        isClientSideSort,
+        itemType,
+        server,
+    });
+    const { setFilter, setTablePagination } = useListStoreActions();
+
+    const refresh = useCallback(
+        (filter: unknown) => {
+            if (display === ListDisplayType.TABLE || display === ListDisplayType.TABLE_PAGINATED) {
+                handleRefreshTable(tableRef, filter);
+                setTablePagination({ data: { currentPage: 0 }, key: pageKey });
+            } else {
+                handleRefreshGrid(gridRef, filter);
+            }
+        },
+        [
+            display,
+            gridRef,
+            handleRefreshGrid,
+            handleRefreshTable,
+            pageKey,
+            setTablePagination,
+            tableRef,
+        ],
+    );
+
+    const search = useCallback(
+        (e: ChangeEvent<HTMLInputElement>) => {
+            const searchTerm = e.target.value === '' ? undefined : e.target.value;
+            const updatedFilters = setFilter({
+                data: { searchTerm },
+                itemType,
+                key: pageKey,
+            });
+            return updatedFilters;
+        },
+        [itemType, pageKey, setFilter],
+    );
+
+    return { customFilters, filter, handlePlay, refresh, search };
+};

--- a/src/renderer/hooks/use-genre-route.ts
+++ b/src/renderer/hooks/use-genre-route.ts
@@ -1,18 +1,15 @@
-import { matchRoutes, useLocation } from 'react-router';
+import { useLocation } from 'react-router';
 import { GenreTarget, useSettingsStore } from '/@/renderer/store';
 import { AppRoute } from '/@/renderer/router/routes';
 import { useMemo } from 'react';
 
+const ALBUM_REGEX = /albums$/;
+const SONG_REGEX = /songs$/;
+
 export const useGenreRoute = () => {
-    const location = useLocation();
-    const matchAlbum = matchRoutes(
-        [{ path: AppRoute.LIBRARY_GENRES_ALBUMS }, { path: AppRoute.LIBRARY_ALBUMS }],
-        location,
-    );
-    const matchSongs = matchRoutes(
-        [{ path: AppRoute.LIBRARY_GENRES_SONGS }, { path: AppRoute.LIBRARY_SONGS }],
-        location,
-    );
+    const { pathname } = useLocation();
+    const matchAlbum = ALBUM_REGEX.test(pathname);
+    const matchSongs = SONG_REGEX.test(pathname);
 
     const baseState = useSettingsStore((state) =>
         state.general.genreTarget === GenreTarget.ALBUM

--- a/src/renderer/hooks/use-genre-route.ts
+++ b/src/renderer/hooks/use-genre-route.ts
@@ -1,0 +1,32 @@
+import { matchRoutes, useLocation } from 'react-router';
+import { GenreTarget, useSettingsStore } from '/@/renderer/store';
+import { AppRoute } from '/@/renderer/router/routes';
+import { useMemo } from 'react';
+
+export const useGenreRoute = () => {
+    const location = useLocation();
+    const matchAlbum = matchRoutes(
+        [{ path: AppRoute.LIBRARY_GENRES_ALBUMS }, { path: AppRoute.LIBRARY_ALBUMS }],
+        location,
+    );
+    const matchSongs = matchRoutes(
+        [{ path: AppRoute.LIBRARY_GENRES_SONGS }, { path: AppRoute.LIBRARY_SONGS }],
+        location,
+    );
+
+    const baseState = useSettingsStore((state) =>
+        state.general.genreTarget === GenreTarget.ALBUM
+            ? AppRoute.LIBRARY_GENRES_ALBUMS
+            : AppRoute.LIBRARY_GENRES_SONGS,
+    );
+
+    return useMemo(() => {
+        if (matchAlbum) {
+            return AppRoute.LIBRARY_GENRES_ALBUMS;
+        }
+        if (matchSongs) {
+            return AppRoute.LIBRARY_GENRES_SONGS;
+        }
+        return baseState;
+    }, [baseState, matchAlbum, matchSongs]);
+};

--- a/src/renderer/hooks/use-list-filter-refresh.ts
+++ b/src/renderer/hooks/use-list-filter-refresh.ts
@@ -8,7 +8,7 @@ import { BasePaginatedResponse, LibraryItem, ServerListItem } from '/@/renderer/
 import { VirtualInfiniteGridRef } from '/@/renderer/components/virtual-grid';
 import orderBy from 'lodash/orderBy';
 
-interface UseHandleListFilterChangeProps {
+export interface UseHandleListFilterChangeProps {
     isClientSideSort?: boolean;
     itemType: LibraryItem;
     server: ServerListItem | null;

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -171,6 +171,11 @@ export enum BindingActions {
     ZOOM_OUT = 'zoomOut',
 }
 
+export enum GenreTarget {
+    ALBUM = 'album',
+    TRACK = 'track',
+}
+
 export interface SettingsState {
     discord: {
         clientId: string;
@@ -192,6 +197,7 @@ export interface SettingsState {
         defaultFullPlaylist: boolean;
         externalLinks: boolean;
         followSystemTheme: boolean;
+        genreTarget: GenreTarget;
         homeItems: SortableItem<HomeItem>[];
         language: string;
         passwordStore?: string;
@@ -311,6 +317,7 @@ const initialState: SettingsState = {
         defaultFullPlaylist: true,
         externalLinks: true,
         followSystemTheme: false,
+        genreTarget: GenreTarget.TRACK,
         homeItems,
         language: 'en',
         passwordStore: undefined,

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -611,6 +611,11 @@ export const useSettingsStore = create<SettingsSlice>()(
                             state.playback.mpvProperties.audioSampleRateHz = 0;
                         });
                     },
+                    setGenreBehavior: (target: GenreTarget) => {
+                        set((state) => {
+                            state.general.genreTarget = target;
+                        });
+                    },
                     setHomeItems: (items: SortableItem<HomeItem>[]) => {
                         set((state) => {
                             state.general.homeItems = items;


### PR DESCRIPTION
The _primary_ purpose of this PR is to enable viewing tracks OR albums for genres. This has a few requirements:
1. Ability to set default route for genres, **except** when already on song/album page
2. Ability to toggle between album and genre view
3. Fixed refresh for genre ID

Additionally, there was some refactoring:
- Since the *-list-headers had very similar functions for search, export that as a hook instead