### PR TITLE
show time remaining instead of duration on click

### DIFF
--- a/src/renderer/features/player/components/center-controls.tsx
+++ b/src/renderer/features/player/components/center-controls.tsx
@@ -13,19 +13,19 @@ import { openShuffleAllModal } from '/@/renderer/features/player/components/shuf
 import { useCenterControls } from '/@/renderer/features/player/hooks/use-center-controls';
 import { usePlayQueueAdd } from '/@/renderer/features/player/hooks/use-playqueue-add';
 import {
+    useAppStore,
+    useAppStoreActions,
     useCurrentPlayer,
     useCurrentSong,
     useCurrentStatus,
     useCurrentTime,
-    useRepeatStatus,
-    useSetCurrentTime,
-    useShuffleStatus,
-} from '/@/renderer/store';
-import {
     useHotkeySettings,
     usePlaybackType,
+    useRepeatStatus,
+    useSetCurrentTime,
     useSettingsStore,
-} from '/@/renderer/store/settings.store';
+    useShuffleStatus,
+} from '/@/renderer/store';
 import { Icon } from '/@/shared/components/icon/icon';
 import { Text } from '/@/shared/components/text/text';
 import { PlaybackSelectors } from '/@/shared/constants/playback-selectors';
@@ -51,6 +51,8 @@ export const CenterControls = ({ playersRef }: CenterControlsProps) => {
     const repeat = useRepeatStatus();
     const shuffle = useShuffleStatus();
     const { bindings } = useHotkeySettings();
+    const { showTimeRemaining } = useAppStore();
+    const { setShowTimeRemaining } = useAppStoreActions();
 
     const {
         handleNextTrack,
@@ -70,7 +72,8 @@ export const CenterControls = ({ playersRef }: CenterControlsProps) => {
     const songDuration = currentSong?.duration ? currentSong.duration / 1000 : 0;
     const currentTime = useCurrentTime();
     const currentPlayerRef = player === 1 ? player1 : player2;
-    const duration = formatDuration(songDuration * 1000 || 0);
+    const formattedDuration = formatDuration(songDuration * 1000 || 0);
+    const formattedTimeRemaining = formatDuration((currentTime - songDuration) * 1000 || 0);
     const formattedTime = formatDuration(currentTime * 1000 || 0);
 
     useEffect(() => {
@@ -293,9 +296,10 @@ export const CenterControls = ({ playersRef }: CenterControlsProps) => {
                         fw={600}
                         isMuted
                         isNoSelect
+                        onClick={() => setShowTimeRemaining(!showTimeRemaining)}
                         size="xs"
                     >
-                        {duration}
+                        {showTimeRemaining ? formattedTimeRemaining : formattedDuration}
                     </Text>
                 </div>
             </div>

--- a/src/renderer/features/player/components/center-controls.tsx
+++ b/src/renderer/features/player/components/center-controls.tsx
@@ -263,6 +263,7 @@ export const CenterControls = ({ playersRef }: CenterControlsProps) => {
                         isMuted
                         isNoSelect
                         size="xs"
+                        style={{ userSelect: 'none' }}
                     >
                         {formattedTime}
                     </Text>
@@ -297,7 +298,9 @@ export const CenterControls = ({ playersRef }: CenterControlsProps) => {
                         isMuted
                         isNoSelect
                         onClick={() => setShowTimeRemaining(!showTimeRemaining)}
+                        role="button"
                         size="xs"
+                        style={{ cursor: 'pointer', userSelect: 'none' }}
                     >
                         {showTimeRemaining ? formattedTimeRemaining : formattedDuration}
                     </Text>

--- a/src/renderer/store/app.store.ts
+++ b/src/renderer/store/app.store.ts
@@ -9,6 +9,7 @@ export interface AppSlice extends AppState {
     actions: {
         setAppStore: (data: Partial<AppSlice>) => void;
         setPrivateMode: (enabled: boolean) => void;
+        setShowTimeRemaining: (enabled: boolean) => void;
         setSideBar: (options: Partial<SidebarProps>) => void;
         setTitleBar: (options: Partial<TitlebarProps>) => void;
     };
@@ -19,6 +20,7 @@ export interface AppState {
     isReorderingQueue: boolean;
     platform: Platform;
     privateMode: boolean;
+    showTimeRemaining: boolean;
     sidebar: SidebarProps;
     titlebar: TitlebarProps;
 }
@@ -57,6 +59,11 @@ export const useAppStore = createWithEqualityFn<AppSlice>()(
                             state.privateMode = privateMode;
                         });
                     },
+                    setShowTimeRemaining: (showTimeRemaining) => {
+                        set((state) => {
+                            state.showTimeRemaining = showTimeRemaining;
+                        });
+                    },
                     setSideBar: (options) => {
                         set((state) => {
                             state.sidebar = { ...state.sidebar, ...options };
@@ -89,6 +96,7 @@ export const useAppStore = createWithEqualityFn<AppSlice>()(
                 isReorderingQueue: false,
                 platform: Platform.WINDOWS,
                 privateMode: false,
+                showTimeRemaining: false,
                 sidebar: {
                     collapsed: false,
                     expanded: [],


### PR DESCRIPTION
this replaces the duration with the time remaining of the current song by clicking on the text, similar to spotify
<img width="866" height="144" alt="image" src="https://github.com/user-attachments/assets/ec0c150e-b38d-46a5-9227-6fbee7087266" />

i'm not sure if the boolean should be stored in app.store or somewhere else, let me know if needs changing