### PR TITLE
cleanup notification text

### DIFF
--- a/src/renderer/features/player/hooks/use-scrobble.ts
+++ b/src/renderer/features/player/hooks/use-scrobble.ts
@@ -108,11 +108,11 @@ export const useScrobble = () => {
                     ) {
                         const artists =
                             currentSong.artists?.length > 0
-                                ? currentSong.artists.map((artist) => artist.name).join(', ')
+                                ? currentSong.artists.map((artist) => artist.name).join(' · ')
                                 : currentSong.artistName;
 
-                        new Notification(`Now playing ${currentSong.name}`, {
-                            body: `by ${artists} on ${currentSong.album}`,
+                        new Notification(`${currentSong.name}`, {
+                            body: `${artists}\n${currentSong.album}`,
                             icon: currentSong.imageUrl || undefined,
                         });
                     }


### PR DESCRIPTION
This does a slight cleanup on the Now playing notifications as mentioned on Discord:

* The notification text isn't localised and would be a general PITA to localise in the first place
* The whole point of this notification showing up is that the song is now playing, meaning "Now playing" in the text is redundant and therefore unnecessary
* I don't know any other music player notification that shows this, for reference this is [DeaDBeeF](https://github.com/DeaDBeeF-Player/deadbeef):
    <img width="341" height="111" alt="image" src="https://github.com/user-attachments/assets/addef073-af11-47b5-ac5f-252a9edc7366" />
* Formatted the layout to mimic the in-player Now Playing display

~~Note I didn't test this with Feishin itself cause I don't currently have a setup to actually compile it, but~~ I did test the strings with `notify-send` and it worked just fine:
<img width="341" height="133" alt="image" src="https://github.com/user-attachments/assets/82820661-0181-47c8-a7ce-37dbca0aa88f" />

Tested with CI artifact and works as expected.
Can't test Windows or Mac though.