### PR TITLE
lyrics: add translation lyrics for netease.ts

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -609,6 +609,8 @@
         "mpvExtraParameters_help": "one per line",
         "musicbrainz": "show musicbrainz links",
         "musicbrainz_description": "show links to musicbrainz on artist/album pages, where mbid exists",
+        "neteaseTranslation": "Enable NetEase translations",
+        "neteaseTranslation_description": "When enabled, fetches and displays translated lyrics from NetEase if available.",
         "passwordStore": "passwords/secret store",
         "passwordStore_description": "what password/secret store to use. change this if you are having issues storing passwords.",
         "playbackStyle": "playback style",

--- a/src/i18n/locales/zh-Hans.json
+++ b/src/i18n/locales/zh-Hans.json
@@ -180,6 +180,8 @@
         "followLyric_description": "滚动歌词到当前播放位置",
         "audioExclusiveMode": "音频独占模式",
         "font": "字体",
+        "neteaseTranslation": "启用网易云歌词翻译",
+        "neteaseTranslation_description": "启用后，在获取歌词时将包含并显示网易云音乐提供的翻译（如果存在）。",
         "crossfadeDuration_description": "设置淡入淡出持续时间",
         "audioDevice": "音频设备",
         "enableRemote": "启用远程控制服务器",

--- a/src/main/features/core/lyrics/netease.ts
+++ b/src/main/features/core/lyrics/netease.ts
@@ -68,6 +68,65 @@ interface NetEaseResponse {
     result: Result;
 }
 
+/**
+ * A helper function to intersperse translated lyric lines into an original LRC string.
+ * It finds lines with matching timestamps and inserts the translated line directly
+ * after the original, preserving the full LRC format for both lines.
+ * @param original The original LRC lyric string.
+ * @param translated The translated LRC lyric string.
+ * @returns A new LRC string with translated lines injected, or the original string if no translation is available.
+ */
+function mergeLyrics(original: string | undefined, translated: string | undefined): string | null {
+    if (!original) {
+        return null;
+    }
+    if (!translated) {
+        return original;
+    }
+
+    const lrcLineRegex = /\[(\d{2}:\d{2}\.\d{2,3})\](.*)/;
+    const translatedMap = new Map<string, string>();
+
+    // Parse the translated LRC and store it in a Map for efficient timestamp-based lookups.
+    translated.split('\n').forEach(line => {
+        const match = line.match(lrcLineRegex);
+        if (match) {
+            const timestamp = match[1];
+            const text = match[2].trim();
+            if (text) {
+                translatedMap.set(timestamp, text);
+            }
+        }
+    });
+
+    if (translatedMap.size === 0) {
+        return original;
+    }
+
+    // Iterate through each line of the original LRC. If a translation exists for
+    // the same timestamp, insert it as a new, fully-formatted LRC line.
+    const finalLines = original.split('\n').flatMap(line => {
+        const match = line.match(lrcLineRegex);
+
+        if (match) {
+            const timestamp = match[1];
+            const translatedText = translatedMap.get(timestamp);
+
+            if (translatedText) {
+                // Return an array containing both the original line and the new translated line.
+                // flatMap will flatten this into the final array of lines.
+                const translatedLine = `[${timestamp}]${translatedText}`;
+                return [line, translatedLine];
+            }
+        }
+
+        // If no match or no translation is found, return only the original line.
+        return [line];
+    });
+
+    return finalLines.join('\n');
+}
+
 export async function getLyricsBySongId(songId: string): Promise<null | string> {
     let result: AxiosResponse<any, any>;
     try {
@@ -76,14 +135,17 @@ export async function getLyricsBySongId(songId: string): Promise<null | string> 
                 id: songId,
                 kv: '-1',
                 lv: '-1',
+                tv: '-1',
             },
         });
     } catch (e) {
         console.error('NetEase lyrics request got an error!', e);
         return null;
     }
