### PR TITLE
fix song getting added twice to queue when using tab navigation in command palette

### DIFF
--- a/src/renderer/features/search/components/library-command-item.tsx
+++ b/src/renderer/features/search/components/library-command-item.tsx
@@ -37,6 +37,7 @@ export const LibraryCommandItem = ({
     const handlePlay = useCallback(
         (e: SyntheticEvent, id: string, playType: Play) => {
             e.stopPropagation();
+            e.preventDefault();
             handlePlayQueueAdd?.({
                 byItemType: {
                     id: [id],


### PR DESCRIPTION
with #1024 there was a bug where a song would be added twice when using keyboard navigation on add last and add next.
this PR fixes it.