### PR TITLE
Add qm-music to an OpenSubsonic compatible server list

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Feishin supports any music server that implements a [Navidrome](https://www.navi
     - [LMS](https://github.com/epoupon/lms)
     - [Nextcloud Music](https://apps.nextcloud.com/apps/music)
     - [Supysonic](https://github.com/spl0k/supysonic)
+    - [Qm-Music](https://github.com/chenqimiao/qm-music)
     - More (?)
 
 ### I have the issue "The SUID sandbox helper binary was found, but is not configured correctly" on Linux


### PR DESCRIPTION
**Feishin is really an absolutely awesome music player. I use it daily in conjunction with my self-hosted OpenSubsonic music server (qm-music).** 

**Qm-music is a self-hosted service that follows the OpenSubsonic standard. Since I started using this combination daily, I feel the experience is exceptionally good. I want to share this setup with more people, so I'd like to add it to the README listing. I hope to get your agreement! Thank you so much!**