### PR TITLE
Automatically reconnect to Discord RPC at interval

### DIFF
--- a/src/main/features/core/discord-rpc/index.ts
+++ b/src/main/features/core/discord-rpc/index.ts
@@ -5,12 +5,12 @@ const FEISHIN_DISCORD_APPLICATION_ID = '1165957668758900787';
 
 let client: Client | null = null;
 
-const createClient = (clientId?: string) => {
+const createClient = async (clientId?: string) => {
     client = new Client({
         clientId: clientId || FEISHIN_DISCORD_APPLICATION_ID,
     });
 
-    client.login();
+    await client.login();
 
     return client;
 };
@@ -39,8 +39,8 @@ const quit = () => {
     }
 };
 
-ipcMain.handle('discord-rpc-initialize', (_event, clientId?: string) => {
-    createClient(clientId);
+ipcMain.handle('discord-rpc-initialize', async (_event, clientId?: string) => {
+    await createClient(clientId);
 });
 
 ipcMain.handle('discord-rpc-is-connected', () => {

--- a/src/main/features/core/discord-rpc/index.ts
+++ b/src/main/features/core/discord-rpc/index.ts
@@ -15,6 +15,10 @@ const createClient = (clientId?: string) => {
     return client;
 };
 
+const isConnected = () => {
+    return client?.isConnected;
+};
+
 const setActivity = (activity: SetActivity) => {
     if (client) {
         client.user?.setActivity({
@@ -39,6 +43,10 @@ ipcMain.handle('discord-rpc-initialize', (_event, clientId?: string) => {
     createClient(clientId);
 });
 
+ipcMain.handle('discord-rpc-is-connected', () => {
+    return isConnected();
+});
+
 ipcMain.handle('discord-rpc-set-activity', (_event, activity: SetActivity) => {
     if (client) {
         setActivity(activity);
@@ -58,6 +66,7 @@ ipcMain.handle('discord-rpc-quit', () => {
 export const discordRpc = {
     clearActivity,
     createClient,
+    isConnected,
     quit,
     setActivity,
 };

--- a/src/preload/discord-rpc.ts
+++ b/src/preload/discord-rpc.ts
@@ -6,6 +6,11 @@ const initialize = (clientId: string) => {
     return client;
 };
 
+const isConnected = () => {
+    const isConnected = ipcRenderer.invoke('discord-rpc-is-connected');
+    return isConnected;
+};
+
 const clearActivity = () => {
     ipcRenderer.invoke('discord-rpc-clear-activity');
 };
@@ -21,6 +26,7 @@ const quit = () => {
 export const discordRpc = {
     clearActivity,
     initialize,
+    isConnected,
     quit,
     setActivity,
 };

--- a/src/renderer/features/discord-rpc/use-discord-rpc.ts
+++ b/src/renderer/features/discord-rpc/use-discord-rpc.ts
@@ -136,8 +136,17 @@ export const useDiscordRpc = () => {
     useEffect(() => {
         if (!discordSettings.enabled) return discordRpc?.quit();
 
-        discordRpc?.initialize(discordSettings.clientId);
+        let timeout: any;
+        (async function initialize() {
+            // Checks RPC status every 10 seconds, initializes if needed
+            const isConnected = await discordRpc?.isConnected();
+            if (!isConnected) {
+                discordRpc?.initialize(discordSettings.clientId);
+            }
+            timeout = setTimeout(initialize, 10000);
+        })();
         return () => {
+            clearTimeout(timeout);
             discordRpc?.quit();
         };
     }, [discordSettings.clientId, discordSettings.enabled]);

--- a/src/renderer/features/discord-rpc/use-discord-rpc.ts
+++ b/src/renderer/features/discord-rpc/use-discord-rpc.ts
@@ -121,6 +121,10 @@ export const useDiscordRpc = () => {
                     activity.largeImageKey = 'icon';
                 }
 
+                // Initialize if needed
+                const isConnected = await discordRpc?.isConnected();
+                if (!isConnected) await discordRpc?.initialize(discordSettings.clientId);
+
                 discordRpc?.setActivity(activity);
             }
         },
@@ -129,6 +133,7 @@ export const useDiscordRpc = () => {
             discordSettings.showServerImage,
             discordSettings.showPaused,
             generalSettings.lastfmApiKey,
+            discordSettings.clientId,
             lastUniqueId,
         ],
     );
@@ -136,17 +141,8 @@ export const useDiscordRpc = () => {
     useEffect(() => {
         if (!discordSettings.enabled) return discordRpc?.quit();
 
-        let timeout: any;
-        (async function initialize() {
-            // Checks RPC status every 10 seconds, initializes if needed
-            const isConnected = await discordRpc?.isConnected();
-            if (!isConnected) {
-                discordRpc?.initialize(discordSettings.clientId);
-            }
-            timeout = setTimeout(initialize, 10000);
-        })();
+        discordRpc?.initialize(discordSettings.clientId);
         return () => {
-            clearTimeout(timeout);
             discordRpc?.quit();
         };
     }, [discordSettings.clientId, discordSettings.enabled]);

--- a/src/renderer/features/discord-rpc/use-discord-rpc.ts
+++ b/src/renderer/features/discord-rpc/use-discord-rpc.ts
@@ -141,7 +141,6 @@ export const useDiscordRpc = () => {
     useEffect(() => {
         if (!discordSettings.enabled) return discordRpc?.quit();
 
-        discordRpc?.initialize(discordSettings.clientId);
         return () => {
             discordRpc?.quit();
         };


### PR DESCRIPTION
Currently, if Discord is launched after Feishin or the connection was to suddenly be disconnected, you would have to disable and re-enable the integration or restart Feishin for it to connect again

This creates an interval every 10 seconds to check the connection and reconnects if needed