### PR TITLE
Update Navidrome list sort mappings for ND v0.53.2

### DIFF
--- a/src/renderer/api/navidrome.types.ts
+++ b/src/renderer/api/navidrome.types.ts
@@ -199,17 +199,17 @@ export type NDGenreListParams = {
     NDOrder;
 
 export enum NDAlbumListSort {
-    ALBUM_ARTIST = 'albumArtist',
+    ALBUM_ARTIST = 'album_artist',
     ARTIST = 'artist',
     DURATION = 'duration',
     NAME = 'name',
-    PLAY_COUNT = 'playCount',
+    PLAY_COUNT = 'play_count',
     PLAY_DATE = 'play_date',
     RANDOM = 'random',
     RATING = 'rating',
     RECENTLY_ADDED = 'recently_added',
     SONG_COUNT = 'songCount',
-    STARRED = 'starred',
+    STARRED = 'starred_at',
     YEAR = 'max_year',
 }
 
@@ -261,7 +261,7 @@ export type NDSongListParams = {
 
 export enum NDAlbumArtistListSort {
     ALBUM_COUNT = 'albumCount',
-    FAVORITED = 'starred',
+    FAVORITED = 'starred_at',
     NAME = 'name',
     PLAY_COUNT = 'playCount',
     RATING = 'rating',

--- a/src/renderer/api/navidrome.types.ts
+++ b/src/renderer/api/navidrome.types.ts
@@ -353,7 +353,7 @@ export type NDPlaylistListResponse = NDPlaylist[];
 export enum NDPlaylistListSort {
     DURATION = 'duration',
     NAME = 'name',
-    OWNER = 'ownerName',
+    OWNER = 'owner_name',
     PUBLIC = 'public',
     SONG_COUNT = 'songCount',
     UPDATED_AT = 'updatedAt',

--- a/src/renderer/api/navidrome/navidrome-controller.ts
+++ b/src/renderer/api/navidrome/navidrome-controller.ts
@@ -50,7 +50,6 @@ import {
     SimilarSongsArgs,
     Song,
     MoveItemArgs,
-    SongListSort,
 } from '../types';
 import { VersionInfo, getFeatures, hasFeature } from '/@/renderer/api/utils';
 import { ServerFeature, ServerFeatures } from '/@/renderer/api/features-types';
@@ -284,34 +283,6 @@ const getSongList = async (args: SongListArgs): Promise<SongListResponse> => {
 
     if (res.status !== 200) {
         throw new Error('Failed to get song list');
-    }
-
-    if (
-        (query.sortBy === SongListSort.ALBUM || query.sortBy === SongListSort.ALBUM_ARTIST) &&
-        !query.limit
-    ) {
-        const isAlbumArtist = query.sortBy === SongListSort.ALBUM_ARTIST;
-
-        res.body.data.sort((a, b) => {
-            if (isAlbumArtist) {
-                const albumDiff = a.album.localeCompare(b.album);
-                if (albumDiff !== 0) {
-                    return albumDiff;
-                }
-            }
-
-            const discDiff = a.discNumber - b.discNumber;
-            if (discDiff !== 0) {
-                return discDiff;
-            }
-
-            const trackDiff = a.trackNumber - b.trackNumber;
-            if (trackDiff !== 0) {
-                return trackDiff;
-            }
-
-            return a.title.localeCompare(b.title);
-        });
     }
 
     return {


### PR DESCRIPTION
Sort mappings updated in internal Navidrome API:
- https://github.com/navidrome/navidrome/blob/50870d3e6129021551271f0525ec01b2d5610531/persistence/mediafile_repository.go#L42
- https://github.com/navidrome/navidrome/blob/50870d3e6129021551271f0525ec01b2d5610531/persistence/album_repository.go
- https://github.com/navidrome/navidrome/blob/50870d3e6129021551271f0525ec01b2d5610531/persistence/artist_repository.go
- https://github.com/navidrome/navidrome/blob/50870d3e6129021551271f0525ec01b2d5610531/persistence/genre_repository.go

This will be commited following Navidrome release v0.53.2.