### PR TITLE
Decode plaintext credentials before params get re-encoded in ssApiClient

### DIFF
--- a/src/renderer/api/subsonic/subsonic-api.ts
+++ b/src/renderer/api/subsonic/subsonic-api.ts
@@ -295,12 +295,12 @@ export const ssApiClient = (args: {
                 const token = server.credential;
                 const params = token.split(/&?\w=/gm);
 
-                authParams.u = server.username;
+                authParams.u = decodeURIComponent(server.username);
                 if (params?.length === 4) {
                     authParams.s = params[2];
                     authParams.t = params[3];
                 } else if (params?.length === 3) {
-                    authParams.p = params[2];
+                    authParams.p = decodeURIComponent(params[2]);
                 }
             } else {
                 baseUrl = url;


### PR DESCRIPTION
ssApiClient in [subsonic-api.ts](https://github.com/pogmommy/feishin/blob/b348b36eccf1e07dd05ecc13b4cb8941bf2b03b9/src/renderer/api/subsonic/subsonic-api.ts) no longer sends http requests containing double-encoded plaintext login credentials.
I.e. ```p@ssword!``` is now sent as ```p%40ssword%21``` rather than ```p%2540ssword%2521``` in http requests.

In my testing, this change does not affect non-legacy subsonic authentication.

Resolves my open #861 