### PR TITLE
Fix ContextMenu star menu clicking

### DIFF
--- a/src/renderer/features/context-menu/context-menu-provider.tsx
+++ b/src/renderer/features/context-menu/context-menu-provider.tsx
@@ -964,7 +964,12 @@ export const ContextMenuProvider = ({ children }: ContextMenuProviderProps) => {
                                                                 </ContextMenuButton>
                                                             </HoverCard.Target>
                                                             <HoverCard.Dropdown>
-                                                                <Stack gap={0}>
+                                                                <Stack
+                                                                    gap={0}
+                                                                    // Pass in this ref to the stack component as well
+                                                                    // so that it is treated as "inside" for clickOutsideRef
+                                                                    ref={mergedRef}
+                                                                >
                                                                     {contextMenuItems[
                                                                         item.id
                                                                     ].children?.map((child) => (


### PR DESCRIPTION
Resolves #985.
Currently, attempting to click on one of the `set rating` buttons is a no-op. This is because it is considered "outside" the `ContextMenu`, which immediately closes it. Pass in the same merged ref into the body of the `DropDown` component so that it is also treated as "inside".

Making this a PR instead of just a push because I'm not sure if there are side effects.