### PR TITLE
Fix URL encoding on Subsonic

### DIFF
--- a/src/renderer/api/subsonic/subsonic-controller.ts
+++ b/src/renderer/api/subsonic/subsonic-controller.ts
@@ -65,7 +65,7 @@ export const SubsonicController: ControllerEndpoint = {
         const cleanServerUrl = `${url.replace(/\/$/, '')}/rest`;
 
         if (body.legacy) {
-            credential = `u=${body.username}&p=${body.password}`;
+            credential = `u=${encodeURIComponent(body.username)}&p=${encodeURIComponent(body.password)}`;
             credentialParams = {
                 p: body.password,
                 u: body.username,
@@ -73,7 +73,7 @@ export const SubsonicController: ControllerEndpoint = {
         } else {
             const salt = randomString(12);
             const hash = md5(body.password + salt);
-            credential = `u=${body.username}&s=${salt}&t=${hash}`;
+            credential = `u=${encodeURIComponent(body.username)}&s=${encodeURIComponent(salt)}&t=${encodeURIComponent(hash)}`;
             credentialParams = {
                 s: salt,
                 t: hash,

--- a/src/renderer/api/subsonic/subsonic-normalize.ts
+++ b/src/renderer/api/subsonic/subsonic-normalize.ts
@@ -24,15 +24,14 @@ const getCoverArtUrl = (args: {
         return null;
     }
 
-    const url =
+    return (
         `${args.baseUrl}/rest/getCoverArt.view` +
         `?id=${args.coverArtId}` +
-        `&${encodeURIComponent(args.credential || '')}` +
+        `&${args.credential}` +
         '&v=1.13.0' +
         '&c=feishin' +
-        `&size=${size}`;
-
-    return url;
+        `&size=${size}`
+    );
 };
 
 const normalizeSong = (
@@ -49,7 +48,7 @@ const normalizeSong = (
             size: size || 300,
         }) || null;
 
-    const streamUrl = `${server?.url}/rest/stream.view?id=${item.id}&v=1.13.0&c=feishin_${deviceId}&${encodeURIComponent(server?.credential || '')}`;
+    const streamUrl = `${server?.url}/rest/stream.view?id=${item.id}&v=1.13.0&c=feishin_${deviceId}&${server?.credential}`;
 
     return {
         album: item.album || '',


### PR DESCRIPTION
Previous commit (https://github.com/jeffvli/feishin/commit/8ec4551b46ff532d3790f23faa63f7ee472ffa33) has been reverted, as it has encoded even equal signs (=), and and signs (&), which should not have been encoded. Nextcloud Music has subsequently failed to receive separate username and password and has therefore failed whilst authenticating the user.

Example of URL beforehand:
https://cloud.example.com/index.php/apps/music/subsonic/rest/stream.view?id=track-4936&v=1.13.0&c=feishin_&u%3Dtest-test%40example.com%26p%3Dpassword

Example of URL now:
https://cloud.example.com/index.php/apps/music/subsonic/rest/stream.view?id=track-4936&v=1.13.0&c=feishin_&u=test-test%40example.com&p=password

Related to #841