### PR TITLE
Remove unnecessary sections from Genius lyrics

### DIFF
--- a/src/main/features/core/lyrics/genius.ts
+++ b/src/main/features/core/lyrics/genius.ts
@@ -204,16 +204,16 @@ async function getSongId(
         return null;
     }
 
-    const artist_normalized = hit.artist_names.replace(/\u00A0/g, ' ').trim();
-    const full_title_normalized = hit.full_title
+    const artistNormalized = hit.artist_names.replace(/\u00A0/g, ' ').trim();
+    const fullTitleNormalized = hit.full_title
         .replace(/\u00A0/g, ' ')
-        .replace(`by ${artist_normalized}`, '')
+        .replace(`by ${artistNormalized}`, '')
         .trim();
 
     return {
-        artist: artist_normalized,
+        artist: artistNormalized,
         id: hit.url,
-        name: full_title_normalized,
+        name: fullTitleNormalized,
         source: LyricSource.GENIUS,
     };
 }

--- a/src/main/features/core/lyrics/genius.ts
+++ b/src/main/features/core/lyrics/genius.ts
@@ -204,16 +204,10 @@ async function getSongId(
         return null;
     }
 
-    const artistNormalized = hit.artist_names.replace(/\u00A0/g, ' ').trim();
-    const fullTitleNormalized = hit.full_title
-        .replace(/\u00A0/g, ' ')
-        .replace(`by ${artistNormalized}`, '')
-        .trim();
-
     return {
-        artist: artistNormalized,
+        artist: hit.artist_names,
         id: hit.url,
-        name: fullTitleNormalized,
+        name: hit.title,
         source: LyricSource.GENIUS,
     };
 }

--- a/src/main/features/core/lyrics/genius.ts
+++ b/src/main/features/core/lyrics/genius.ts
@@ -109,8 +109,11 @@ export async function getLyricsBySongId(url: string): Promise<null | string> {
 
     if (lyricsDiv.length > 0) return lyricsDiv.text().trim();
 
-    const lyricSections = $('div[class^=Lyrics__Container]')
-        .map((_, e) => $(e).text())
+    const lyricSections = $('div[data-lyrics-container="true"]')
+        .map((_, e) => {
+            $(e).find('[data-exclude-from-selection="true"]').remove();
+            return $(e).text();
+        })
         .toArray()
         .join('\n');
     return lyricSections;
@@ -201,10 +204,16 @@ async function getSongId(
         return null;
     }
 
+    const artist_normalized = hit.artist_names.replace(/\u00A0/g, ' ').trim();
+    const full_title_normalized = hit.full_title
+        .replace(/\u00A0/g, ' ')
+        .replace(`by ${artist_normalized}`, '')
+        .trim();
+
     return {
-        artist: hit.artist_names,
+        artist: artist_normalized,
         id: hit.url,
-        name: hit.full_title,
+        name: full_title_normalized,
         source: LyricSource.GENIUS,
     };
 }


### PR DESCRIPTION
When I was fetching lyrics from genius, I was noticing that the title displayed had the artist(s) names duplicated twice. I've added some adjustments to the artists and titles returned from the api response to try and remove that duplication, removing the artist name from the `full_title` field. 

I've also noticed that some unwanted text such as "143 Contributors" and "Translations" are appearing in the lyrics, those have been removed too.

Here's some screenshots to showcase the change:
**Before**
<img width="1919" height="1030" alt="image" src="https://github.com/user-attachments/assets/80a4602f-43e5-4561-8aff-196edcbffc3f" />

**After**
<img width="1919" height="1032" alt="image" src="https://github.com/user-attachments/assets/b4d0cefc-70ce-40f1-87a2-b81e03f78add" />