-
-    return result.data.klyric?.lyric || result.data.lrc?.lyric;
+    const originalLrc = result.data.lrc?.lyric;
+    const translatedLrc = result.data.tlyric?.lyric;
+        // Attempt to merge the original lyrics with available translations.
+    return mergeLyrics(originalLrc, translatedLrc);
 }
 
 export async function getSearchResults(

--- a/src/main/features/core/lyrics/netease.ts
+++ b/src/main/features/core/lyrics/netease.ts
@@ -6,6 +6,7 @@ import {
     LyricSearchQuery,
     LyricSource,
 } from '.';
+import { store } from '../settings';
 import { orderSearchResults } from './shared';
 
 const SEARCH_URL = 'https://music.163.com/api/search/get';
@@ -68,65 +69,6 @@ interface NetEaseResponse {
     result: Result;
 }
 
-/**
- * A helper function to intersperse translated lyric lines into an original LRC string.
- * It finds lines with matching timestamps and inserts the translated line directly
- * after the original, preserving the full LRC format for both lines.
- * @param original The original LRC lyric string.
- * @param translated The translated LRC lyric string.
- * @returns A new LRC string with translated lines injected, or the original string if no translation is available.
- */
-function mergeLyrics(original: string | undefined, translated: string | undefined): string | null {
-    if (!original) {
-        return null;
-    }
-    if (!translated) {
-        return original;
-    }
-
-    const lrcLineRegex = /\[(\d{2}:\d{2}\.\d{2,3})\](.*)/;
-    const translatedMap = new Map<string, string>();
-
-    // Parse the translated LRC and store it in a Map for efficient timestamp-based lookups.
-    translated.split('\n').forEach(line => {
-        const match = line.match(lrcLineRegex);
-        if (match) {
-            const timestamp = match[1];
-            const text = match[2].trim();
-            if (text) {
-                translatedMap.set(timestamp, text);
-            }
-        }
-    });
-
-    if (translatedMap.size === 0) {
-        return original;
-    }
-
-    // Iterate through each line of the original LRC. If a translation exists for
-    // the same timestamp, insert it as a new, fully-formatted LRC line.
-    const finalLines = original.split('\n').flatMap(line => {
-        const match = line.match(lrcLineRegex);
-
-        if (match) {
-            const timestamp = match[1];
-            const translatedText = translatedMap.get(timestamp);
-
-            if (translatedText) {
-                // Return an array containing both the original line and the new translated line.
-                // flatMap will flatten this into the final array of lines.
-                const translatedLine = `[${timestamp}]${translatedText}`;
-                return [line, translatedLine];
-            }
-        }
-
-        // If no match or no translation is found, return only the original line.
-        return [line];
-    });
-
-    return finalLines.join('\n');
-}
-
 export async function getLyricsBySongId(songId: string): Promise<null | string> {
     let result: AxiosResponse<any, any>;
     try {
@@ -142,9 +84,12 @@ export async function getLyricsBySongId(songId: string): Promise<null | string> 
         console.error('NetEase lyrics request got an error!', e);
         return null;
     }
+    const enableTranslation = store.get('enableNeteaseTranslation', true) as boolean;
     const originalLrc = result.data.lrc?.lyric;
+    if (!enableTranslation) {
+        return originalLrc || null;
+    }
     const translatedLrc = result.data.tlyric?.lyric;
-        // Attempt to merge the original lyrics with available translations.
     return mergeLyrics(originalLrc, translatedLrc);
 }
 
@@ -227,4 +172,55 @@ async function getMatchedLyrics(
     }
 
     return firstMatch;
+}
+
+function mergeLyrics(original: string | undefined, translated: string | undefined): null | string {
+    if (!original) {
+        return null;
+    }
+    if (!translated) {
+        return original;
+    }
+
+    const lrcLineRegex = /\[(\d{2}:\d{2}\.\d{2,3})\](.*)/;
+    const translatedMap = new Map<string, string>();
+
+    // Parse the translated LRC and store it in a Map for efficient timestamp-based lookups.
+    translated.split('\n').forEach((line) => {
+        const match = line.match(lrcLineRegex);
+        if (match) {
+            const timestamp = match[1];
+            const text = match[2].trim();
+            if (text) {
+                translatedMap.set(timestamp, text);
+            }
+        }
+    });
+
+    if (translatedMap.size === 0) {
+        return original;
+    }
+
+    // Iterate through each line of the original LRC. If a translation exists for
+    // the same timestamp, insert it as a new, fully-formatted LRC line.
+    const finalLines = original.split('\n').flatMap((line) => {
+        const match = line.match(lrcLineRegex);
+
+        if (match) {
+            const timestamp = match[1];
+            const translatedText = translatedMap.get(timestamp);
+
+            if (translatedText) {
+                // Return an array containing both the original line and the new translated line.
+                // flatMap will flatten this into the final array of lines.
+                const translatedLine = `[${timestamp}]${translatedText}`;
+                return [line, translatedLine];
+            }
+        }
+
+        // If no match or no translation is found, return only the original line.
+        return [line];
+    });
+
+    return finalLines.join('\n');
 }

