### PR TITLE
Added a Linux Notes section below MacOS for desktop.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If you're using a Linux device, a `.desktop` file is recommended for easy launch
 
 Download the [latest release (AppImage)](https://github.com/jeffvli/feishin/releases) and [application icon](https://github.com/jeffvli/feishin/blob/development/resources/icon.png?raw=true) to your `~/applications/` folder. This folder may need to be created if it does not already exist.
 
-Rename the AppImage to `Feishin-linux-x86_64.AppImage` and the icon to `Feishin-linux-x86_64.png`.
+Rename the icon to `Feishin-linux-x86_64.png`.
 
 Save the [example desktop file](https://raw.githubusercontent.com/jeffvli/feishin/refs/heads/development/feishin.desktop) as `~/.local/share/applications/feishin.desktop`.
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,24 @@ If you're using a device running macOS 12 (Monterey) or higher, [check here](htt
 
 For media keys to work, you will be prompted to allow Feishin to be a Trusted Accessibility Client. After allowing, you will need to restart Feishin for the privacy settings to take effect.
 
+#### Linux Notes
+
+If you're using a Linux device, a `.desktop` file is recommended for easy launching of Feishin.
+
+The below file can be saved as `~/.local/share/applications/feishin.desktop` and assumes Feishin is downloaded to the `~/.applications/` folder.
+
+```yaml
+[Desktop Entry]
+Name=Feishin
+Comment=An Electron-based music streaming app
+Exec=/home/username/.applications/Feishin-linux-x86_64.AppImage
+Icon=/home/username/.applications/Feishin-linux-x86_64.png
+Terminal=false
+Type=Application
+Categories=AudioVideo;Music;Player;
+StartupNotify=true
+```
+
 ### Web and Docker
 
 Visit [https://feishin.vercel.app](https://feishin.vercel.app) to use the hosted web version of Feishin. The web client only supports the web player backend.

--- a/README.md
+++ b/README.md
@@ -61,19 +61,13 @@ For media keys to work, you will be prompted to allow Feishin to be a Trusted Ac
 
 If you're using a Linux device, a `.desktop` file is recommended for easy launching of Feishin.
 
-The below file can be saved as `~/.local/share/applications/feishin.desktop` and assumes Feishin is downloaded to the `~/.applications/` folder.
+Download the [latest release (AppImage)](https://github.com/jeffvli/feishin/releases) and [application icon](https://github.com/jeffvli/feishin/blob/development/resources/icon.png?raw=true) to your `~/applications/` folder. This folder may need to be created if it does not already exist.
 
-```yaml
-[Desktop Entry]
-Name=Feishin
-Comment=An Electron-based music streaming app
-Exec=/home/username/.applications/Feishin-linux-x86_64.AppImage
-Icon=/home/username/.applications/Feishin-linux-x86_64.png
-Terminal=false
-Type=Application
-Categories=AudioVideo;Music;Player;
-StartupNotify=true
-```
+Rename the AppImage to `Feishin-linux-x86_64.AppImage` and the icon to `Feishin-linux-x86_64.png`.
+
+Save the [example desktop file](https://raw.githubusercontent.com/jeffvli/feishin/refs/heads/development/feishin.desktop) as `~/.local/share/applications/feishin.desktop`.
+
+You will now see Feishin show up in your menu.
 
 ### Web and Docker
 

--- a/feishin.desktop
+++ b/feishin.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Feishin
 Comment=An Electron-based music streaming app
-Exec=/home/username/.applications/Feishin-linux-x86_64.AppImage
+Exec=/home/username/.applications/Feishin-linux-x86_64.AppImage --enable-features=UseOzonePlatform,WaylandWindowDecorations --ozone-platform-hint=auto
 Icon=/home/username/.applications/Feishin-linux-x86_64.png
 Terminal=false
 Type=Application

--- a/feishin.desktop
+++ b/feishin.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Feishin
+Comment=An Electron-based music streaming app
+Exec=/home/username/.applications/Feishin-linux-x86_64.AppImage
+Icon=/home/username/.applications/Feishin-linux-x86_64.png
+Terminal=false
+Type=Application
+Categories=AudioVideo;Music;Player;
+StartupNotify=true

--- a/jeffvli-feishin.desktop
+++ b/jeffvli-feishin.desktop
@@ -5,5 +5,5 @@ Exec=/home/username/.applications/Feishin-linux-x86_64.AppImage
 Icon=/home/username/.applications/Feishin-linux-x86_64.png
 Terminal=false
 Type=Application
-Categories=AudioVideo;Music;Player;
+Categories=AudioVideo;Audio;Music;Player;
 StartupNotify=true

--- a/jeffvli-feishin.desktop
+++ b/jeffvli-feishin.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Feishin
 Comment=An Electron-based music streaming app
-Exec=/home/username/.applications/Feishin-linux-x86_64.AppImage --enable-features=UseOzonePlatform,WaylandWindowDecorations --ozone-platform-hint=auto
+Exec="/home/username/.applications/Feishin-linux-x86_64.AppImage" --enable-features=UseOzonePlatform,WaylandWindowDecorations --ozone-platform-hint=auto
 Icon=/home/username/.applications/Feishin-linux-x86_64.png
 Terminal=false
 Type=Application

--- a/jeffvli-feishin.desktop
+++ b/jeffvli-feishin.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Feishin
 Comment=An Electron-based music streaming app
-Exec="/home/username/.applications/Feishin-linux-x86_64.AppImage" --enable-features=UseOzonePlatform,WaylandWindowDecorations --ozone-platform-hint=auto
+Exec=/home/username/.applications/Feishin-linux-x86_64.AppImage
 Icon=/home/username/.applications/Feishin-linux-x86_64.png
 Terminal=false
 Type=Application


### PR DESCRIPTION
This adds a section to the README file indicating the AppImage is the recommended way to use Feishin on Linux.

It also provides an example `.desktop` file.