### PR TITLE
Add autodiscovery for Jellyfin servers

### DIFF
--- a/src/main/features/core/autodiscover/index.ts
+++ b/src/main/features/core/autodiscover/index.ts
@@ -1,11 +1,16 @@
 import { createSocket } from 'dgram';
 import { ipcMain } from 'electron';
+
 import { DiscoveredServerItem, ServerType } from '/@/shared/types/types';
 
 type JellyfinResponse = {
     Address: string;
     Id: string;
     Name: string;
+};
+
+function discoverAll(reply: (server: DiscoveredServerItem) => void) {
+    return Promise.all([discoverJellyfin(reply)]);
 }
 
 function discoverJellyfin(reply: (server: DiscoveredServerItem) => void) {
@@ -15,8 +20,8 @@ function discoverJellyfin(reply: (server: DiscoveredServerItem) => void) {
             const response: JellyfinResponse = JSON.parse(msg.toString('utf-8'));
 
             reply({
-                type: ServerType.JELLYFIN,
                 name: response.Name,
+                type: ServerType.JELLYFIN,
                 url: response.Address,
             });
         } catch (e) {
@@ -38,17 +43,11 @@ function discoverJellyfin(reply: (server: DiscoveredServerItem) => void) {
     });
 }
 
-function discoverAll(reply: (server: DiscoveredServerItem) => void) {
-    return Promise.all([
-        discoverJellyfin(reply),
-    ]);
-}
-
 ipcMain.on('autodiscover-ping', (ev) => {
     if (ev.ports.length === 0) throw new Error('Expected a port to stream autodiscovery results');
     const port = ev.ports[0];
 
-    discoverAll(result => port.postMessage(result))
+    discoverAll((result) => port.postMessage(result))
         .then(() => port.close())
         .catch((err) => console.error(err));
 });

--- a/src/main/features/core/autodiscover/index.ts
+++ b/src/main/features/core/autodiscover/index.ts
@@ -1,0 +1,54 @@
+import { createSocket } from 'dgram';
+import { ipcMain } from 'electron';
+import { DiscoveredServerItem, ServerType } from '/@/shared/types/types';
+
+type JellyfinResponse = {
+    Address: string;
+    Id: string;
+    Name: string;
+}
+
+function discoverJellyfin(reply: (server: DiscoveredServerItem) => void) {
+    const sock = createSocket('udp4');
+    sock.on('message', (msg) => {
+        try {
+            const response: JellyfinResponse = JSON.parse(msg.toString('utf-8'));
+
+            reply({
+                type: ServerType.JELLYFIN,
+                name: response.Name,
+                url: response.Address,
+            });
+        } catch (e) {
+            // Got a spurious response, ignore?
+            console.error(e);
+        }
+    });
+
+    sock.bind(() => {
+        sock.setBroadcast(true);
+        sock.send('who is JellyfinServer?', 7359, '255.255.255.255');
+    });
+
+    return new Promise<void>((resolve) => {
+        setTimeout(() => {
+            sock.close();
+            resolve();
+        }, 3000);
+    });
+}
+
+function discoverAll(reply: (server: DiscoveredServerItem) => void) {
+    return Promise.all([
+        discoverJellyfin(reply),
+    ]);
+}
+
+ipcMain.on('autodiscover-ping', (ev) => {
+    if (ev.ports.length === 0) throw new Error('Expected a port to stream autodiscovery results');
+    const port = ev.ports[0];
+
+    discoverAll(result => port.postMessage(result))
+        .then(() => port.close())
+        .catch((err) => console.error(err));
+});

