### PR TITLE
[bugfix] Fix cache settings not being sentence cased

### DIFF
--- a/src/renderer/features/settings/components/window/cache-settngs.tsx
+++ b/src/renderer/features/settings/components/window/cache-settngs.tsx
@@ -49,7 +49,7 @@ export const CacheSettings = () => {
                     {t(`common.areYouSure`, { postProcess: 'sentenceCase' })}
                 </ConfirmModal>
             ),
-            title: t(`setting.${key}`),
+            title: t(`setting.${key}`, { postProcess: 'sentenceCase' }),
         });
     };
 
@@ -67,8 +67,9 @@ export const CacheSettings = () => {
             ),
             description: t('setting.clearQueryCache', {
                 context: 'description',
+                postProcess: 'sentenceCase',
             }),
-            title: t('setting.clearQueryCache'),
+            title: t('setting.clearQueryCache', { postProcess: 'sentenceCase' }),
         },
         {
             control: (
@@ -83,9 +84,10 @@ export const CacheSettings = () => {
             ),
             description: t('setting.clearCache', {
                 context: 'description',
+                postProcess: 'sentenceCase',
             }),
             isHidden: !browser,
-            title: t('setting.clearCache'),
+            title: t('setting.clearCache', { postProcess: 'sentenceCase' }),
         },
     ];
 


### PR DESCRIPTION
This seems to be a pretty longstanding bug that still hasn't been fixed ever since the cache clearing options were introduced. This PR just readds the missing `postProcess` option for the modal, option title, & option description.