### PR TITLE
[qol]: adjust rules for user-select

### DIFF
--- a/src/renderer/features/settings/components/general/draggable-items.tsx
+++ b/src/renderer/features/settings/components/general/draggable-items.tsx
@@ -107,6 +107,7 @@ export const DraggableItems = <K extends string, T extends SortableItem<K>>({
             {open && (
                 <Reorder.Group
                     axis="y"
+                    style={{ userSelect: 'none' }}
                     values={localItems}
                     onReorder={setLocalItems}
                 >

--- a/src/renderer/styles/global.scss
+++ b/src/renderer/styles/global.scss
@@ -22,7 +22,6 @@ html {
     background: var(--content-bg);
     font-family: var(--content-font-family);
     font-size: var(--root-font-size);
-    user-select: none;
 }
 
 @media only screen and (max-width: 639px) {


### PR DESCRIPTION
This PR removes the `user-select: none;` rule from body and HTML, instead applying it directly inside of `draggable-items.tsx` (which seems to be the root of everything draggable inside the app).

I haven't been able to find anywhere else where user select would need to be applied, so if you find anywhere where the user selection still shows up, let me know.