--- a/src/main/features/core/autodiscover/index.ts
+++ b/src/main/features/core/autodiscover/index.ts
@@ -32,6 +32,8 @@ function discoverJellyfin(reply: (server: DiscoveredServerItem) => void) {
 
     sock.bind(() => {
         sock.setBroadcast(true);
+        // Send a broadcast packet to both loopback and default route, allowing discovery of same-machine instances
+        sock.send('who is JellyfinServer?', 7359, '127.255.255.255');
         sock.send('who is JellyfinServer?', 7359, '255.255.255.255');
     });
 

--- a/src/main/features/core/index.ts
+++ b/src/main/features/core/index.ts
@@ -1,3 +1,4 @@
+import './autodiscover';
 import './lyrics';
 import './player';
 import './remote';

--- a/src/preload/autodiscover.ts
+++ b/src/preload/autodiscover.ts
@@ -6,10 +6,7 @@ const discover = (onReply: (server: DiscoveredServerItem) => void): Promise<void
 
     ipcRenderer.postMessage('autodiscover-ping', {}, [remote]);
 
-    console.log("discover() called");
-
     local.onmessage = (ev) => {
-        console.log(ev);
         onReply(ev.data);
     }
 

--- a/src/preload/autodiscover.ts
+++ b/src/preload/autodiscover.ts
@@ -1,0 +1,26 @@
+import { DiscoveredServerItem } from '../shared/types/types';
+import { ipcRenderer } from 'electron';
+
+const discover = (onReply: (server: DiscoveredServerItem) => void): Promise<void> => {
+    const { port1: local, port2: remote } = new MessageChannel();
+
+    ipcRenderer.postMessage('autodiscover-ping', {}, [remote]);
+
+    console.log("discover() called");
+
+    local.onmessage = (ev) => {
+        console.log(ev);
+        onReply(ev.data);
+    }
+
+    return new Promise<void>(resolve => {
+        local.addEventListener('close', () => resolve());
+    });
+}
+
+export const autodiscover = {
+    discover,
+};
+
+export type AutoDiscover = typeof autodiscover;
+

--- a/src/preload/autodiscover.ts
+++ b/src/preload/autodiscover.ts
@@ -1,5 +1,6 @@
-import { DiscoveredServerItem } from '../shared/types/types';
 import { ipcRenderer } from 'electron';
+
+import { DiscoveredServerItem } from '../shared/types/types';
 
 const discover = (onReply: (server: DiscoveredServerItem) => void): Promise<void> => {
     const { port1: local, port2: remote } = new MessageChannel();
@@ -8,16 +9,15 @@ const discover = (onReply: (server: DiscoveredServerItem) => void): Promise<void
 
     local.onmessage = (ev) => {
         onReply(ev.data);
-    }
+    };
 
-    return new Promise<void>(resolve => {
+    return new Promise<void>((resolve) => {
         local.addEventListener('close', () => resolve());
     });
-}
+};
 
 export const autodiscover = {
     discover,
 };
 
 export type AutoDiscover = typeof autodiscover;
-

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,7 @@
 import { electronAPI } from '@electron-toolkit/preload';
 import { contextBridge } from 'electron';
 
+import { autodiscover } from './autodiscover';
 import { browser } from './browser';
 import { discordRpc } from './discord-rpc';
 import { ipc } from './ipc';
@@ -13,6 +14,7 @@ import { utils } from './utils';
 
 // Custom APIs for renderer
 const api = {
+    autodiscover,
     browser,
     discordRpc,
     ipc,

--- a/src/renderer/features/servers/components/add-server-form.tsx
+++ b/src/renderer/features/servers/components/add-server-form.tsx
@@ -3,7 +3,7 @@ import { useFocusTrap } from '@mantine/hooks';
 import { closeAllModals } from '@mantine/modals';
 import isElectron from 'is-electron';
 import { nanoid } from 'nanoid/non-secure';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { api } from '/@/renderer/api';
@@ -14,6 +14,7 @@ import { useAuthStoreActions } from '/@/renderer/store';
 import { Button } from '/@/shared/components/button/button';
 import { Checkbox } from '/@/shared/components/checkbox/checkbox';
 import { Group } from '/@/shared/components/group/group';
+import { Paper } from '/@/shared/components/paper/paper';
 import { PasswordInput } from '/@/shared/components/password-input/password-input';
 import { SegmentedControl } from '/@/shared/components/segmented-control/segmented-control';
 import { Stack } from '/@/shared/components/stack/stack';
@@ -21,12 +22,35 @@ import { TextInput } from '/@/shared/components/text-input/text-input';
 import { Text } from '/@/shared/components/text/text';
 import { toast } from '/@/shared/components/toast/toast';
 import { AuthenticationResponse } from '/@/shared/types/domain-types';
-import { ServerType, toServerType } from '/@/shared/types/types';
+import { DiscoveredServerItem, ServerType, toServerType } from '/@/shared/types/types';
 
+const autodiscover = isElectron() ? window.api.autodiscover : null;
 const localSettings = isElectron() ? window.api.localSettings : null;
+
+function useAutodiscovery() {
+    const [isDone, setDone] = useState(false);
+    const [servers, setServers] = useState<DiscoveredServerItem[]>([]);
+
+    useEffect(() => {
+        setServers([]);
+
+        autodiscover?.discover(newServer => {
+            setServers(tail => [...tail, newServer]);
+        }).then(() => {
+            setDone(true);
+        });
+    }, []);
+
+    return { isDone, servers };
+}
 
 interface AddServerFormProps {
     onCancel: (() => void) | null;
+}
+
+interface ServerDetails {
+    name: string;
+    icon: string;
 }
 
 function ServerIconWithLabel({ icon, label }: { icon: string; label: string }) {
@@ -38,26 +62,35 @@ function ServerIconWithLabel({ icon, label }: { icon: string; label: string }) {
     );
 }
 
-const SERVER_TYPES = [
-    {
-        label: <ServerIconWithLabel icon={JellyfinIcon} label="Jellyfin" />,
-        value: ServerType.JELLYFIN,
+const SERVER_TYPES: Record<ServerType, ServerDetails> = {
+    [ServerType.JELLYFIN]: {
+        name: "Jellyfin",
+        icon: JellyfinIcon,
     },
-    {
-        label: <ServerIconWithLabel icon={NavidromeIcon} label="Navidrome" />,
-        value: ServerType.NAVIDROME,
+    [ServerType.NAVIDROME]: {
+        name: "Navidrome",
+        icon: NavidromeIcon,
     },
-    {
-        label: <ServerIconWithLabel icon={SubsonicIcon} label="OpenSubsonic" />,
-        value: ServerType.SUBSONIC,
+    [ServerType.SUBSONIC]: {
+        name: "OpenSubsonic",
+        icon: SubsonicIcon,
     },
-];
+};
+
+const ALL_SERVERS = Object.keys(SERVER_TYPES).map(serverType => {
+    const info = SERVER_TYPES[serverType];
+    return {
+        label: <ServerIconWithLabel icon={info.icon} label={info.name} />,
+        value: serverType,
+    };
+});
 
 export const AddServerForm = ({ onCancel }: AddServerFormProps) => {
     const { t } = useTranslation();
     const focusTrapRef = useFocusTrap(true);
     const [isLoading, setIsLoading] = useState(false);
     const { addServer, setCurrentServer } = useAuthStoreActions();
+    const { servers: discovered } = useAutodiscovery();
 
     const form = useForm({
         initialValues: {
@@ -84,6 +117,10 @@ export const AddServerForm = ({ onCancel }: AddServerFormProps) => {
               window.SERVER_URL) || false;
 
     const isSubmitDisabled = !form.values.name || !form.values.url || !form.values.username;
+
+    const fillServerDetails = (server: DiscoveredServerItem) => {
+        form.setValues({ ...server });
+    };
 
     const handleSubmit = form.onSubmit(async (values) => {
         const authFunction = api.controller.authenticate;
@@ -150,11 +187,24 @@ export const AddServerForm = ({ onCancel }: AddServerFormProps) => {
         return setIsLoading(false);
     });
 
-    return (
+    return (<>
+        <Stack>
+            {discovered.map(server =>
+                <Paper key={server.url} p="10px">
+                    <Group>
+                        <img height="32" width="32" src={SERVER_TYPES[server.type].icon} />
+                        <div style={{cursor: "pointer"}} onClick={() => fillServerDetails(server)}>
+                            <Text fw={700}>{server.name}</Text>
+                            <Text>{SERVER_TYPES[server.type].name} server at {server.url}</Text>
+                        </div>
+                    </Group>
+                </Paper>
+            )}
+        </Stack>
         <form onSubmit={handleSubmit}>
             <Stack m={5} ref={focusTrapRef}>
                 <SegmentedControl
-                    data={SERVER_TYPES}
+                    data={ALL_SERVERS}
                     disabled={Boolean(serverLock)}
                     p="md"
                     withItemsBorders={false}
@@ -230,5 +280,5 @@ export const AddServerForm = ({ onCancel }: AddServerFormProps) => {
                 </Group>
             </Stack>
         </form>
-    );
+    </>);
 };

--- a/src/renderer/features/servers/components/add-server-form.tsx
+++ b/src/renderer/features/servers/components/add-server-form.tsx
@@ -27,30 +27,13 @@ import { DiscoveredServerItem, ServerType, toServerType } from '/@/shared/types/
 const autodiscover = isElectron() ? window.api.autodiscover : null;
 const localSettings = isElectron() ? window.api.localSettings : null;
 
-function useAutodiscovery() {
-    const [isDone, setDone] = useState(false);
-    const [servers, setServers] = useState<DiscoveredServerItem[]>([]);
-
-    useEffect(() => {
-        setServers([]);
-
-        autodiscover?.discover(newServer => {
-            setServers(tail => [...tail, newServer]);
-        }).then(() => {
-            setDone(true);
-        });
-    }, []);
-
-    return { isDone, servers };
-}
-
 interface AddServerFormProps {
     onCancel: (() => void) | null;
 }
 
 interface ServerDetails {
-    name: string;
     icon: string;
+    name: string;
 }
 
 function ServerIconWithLabel({ icon, label }: { icon: string; label: string }) {
@@ -62,22 +45,41 @@ function ServerIconWithLabel({ icon, label }: { icon: string; label: string }) {
     );
 }
 
+function useAutodiscovery() {
+    const [isDone, setDone] = useState(false);
+    const [servers, setServers] = useState<DiscoveredServerItem[]>([]);
+
+    useEffect(() => {
+        setServers([]);
+
+        autodiscover
+            ?.discover((newServer) => {
+                setServers((tail) => [...tail, newServer]);
+            })
+            .then(() => {
+                setDone(true);
+            });
+    }, []);
+
+    return { isDone, servers };
+}
+
 const SERVER_TYPES: Record<ServerType, ServerDetails> = {
     [ServerType.JELLYFIN]: {
-        name: "Jellyfin",
         icon: JellyfinIcon,
+        name: 'Jellyfin',
     },
     [ServerType.NAVIDROME]: {
-        name: "Navidrome",
         icon: NavidromeIcon,
+        name: 'Navidrome',
     },
     [ServerType.SUBSONIC]: {
-        name: "OpenSubsonic",
         icon: SubsonicIcon,
+        name: 'OpenSubsonic',
     },
 };
 
-const ALL_SERVERS = Object.keys(SERVER_TYPES).map(serverType => {
+const ALL_SERVERS = Object.keys(SERVER_TYPES).map((serverType) => {
     const info = SERVER_TYPES[serverType];
     return {
         label: <ServerIconWithLabel icon={info.icon} label={info.name} />,
@@ -187,98 +189,105 @@ export const AddServerForm = ({ onCancel }: AddServerFormProps) => {
         return setIsLoading(false);
     });
 
-    return (<>
-        <Stack>
-            {discovered.map(server =>
-                <Paper key={server.url} p="10px">
-                    <Group>
-                        <img height="32" width="32" src={SERVER_TYPES[server.type].icon} />
-                        <div style={{cursor: "pointer"}} onClick={() => fillServerDetails(server)}>
-                            <Text fw={700}>{server.name}</Text>
-                            <Text>{SERVER_TYPES[server.type].name} server at {server.url}</Text>
-                        </div>
-                    </Group>
-                </Paper>
-            )}
-        </Stack>
-        <form onSubmit={handleSubmit}>
-            <Stack m={5} ref={focusTrapRef}>
-                <SegmentedControl
-                    data={ALL_SERVERS}
-                    disabled={Boolean(serverLock)}
-                    p="md"
-                    withItemsBorders={false}
-                    {...form.getInputProps('type')}
-                />
-                <Group grow>
-                    <TextInput
-                        data-autofocus
-                        disabled={Boolean(serverLock)}
-                        label={t('form.addServer.input', {
-                            context: 'name',
-                            postProcess: 'titleCase',
-                        })}
-                        {...form.getInputProps('name')}
-                    />
-                    <TextInput
-                        disabled={Boolean(serverLock)}
-                        label={t('form.addServer.input', {
-                            context: 'url',
-                            postProcess: 'titleCase',
-                        })}
-                        {...form.getInputProps('url')}
-                    />
-                </Group>
-                <TextInput
-                    label={t('form.addServer.input', {
-                        context: 'username',
-                        postProcess: 'titleCase',
-                    })}
-                    {...form.getInputProps('username')}
-                />
-                <PasswordInput
-                    label={t('form.addServer.input', {
-                        context: 'password',
-                        postProcess: 'titleCase',
-                    })}
-                    {...form.getInputProps('password')}
-                />
-                {localSettings && form.values.type === ServerType.NAVIDROME && (
-                    <Checkbox
-                        label={t('form.addServer.input', {
-                            context: 'savePassword',
-                            postProcess: 'titleCase',
-                        })}
-                        {...form.getInputProps('savePassword', {
-                            type: 'checkbox',
-                        })}
-                    />
-                )}
-                {form.values.type === ServerType.SUBSONIC && (
-                    <Checkbox
-                        label={t('form.addServer.input', {
-                            context: 'legacyAuthentication',
-                            postProcess: 'titleCase',
-                        })}
-                        {...form.getInputProps('legacyAuth', { type: 'checkbox' })}
-                    />
-                )}
-                <Group grow justify="flex-end">
-                    {onCancel && (
-                        <Button onClick={onCancel} variant="subtle">
-                            {t('common.cancel', { postProcess: 'titleCase' })}
-                        </Button>
-                    )}
-                    <Button
-                        disabled={isSubmitDisabled}
-                        loading={isLoading}
-                        type="submit"
-                        variant="filled"
-                    >
-                        {t('common.add', { postProcess: 'titleCase' })}
-                    </Button>
-                </Group>
+    return (
+        <>
+            <Stack>
+                {discovered.map((server) => (
+                    <Paper key={server.url} p="10px">
+                        <Group>
+                            <img height="32" src={SERVER_TYPES[server.type].icon} width="32" />
+                            <div
+                                onClick={() => fillServerDetails(server)}
+                                style={{ cursor: 'pointer' }}
+                            >
+                                <Text fw={700}>{server.name}</Text>
+                                <Text>
+                                    {SERVER_TYPES[server.type].name} server at {server.url}
+                                </Text>
+                            </div>
+                        </Group>
+                    </Paper>
+                ))}
             </Stack>
-        </form>
-    </>);
+            <form onSubmit={handleSubmit}>
+                <Stack m={5} ref={focusTrapRef}>
+                    <SegmentedControl
+                        data={ALL_SERVERS}
+                        disabled={Boolean(serverLock)}
+                        p="md"
+                        withItemsBorders={false}
+                        {...form.getInputProps('type')}
+                    />
+                    <Group grow>
+                        <TextInput
+                            data-autofocus
+                            disabled={Boolean(serverLock)}
+                            label={t('form.addServer.input', {
+                                context: 'name',
+                                postProcess: 'titleCase',
+                            })}
+                            {...form.getInputProps('name')}
+                        />
+                        <TextInput
+                            disabled={Boolean(serverLock)}
+                            label={t('form.addServer.input', {
+                                context: 'url',
+                                postProcess: 'titleCase',
+                            })}
+                            {...form.getInputProps('url')}
+                        />
+                    </Group>
+                    <TextInput
+                        label={t('form.addServer.input', {
+                            context: 'username',
+                            postProcess: 'titleCase',
+                        })}
+                        {...form.getInputProps('username')}
+                    />
+                    <PasswordInput
+                        label={t('form.addServer.input', {
+                            context: 'password',
+                            postProcess: 'titleCase',
+                        })}
+                        {...form.getInputProps('password')}
+                    />
+                    {localSettings && form.values.type === ServerType.NAVIDROME && (
+                        <Checkbox
+                            label={t('form.addServer.input', {
+                                context: 'savePassword',
+                                postProcess: 'titleCase',
+                            })}
+                            {...form.getInputProps('savePassword', {
+                                type: 'checkbox',
+                            })}
+                        />
+                    )}
+                    {form.values.type === ServerType.SUBSONIC && (
+                        <Checkbox
+                            label={t('form.addServer.input', {
+                                context: 'legacyAuthentication',
+                                postProcess: 'titleCase',
+                            })}
+                            {...form.getInputProps('legacyAuth', { type: 'checkbox' })}
+                        />
+                    )}
+                    <Group grow justify="flex-end">
+                        {onCancel && (
+                            <Button onClick={onCancel} variant="subtle">
+                                {t('common.cancel', { postProcess: 'titleCase' })}
+                            </Button>
+                        )}
+                        <Button
+                            disabled={isSubmitDisabled}
+                            loading={isLoading}
+                            type="submit"
+                            variant="filled"
+                        >
+                            {t('common.add', { postProcess: 'titleCase' })}
+                        </Button>
+                    </Group>
+                </Stack>
+            </form>
+        </>
+    );
 };

--- a/src/shared/types/types.ts
+++ b/src/shared/types/types.ts
@@ -224,6 +224,12 @@ export type ServerListItem = {
     version?: string;
 };
 
+export type DiscoveredServerItem = {
+    type: ServerType;
+    name: string;
+    url: string;
+};
+
 export type SongState = {
     position?: number;
     repeat?: PlayerRepeat;

--- a/src/shared/types/types.ts
+++ b/src/shared/types/types.ts
@@ -166,6 +166,12 @@ export enum TableColumn {
     YEAR = 'releaseYear',
 }
 
+export type DiscoveredServerItem = {
+    name: string;
+    type: ServerType;
+    url: string;
+};
+
 export type GridCardData = {
     cardControls: any;
     cardRows: CardRow<Album | AlbumArtist | Artist | Playlist | Song>[];
@@ -222,12 +228,6 @@ export type ServerListItem = {
     userId: null | string;
     username: string;
     version?: string;
-};
-
-export type DiscoveredServerItem = {
-    type: ServerType;
-    name: string;
-    url: string;
 };
 
 export type SongState = {


### PR DESCRIPTION
I was disappointed that Feishin didn't auto-detect my jellyfin server on launch, so I implemented it :3

- Autodiscovery fires automatically and results are streamed back to the UI as they arrive
- Only implemented for Jellyfin, but space left in the implementation if the other servers secretly have autodiscovery methods too (I couldn't find any from a cursory look)
- Click a result to autofill the name and URL into the setup form
- UI could maybe do with a touch up