### PR TITLE
fix: fetch album art via Last.fm should use album artist name

### DIFF
--- a/src/renderer/features/discord-rpc/use-discord-rpc.ts
+++ b/src/renderer/features/discord-rpc/use-discord-rpc.ts
@@ -69,10 +69,10 @@ export const useDiscordRpc = () => {
             activity.largeImageKey = song?.imageUrl;
         }
 
-        if (generalSettings.lastfmApiKey && song?.album && song?.artists.length) {
-            console.log('Fetching album info for', song.album, song.artists[0].name);
+        if (generalSettings.lastfmApiKey && song?.album && song?.albumArtists.length) {
+            console.log('Fetching album info for', song.album, song.albumArtists[0].name);
             const albumInfo = await fetch(
-                `https://ws.audioscrobbler.com/2.0/?method=album.getinfo&api_key=${generalSettings.lastfmApiKey}&artist=${encodeURIComponent(song.artistName)}&album=${encodeURIComponent(song.album)}&format=json`,
+                `https://ws.audioscrobbler.com/2.0/?method=album.getinfo&api_key=${generalSettings.lastfmApiKey}&artist=${encodeURIComponent(song.albumArtists[0].name)}&album=${encodeURIComponent(song.album)}&format=json`,
             );
 
             const albumInfoJson = await albumInfo.json();


### PR DESCRIPTION
Track's artist name not always the same with album's artist so it unable to fetch album data for a lot of song, so I just changed it from `artists` to `albumArtists`