--- a/src/renderer/features/settings/components/playback/lyric-settings.tsx
+++ b/src/renderer/features/settings/components/playback/lyric-settings.tsx
@@ -103,6 +103,30 @@ export const LyricSettings = () => {
         },
         {
             control: (
+                <Switch
+                    aria-label="Enable NetEase translations"
+                    defaultChecked={settings.enableNeteaseTranslation}
+                    onChange={(e) => {
+                        const isChecked = e.currentTarget.checked;
+                        setSettings({
+                            lyrics: {
+                                ...settings,
+                                enableNeteaseTranslation: e.currentTarget.checked,
+                            },
+                        });
+                        localSettings?.set('enableNeteaseTranslation', isChecked);
+                    }}
+                />
+            ),
+            description: t('setting.neteaseTranslation', {
+                context: 'description',
+                postProcess: 'sentenceCase',
+            }),
+            isHidden: !isElectron(),
+            title: t('setting.neteaseTranslation', { postProcess: 'sentenceCase' }),
+        },
+        {
+            control: (
                 <NumberInput
                     defaultValue={settings.delayMs}
                     onBlur={(e) => {

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -263,6 +263,7 @@ export interface SettingsState {
     lyrics: {
         alignment: 'center' | 'left' | 'right';
         delayMs: number;
+        enableNeteaseTranslation: boolean;
         fetch: boolean;
         follow: boolean;
         fontSize: number;
@@ -445,6 +446,7 @@ const initialState: SettingsState = {
     lyrics: {
         alignment: 'center',
         delayMs: 0,
+        enableNeteaseTranslation: false,
         fetch: false,
         follow: true,
         fontSize: 46,


### PR DESCRIPTION
### What is the motivation for this change?

Currently, the NetEase lyrics provider (`netease.ts`) only fetches the original lyrics (`lrc`) and ignores available translated lyrics (`tlyric`). This prevents users from seeing translations for many songs, especially CJK (Chinese, Japanese, Korean) pop music, even when the translations exist on the NetEase platform.

This PR aims to resolve this issue by enabling support for translated lyrics from NetEase.

### What is the new behavior?

- The `getLyricsBySongId` function in `netease.ts` now fetches both original (`lrc`) and translated (`tlyric`) lyrics from the NetEase API.
- If a translation is found, it is parsed and injected as new, fully-formatted LRC lines directly following their corresponding original lines.
- For example, a single original line `[00:12.34]Original Text` becomes two lines in the output string:
  ```lrc
  [00:12.34]Original Text
  [00:12.34]Translated Text
  ```
 This approach was chosen to keep the function's public contract (Promise<string | null>) unchanged, ensuring minimal and non-breaking changes for higher chances of acceptance.

How to test the new behavior?

Check out this branch.

Run the app in production preview mode (pnpm run start).

Play a song that has a known translation on NetEase (e.g., "Lemon" by Kenshi Yonezu, ID: 536622451).


![图片](https://github.com/user-attachments/assets/9fefe3ff-254f-4a4d-9fff-55cc7524258f)

