### PR TITLE
Feature: improve add to playlist UX

### DIFF
--- a/src/renderer/features/playlists/components/add-to-playlist-context-modal.tsx
+++ b/src/renderer/features/playlists/components/add-to-playlist-context-modal.tsx
@@ -36,6 +36,7 @@ export const AddToPlaylistContextModal = ({
     const { albumId, artistId, genreId, songId } = innerProps;
     const server = useCurrentServer();
     const [isLoading, setIsLoading] = useState(false);
+    const [isDropdownOpened, setIsDropdownOpened] = useState(true);
 
     const addToPlaylistMutation = useAddToPlaylist({});
 
@@ -235,7 +236,13 @@ export const AddToPlaylistContextModal = ({
                         })}
                         searchable
                         size="md"
+                        dropdownOpened={isDropdownOpened}
                         {...form.getInputProps('playlistId')}
+                        onClick={() => setIsDropdownOpened(true)}
+                        onChange={(e) => {
+                            setIsDropdownOpened(false);
+                            form.getInputProps('playlistId').onChange(e);
+                        }}
                     />
                     <Switch
                         label={t('form.addToPlaylist.input', {


### PR DESCRIPTION
## Description
Currently the UX behaviour of the add to playlist is not that nice. I believe most of the people will only add one song to a playlist at a time. Currently the behaviour of the add to playlist is as follow:
1. right click to open context menu
2. click add to playlist
3. click the multiselect box
4. select the playlist
5. click again the multiselect box to close it
6. click add

When i'm arranging my playlist. The steps 3-5 is apparently very tiring especially when i just created a new set of songs for a playlist. So in this PR, i change the behaviour:

1. right click to open context menu
2. click add to playlist, the multiselect opened right away
4. select the playlist, the multiselect automatically closed
5. click add

## Proof Of Work
![feishin](https://github.com/user-attachments/assets/e655629f-1ab2-4c66-80af-f05d31407410)

