### PR TITLE
[fix]: package.json's devEngines property

### DIFF
--- a/package.json
+++ b/package.json
@@ -360,8 +360,16 @@
         "styled-components": "^6"
     },
     "devEngines": {
-        "node": ">=18.x",
-        "npm": ">=7.x"
+        "runtime": {
+            "name": "node",
+            "version": ">=18.x",
+            "onFail": "error"
+        },
+        "packageManager": {
+            "name": "npm",
+            "version": ">=7.x",
+            "onFail": "error"
+        }
     },
     "browserslist": [],
     "electronmon": {


### PR DESCRIPTION
This pull request updates the devEngines property so that it follows the specification on [npm's docs](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#devengines)

Error without this change:
![Code_DD3J8fHuIt](https://github.com/user-attachments/assets/1a34d91b-05e2-44c9-a2b2-f81f3727af7e)
