### PR TITLE
Clicking outside a context menu closes it

### DIFF
--- a/src/renderer/features/context-menu/context-menu-provider.tsx
+++ b/src/renderer/features/context-menu/context-menu-provider.tsx
@@ -114,7 +114,6 @@ export const ContextMenuProvider = ({ children }: ContextMenuProviderProps) => {
     const clickOutsideRef = useClickOutside(
         () => setOpened(false),
         ['mousedown', 'touchstart'],
-        [contextMenuRef, ratingsRef],
     );
 
     const viewport = useViewportSize();


### PR DESCRIPTION
Fixes https://github.com/jeffvli/feishin/issues/1120.

As title says, clicking outside of any context menu now closes the context menu.