### PR TITLE
fix: discord presence not clearing after pausing player

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -514,6 +514,8 @@
         "disableLibraryUpdateOnStartup": "disable checking for new versions on startup",
         "discordApplicationId": "{{discord}} application id",
         "discordApplicationId_description": "the application id for {{discord}} rich presence (defaults to {{defaultId}})",
+        "discordPausedStatus": "show rich presence when paused",
+        "discordPausedStatus_description": "when enabled, status will show when player is paused",
         "discordIdleStatus": "show rich presence idle status",
         "discordIdleStatus_description": "when enabled, update status while player is idle",
         "discordListening": "show status as listening",

--- a/src/renderer/features/discord-rpc/use-discord-rpc.ts
+++ b/src/renderer/features/discord-rpc/use-discord-rpc.ts
@@ -25,7 +25,7 @@ export const useDiscordRpc = () => {
             previous: (number | PlayerStatus | QueueSong | undefined)[],
         ) => {
             // No current song, or we switched to a new track and the player was paused (end of album, etc.)
-            if (!current[0] || (current[0] && current[2] === 'paused' && current[1] === 0))
+            if (!current[0] || (current[0] && current[2] === 'paused') || current[1] === 0)
                 return discordRpc?.clearActivity();
 
             // Handle change detection

--- a/src/renderer/features/discord-rpc/use-discord-rpc.ts
+++ b/src/renderer/features/discord-rpc/use-discord-rpc.ts
@@ -24,8 +24,13 @@ export const useDiscordRpc = () => {
             current: (number | PlayerStatus | QueueSong | undefined)[],
             previous: (number | PlayerStatus | QueueSong | undefined)[],
         ) => {
-            // No current song, or we switched to a new track and the player was paused (end of album, etc.)
-            if (!current[0] || (current[0] && current[2] === 'paused') || current[1] === 0)
+            if (
+                !current[0] || // No track
+                (current[0] &&
+                    current[2] === 'paused' && // Track paused
+                    (discordSettings.showPaused ? current[1] === 0 : true)) || // Beginning of track (only if show paused setting enabled)
+                (discordSettings.showPaused ? false : current[1] === 0) // Beginning of track (only if show paused setting disabled)
+            )
                 return discordRpc?.clearActivity();
 
             // Handle change detection

--- a/src/renderer/features/discord-rpc/use-discord-rpc.ts
+++ b/src/renderer/features/discord-rpc/use-discord-rpc.ts
@@ -127,6 +127,7 @@ export const useDiscordRpc = () => {
         [
             discordSettings.showAsListening,
             discordSettings.showServerImage,
+            discordSettings.showPaused,
             generalSettings.lastfmApiKey,
             lastUniqueId,
         ],

--- a/src/renderer/features/settings/components/window/discord-settings.tsx
+++ b/src/renderer/features/settings/components/window/discord-settings.tsx
@@ -77,6 +77,29 @@ export const DiscordSettings = () => {
         {
             control: (
                 <Switch
+                    checked={settings.showPaused}
+                    onChange={(e) => {
+                        setSettings({
+                            discord: {
+                                ...settings,
+                                showPaused: e.currentTarget.checked,
+                            },
+                        });
+                    }}
+                />
+            ),
+            description: t('setting.discordPausedStatus', {
+                context: 'description',
+                postProcess: 'sentenceCase',
+            }),
+            isHidden: !isElectron(),
+            title: t('setting.discordPausedStatus', {
+                postProcess: 'sentenceCase',
+            }),
+        },
+        {
+            control: (
+                <Switch
                     checked={settings.showAsListening}
                     onChange={(e) => {
                         setSettings({

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -200,6 +200,7 @@ export interface SettingsState {
         clientId: string;
         enabled: boolean;
         showAsListening: boolean;
+        showPaused: boolean;
         showServerImage: boolean;
     };
     font: {
@@ -352,6 +353,7 @@ const initialState: SettingsState = {
         clientId: '1165957668758900787',
         enabled: false,
         showAsListening: false,
+        showPaused: true,
         showServerImage: false,
     },
     font: {


### PR DESCRIPTION
Discord presence was not getting cleared when pausing the player unless it was the beginning of the track, it now clears if:
* No current song
* Player is paused
* Beginning of track

Before:
* No current song
* Player is paused and beginning of track