### PR TITLE
Fix full screen player metadata may not change when switching queue

### DIFF
--- a/src/renderer/store/player.store.ts
+++ b/src/renderer/store/player.store.ts
@@ -1054,7 +1054,7 @@ export const usePlayerData = () =>
     usePlayerStore(
         (state) => state.actions.getPlayerData(),
         (a, b) => {
-            return a.current.nextIndex === b.current.nextIndex;
+            return a.current.song?.uniqueId === b.current.song?.uniqueId;
         },
     );
 


### PR DESCRIPTION
## Issue

Referenced `usePlayerData()` hook in `full-screen-player-image.tsx`:

https://github.com/jeffvli/feishin/blob/0b786b025fdb376a19075a5ecf1864b6a6f5f18c/src/renderer/features/player/components/full-screen-player-image.tsx#L136C1-L138C39

```tsx
const { queue } = usePlayerData();
const { useImageAspectRatio } = useFullScreenPlayerStore();
const currentSong = queue.current;
```

Then `usePlayerData` compares the equality dependent on `PlayerData.current.nextIndex`(*value is `nextSongIndex`*):

https://github.com/jeffvli/feishin/blob/0b786b025fdb376a19075a5ecf1864b6a6f5f18c/src/renderer/store/player.store.ts#L1053C1-L1059C7

```ts
export const usePlayerData = () =>
    usePlayerStore(
        (state) => state.actions.getPlayerData(),
        (a, b) => {
            return a.current.nextIndex === b.current.nextIndex;
        },
    );
```

But this is not always reliable. 

Assume the song has no track information, switch from the first song of *queue1* to *queue2*, the value of `PlayerData.current.nextIndex` is always `1`. **This cause in the referenced `usePlayerData()` hook not changing**. Its song information is still the first song in *queue1*.

For example, in the picture below:

![bug](https://github.com/user-attachments/assets/041cf3c9-3037-4750-b184-d7e7fc67c2ee)

## Solution

Use more reliable song information for equality comparison, such as: `PlayerData.current.song?.uniqueId`.
