### PR TITLE
fix: electron menu bar for darwin devices

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -489,7 +489,10 @@ async function createWindow(first = true): Promise<void> {
 
     const menuBuilder = new MenuBuilder(mainWindow);
     menuBuilder.buildMenu();
-    Menu.setApplicationMenu(null);
+
+    if (process.platform !== 'darwin') {
+        Menu.setApplicationMenu(null);
+    }
 
     // Open URLs in the user's browser
     mainWindow.webContents.setWindowOpenHandler((edata) => {


### PR DESCRIPTION
Since @jeffvli's commit 20debb0 in the v0.20.0, it completely disabled any `cmd`+`key` shortcut in the entire app, including quit, copy, paste, select all, and so on : 

<img width="405" height="241" alt="image" src="https://github.com/user-attachments/assets/50d5db1e-b726-4f51-b5a8-02cb5afac4be" />
<img width="378" height="235" alt="image" src="https://github.com/user-attachments/assets/81c83344-ca2e-4a85-a8a1-360521fe06a9" />

(screenshots without and with the fix)

Since the menu bar is not included in the electron window on Darwin devices, issue #1041 does not apply and is therefore a regression.

I fixed this by applying menu bar masking only to non-Darwin devices.

~~I used `setMenuBarVisibility` to allow non-Darwin users who wish to do so to use the menu bar if necessary. By default, it will be invisible and can be redisplayed using the `Alt` key.~~

This restores all shortcuts and benefits in terms of convenience and accessibility.

Not to mention: it allows you to paste extremely complicated passwords from password managers when entering server information, for example.