### PR TITLE
[bugfix]: switch to UTC for release dates

### DIFF
--- a/src/renderer/components/virtual-table/index.tsx
+++ b/src/renderer/components/virtual-table/index.tsx
@@ -42,6 +42,7 @@ import { NoteCell } from '/@/renderer/components/virtual-table/cells/note-cell';
 import { RowIndexCell } from '/@/renderer/components/virtual-table/cells/row-index-cell';
 import i18n from '/@/i18n/i18n';
 import {
+    formatDateAbsolute,
     formatDateAbsoluteUTC,
     formatDateRelative,
     formatSizeString,
@@ -183,7 +184,7 @@ const tableColumns: { [key: string]: ColDef } = {
             GenericTableHeader(params, { position: 'center' }),
         headerName: i18n.t('table.column.dateAdded'),
         suppressSizeToFit: true,
-        valueFormatter: (params: ValueFormatterParams) => formatDateAbsoluteUTC(params.value),
+        valueFormatter: (params: ValueFormatterParams) => formatDateAbsolute(params.value),
         valueGetter: (params: ValueGetterParams) =>
             params.data ? params.data.createdAt : undefined,
         width: 130,

--- a/src/renderer/components/virtual-table/index.tsx
+++ b/src/renderer/components/virtual-table/index.tsx
@@ -41,7 +41,11 @@ import { useFixedTableHeader } from '/@/renderer/components/virtual-table/hooks/
 import { NoteCell } from '/@/renderer/components/virtual-table/cells/note-cell';
 import { RowIndexCell } from '/@/renderer/components/virtual-table/cells/row-index-cell';
 import i18n from '/@/i18n/i18n';
-import { formatDateAbsolute, formatDateRelative, formatSizeString } from '/@/renderer/utils/format';
+import {
+    formatDateAbsoluteUTC,
+    formatDateRelative,
+    formatSizeString,
+} from '/@/renderer/utils/format';
 import { useTableChange } from '/@/renderer/hooks/use-song-change';
 
 export * from './table-config-dropdown';
@@ -179,7 +183,7 @@ const tableColumns: { [key: string]: ColDef } = {
             GenericTableHeader(params, { position: 'center' }),
         headerName: i18n.t('table.column.dateAdded'),
         suppressSizeToFit: true,
-        valueFormatter: (params: ValueFormatterParams) => formatDateAbsolute(params.value),
+        valueFormatter: (params: ValueFormatterParams) => formatDateAbsoluteUTC(params.value),
         valueGetter: (params: ValueGetterParams) =>
             params.data ? params.data.createdAt : undefined,
         width: 130,
@@ -253,7 +257,7 @@ const tableColumns: { [key: string]: ColDef } = {
             GenericTableHeader(params, { position: 'center' }),
         headerName: i18n.t('table.column.releaseDate'),
         suppressSizeToFit: true,
-        valueFormatter: (params: ValueFormatterParams) => formatDateAbsolute(params.value),
+        valueFormatter: (params: ValueFormatterParams) => formatDateAbsoluteUTC(params.value),
         valueGetter: (params: ValueGetterParams) =>
             params.data ? params.data.releaseDate : undefined,
         width: 130,

--- a/src/renderer/features/albums/components/album-detail-header.tsx
+++ b/src/renderer/features/albums/components/album-detail-header.tsx
@@ -10,7 +10,7 @@ import { LibraryHeader, useSetRating } from '/@/renderer/features/shared';
 import { useContainerQuery } from '/@/renderer/hooks';
 import { AppRoute } from '/@/renderer/router/routes';
 import { useCurrentServer } from '/@/renderer/store';
-import { formatDateAbsolute, formatDurationString } from '/@/renderer/utils';
+import { formatDateAbsoluteUTC, formatDurationString } from '/@/renderer/utils';
 
 interface AlbumDetailHeaderProps {
     background: {
@@ -42,7 +42,7 @@ export const AlbumDetailHeader = forwardRef(
                 id: 'releaseDate',
                 value:
                     detailQuery?.data?.releaseDate &&
-                    `${releasePrefix} ${formatDateAbsolute(detailQuery?.data?.releaseDate)}`,
+                    `${releasePrefix} ${formatDateAbsoluteUTC(detailQuery?.data?.releaseDate)}`,
             },
             {
                 id: 'songCount',
@@ -62,7 +62,7 @@ export const AlbumDetailHeader = forwardRef(
         ];
 
         if (originalDifferentFromRelease) {
-            const formatted = `♫ ${formatDateAbsolute(detailQuery!.data!.originalDate)}`;
+            const formatted = `♫ ${formatDateAbsoluteUTC(detailQuery!.data!.originalDate)}`;
             metadataItems.splice(0, 0, {
                 id: 'originalDate',
                 value: formatted,

--- a/src/renderer/utils/format.tsx
+++ b/src/renderer/utils/format.tsx
@@ -9,6 +9,9 @@ dayjs.extend(relativeTime);
 dayjs.extend(utc);
 
 export const formatDateAbsolute = (key: string | null) =>
+    key ? dayjs(key).format('MMM D, YYYY') : '';
+
+export const formatDateAbsoluteUTC = (key: string | null) =>
     key ? dayjs.utc(key).format('MMM D, YYYY') : '';
 
 export const formatDateRelative = (key: string | null) => (key ? dayjs(key).fromNow() : '');

--- a/src/renderer/utils/format.tsx
+++ b/src/renderer/utils/format.tsx
@@ -8,11 +8,13 @@ import { Rating } from '/@/renderer/components/rating';
 dayjs.extend(relativeTime);
 dayjs.extend(utc);
 
+const DATE_FORMAT = 'MMM D, YYYY';
+
 export const formatDateAbsolute = (key: string | null) =>
-    key ? dayjs(key).format('MMM D, YYYY') : '';
+    key ? dayjs(key).format(DATE_FORMAT) : '';
 
 export const formatDateAbsoluteUTC = (key: string | null) =>
-    key ? dayjs.utc(key).format('MMM D, YYYY') : '';
+    key ? dayjs.utc(key).format(DATE_FORMAT) : '';
 
 export const formatDateRelative = (key: string | null) => (key ? dayjs(key).fromNow() : '');
 

--- a/src/renderer/utils/format.tsx
+++ b/src/renderer/utils/format.tsx
@@ -1,13 +1,15 @@
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
+import utc from 'dayjs/plugin/utc';
 import formatDuration from 'format-duration';
 import type { Album, AlbumArtist, Song } from '/@/renderer/api/types';
 import { Rating } from '/@/renderer/components/rating';
 
 dayjs.extend(relativeTime);
+dayjs.extend(utc);
 
 export const formatDateAbsolute = (key: string | null) =>
-    key ? dayjs(key).format('MMM D, YYYY') : '';
+    key ? dayjs.utc(key).format('MMM D, YYYY') : '';
 
 export const formatDateRelative = (key: string | null) => (key ? dayjs(key).fromNow() : '');
 


### PR DESCRIPTION
This commit switches DayJS to use UTC rather then local time when processing absolute dates, this fixes a bug where albums would show as releasing a day before they really did.

Some quick tests I did:
- Album release (and original) dates are correct.
- `createdAt` and `dateAdded` fields are still correct.

If you see anything wrong let me know, but I've tested every file that uses this function and they all seem to work correctly.