### PR TITLE
(Jellyfin) Adjust querying recent album releases

### DIFF
--- a/src/renderer/features/artists/components/album-artist-detail-content.tsx
+++ b/src/renderer/features/artists/components/album-artist-detail-content.tsx
@@ -99,7 +99,7 @@ export const AlbumArtistDetailContent = ({ background }: AlbumArtistDetailConten
             _custom: {
                 jellyfin: {
                     ...(server?.type === ServerType.JELLYFIN
-                        ? { ArtistIds: albumArtistId }
+                        ? { AlbumArtistIds: albumArtistId }
                         : undefined),
                 },
                 navidrome: {


### PR DESCRIPTION
# Changes
* Modify `recentAlbumsQuery`, so that "Recent releases" only displays albums, where an artist is the author/album artist or one of the album artists of the release.