### PR TITLE
feat: add context menu on left controls and sidebar image

### DIFF
--- a/src/renderer/features/player/components/left-controls.tsx
+++ b/src/renderer/features/player/components/left-controls.tsx
@@ -46,6 +46,11 @@ export const LeftControls = () => {
     );
 
     const handleToggleFullScreenPlayer = (e?: KeyboardEvent | MouseEvent<HTMLDivElement>) => {
+        // don't toggle if right click
+        if (e && 'button' in e && e.button === 2) {
+            return;
+        }
+
         e?.stopPropagation();
         setFullScreenPlayerStore({ expanded: !isFullScreenPlayerExpanded });
     };
@@ -53,6 +58,15 @@ export const LeftControls = () => {
     const handleToggleSidebarImage = (e?: MouseEvent<HTMLButtonElement>) => {
         e?.stopPropagation();
         setSideBar({ image: true });
+    };
+
+    const handleToggleContextMenu = (e: MouseEvent<HTMLDivElement>) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        if (isSongDefined && !isFullScreenPlayerExpanded) {
+            handleGeneralContextMenu(e, [currentSong!]);
+        }
     };
 
     const stopPropagation = (e?: MouseEvent) => e?.stopPropagation();
@@ -79,6 +93,7 @@ export const LeftControls = () => {
                                 initial={{ opacity: 0, x: -50 }}
                                 key="playerbar-image"
                                 onClick={handleToggleFullScreenPlayer}
+                                onContextMenu={handleToggleContextMenu}
                                 role="button"
                                 transition={{ duration: 0.2, ease: 'easeIn' }}
                             >
@@ -127,6 +142,7 @@ export const LeftControls = () => {
                                 component={Link}
                                 fw={500}
                                 isLink
+                                onContextMenu={handleToggleContextMenu} // Ajout du clic droit
                                 overflow="hidden"
                                 to={AppRoute.NOW_PLAYING}
                             >


### PR DESCRIPTION
On many platforms, right-clicking on the cover or title of a song displays the classic context menu, as shown when clicking on the small (and not very accessible) button next to the song title.
This provides an intuitive access to the context menu and its options.

I suggest adding this context menu when right-clicking on the cover (in collapsed and expanded mode) and the title. As is the case on various platforms, clicking outside the context menu does not cancel the action of the element behind it, so if the user wants to close the context menu, they must click in a neutral area. I imagine this is acceptable behavior because it is in line with the usage habits specific to the design systems of many applications.

Here are some screenshots:

*Right click on title*
------------------------------------
<img width="447" height="573" alt="image" src="https://github.com/user-attachments/assets/b026469c-bd9d-4f3b-bc5a-db2bd00694c4" />

*Right click on collapsed image*
------------------------------------
<img width="366" height="583" alt="image" src="https://github.com/user-attachments/assets/43bf7a87-326f-4495-b1fd-dea5298815b5" />

*Right click on expanded image*
------------------------------------
<img width="442" height="816" alt="image" src="https://github.com/user-attachments/assets/db3db0eb-8801-461a-858d-26ae0d04d04d" />
