### PR TITLE
fix discord status clearing when song loops

### DIFF
--- a/src/renderer/features/discord-rpc/use-discord-rpc.ts
+++ b/src/renderer/features/discord-rpc/use-discord-rpc.ts
@@ -26,10 +26,8 @@ export const useDiscordRpc = () => {
         ) => {
             if (
                 !current[0] || // No track
-                (current[0] &&
-                    current[2] === 'paused' && // Track paused
-                    (discordSettings.showPaused ? current[1] === 0 : true)) || // Beginning of track (only if show paused setting enabled)
-                (discordSettings.showPaused ? false : current[1] === 0) // Beginning of track (only if show paused setting disabled)
+                current[1] === 0 || // Start of track
+                (current[2] === 'paused' && !discordSettings.showPaused) // Track paused with show paused setting disabled
             )
                 return discordRpc?.clearActivity();
 
@@ -38,11 +36,13 @@ export const useDiscordRpc = () => {
             const trackChanged = lastUniqueId !== song.uniqueId;
 
             /*
-                1. If we jump more then 1.2 seconds from last state, update status to match
-                2. If the current song id is completely different, update status
-                3. If the player state changed, update status
+                1. If the song has just started, update status
+                2. If we jump more then 1.2 seconds from last state, update status to match
+                3. If the current song id is completely different, update status
+                4. If the player state changed, update status
             */
             if (
+                previous[1] === 0 ||
                 Math.abs((current[1] as number) - (previous[1] as number)) > 1.2 ||
                 trackChanged ||
                 current[2] !== previous[2]


### PR DESCRIPTION
Fixes https://discord.com/channels/922656312888811530/1396995162231800088

Currently, the activity is cleared if the position of the song is 0, this means that the next time it checks if the activity should be updated it will think the song has not changed and not update

Now it checks if the previous song position is 0 and update if so