### PR TITLE
Fix LrcLib fetcher

### DIFF
--- a/src/main/features/core/lyrics/index.ts
+++ b/src/main/features/core/lyrics/index.ts
@@ -72,7 +72,7 @@ const getRemoteLyrics = async (song: QueueSong) => {
         const params = {
             album: song.album || song.name,
             artist: song.artistName,
-            duration: song.duration,
+            duration: song.duration / 1000.0,
             name: song.name,
         };
         const response = await FETCHERS[source](params);


### PR DESCRIPTION
[LrcLib expects durations in seconds](https://lrclib.net/docs), while the duration field in Feishin is [normalized to milliseconds](https://github.com/jeffvli/feishin/blob/9cd8807a75e5acb158ac711cd053e13bd33523c6/src/renderer/api/navidrome/navidrome-normalize.ts#L97).
This causes the lyrics fetch to fail.

Convert the normalized duration into seconds.