### PR TITLE
Album page design refactor

### DIFF
--- a/src/renderer/features/albums/components/album-detail-content.module.css
+++ b/src/renderer/features/albums/components/album-detail-content.module.css
@@ -7,6 +7,6 @@
     display: flex;
     flex-direction: column;
     gap: var(--theme-spacing-lg);
-    padding: 1rem 2rem 5rem;
+    padding-bottom: 5rem;
     overflow: hidden;
 }

--- a/src/renderer/features/albums/components/album-detail-content.tsx
+++ b/src/renderer/features/albums/components/album-detail-content.tsx
@@ -29,7 +29,12 @@ import {
     SONG_CONTEXT_MENU_ITEMS,
 } from '/@/renderer/features/context-menu/context-menu-items';
 import { usePlayQueueAdd } from '/@/renderer/features/player';
-import { PlayButton, useCreateFavorite, useDeleteFavorite } from '/@/renderer/features/shared';
+import {
+    PlayButton,
+    useCreateFavorite,
+    useDeleteFavorite,
+    useSetRating,
+} from '/@/renderer/features/shared';
 import { LibraryBackgroundOverlay } from '/@/renderer/features/shared/components/library-background-overlay';
 import { useAppFocus, useContainerQuery } from '/@/renderer/hooks';
 import { useGenreRoute } from '/@/renderer/hooks/use-genre-route';
@@ -47,6 +52,7 @@ import { ActionIcon } from '/@/shared/components/action-icon/action-icon';
 import { Button } from '/@/shared/components/button/button';
 import { Group } from '/@/shared/components/group/group';
 import { Popover } from '/@/shared/components/popover/popover';
+import { Rating } from '/@/shared/components/rating/rating';
 import { Spoiler } from '/@/shared/components/spoiler/spoiler';
 import { Stack } from '/@/shared/components/stack/stack';
 import {
@@ -54,6 +60,7 @@ import {
     AlbumListSort,
     LibraryItem,
     QueueSong,
+    ServerType,
     SortOrder,
 } from '/@/shared/types/domain-types';
 import { Play } from '/@/shared/types/types';
@@ -280,6 +287,22 @@ export const AlbumDetailContent = ({ background, tableRef }: AlbumDetailContentP
         }
     };
 
+    const showRating = detailQuery?.data?.serverType === ServerType.NAVIDROME;
+
+    const updateRatingMutation = useSetRating({});
+
+    const handleUpdateRating = (rating: number) => {
+        if (!detailQuery?.data) return;
+
+        updateRatingMutation.mutate({
+            query: {
+                item: [detailQuery.data],
+                rating,
+            },
+            serverId: detailQuery.data.serverId,
+        });
+    };
+
     const showGenres = detailQuery?.data?.genres ? detailQuery?.data?.genres.length !== 0 : false;
     const comment = detailQuery?.data?.comment;
 
@@ -342,6 +365,16 @@ export const AlbumDetailContent = ({ background, tableRef }: AlbumDetailContentP
                                     size="lg"
                                     variant="transparent"
                                 />
+                                {showRating && (
+                                    <Rating
+                                        onChange={handleUpdateRating}
+                                        readOnly={
+                                            detailQuery?.isFetching ||
+                                            updateRatingMutation.isLoading
+                                        }
+                                        value={detailQuery?.data?.userRating || 0}
+                                    />
+                                )}
                                 <ActionIcon
                                     icon="ellipsisHorizontal"
                                     onClick={(e) => {

--- a/src/renderer/features/albums/components/album-detail-content.tsx
+++ b/src/renderer/features/albums/components/album-detail-content.tsx
@@ -375,6 +375,44 @@ export const AlbumDetailContent = ({ background, tableRef }: AlbumDetailContentP
                                         value={detailQuery?.data?.userRating || 0}
                                     />
                                 )}
+                                {externalLinks && lastFM && (
+                                    <ActionIcon
+                                        component="a"
+                                        href={`https://www.last.fm/music/${encodeURIComponent(
+                                            detailQuery?.data?.albumArtist || '',
+                                        )}/${encodeURIComponent(detailQuery.data?.name || '')}`}
+                                        icon="brandLastfm"
+                                        iconProps={{
+                                            fill: 'default',
+                                            size: 'lg',
+                                        }}
+                                        rel="noopener noreferrer"
+                                        size="lg"
+                                        target="_blank"
+                                        tooltip={{
+                                            label: t('action.openIn.lastfm'),
+                                        }}
+                                        variant="transparent"
+                                    />
+                                )}
+                                {externalLinks && mbzId && musicBrainz && (
+                                    <ActionIcon
+                                        component="a"
+                                        href={`https://musicbrainz.org/release/${mbzId}`}
+                                        icon="brandMusicBrainz"
+                                        iconProps={{
+                                            fill: 'default',
+                                            size: 'lg',
+                                        }}
+                                        rel="noopener noreferrer"
+                                        size="lg"
+                                        target="_blank"
+                                        tooltip={{
+                                            label: t('action.openIn.musicbrainz'),
+                                        }}
+                                        variant="transparent"
+                                    />
+                                )}
                                 <ActionIcon
                                     icon="ellipsisHorizontal"
                                     onClick={(e) => {
@@ -424,51 +462,6 @@ export const AlbumDetailContent = ({ background, tableRef }: AlbumDetailContentP
                         </Group>
                     </section>
                 )}
-                {externalLinks && (lastFM || musicBrainz) ? (
-                    <section>
-                        <Group gap="sm">
-                            {lastFM && (
-                                <ActionIcon
-                                    component="a"
-                                    href={`https://www.last.fm/music/${encodeURIComponent(
-                                        detailQuery?.data?.albumArtist || '',
-                                    )}/${encodeURIComponent(detailQuery.data?.name || '')}`}
-                                    icon="brandLastfm"
-                                    iconProps={{
-                                        fill: 'default',
-                                        size: 'xl',
-                                    }}
-                                    radius="md"
-                                    rel="noopener noreferrer"
-                                    target="_blank"
-                                    tooltip={{
-                                        label: t('action.openIn.lastfm'),
-                                    }}
-                                    variant="subtle"
-                                />
-                            )}
-                            {mbzId && musicBrainz ? (
-                                <ActionIcon
-                                    component="a"
-                                    href={`https://musicbrainz.org/release/${mbzId}`}
-                                    icon="brandMusicBrainz"
-                                    iconProps={{
-                                        fill: 'default',
-                                        size: 'xl',
-                                    }}
-                                    radius="md"
-                                    rel="noopener noreferrer"
-                                    size="md"
-                                    target="_blank"
-                                    tooltip={{
-                                        label: t('action.openIn.musicbrainz'),
-                                    }}
-                                    variant="subtle"
-                                />
-                            ) : null}
-                        </Group>
-                    </section>
-                ) : null}
                 {comment && (
                     <section>
                         <Spoiler maxHeight={75}>{replaceURLWithHTMLLinks(comment)}</Spoiler>

--- a/src/renderer/features/albums/components/album-detail-content.tsx
+++ b/src/renderer/features/albums/components/album-detail-content.tsx
@@ -5,7 +5,6 @@ import { useSetState } from '@mantine/hooks';
 import { MutableRefObject, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { generatePath, useParams } from 'react-router';
-import { Link } from 'react-router-dom';
 
 import styles from './album-detail-content.module.css';
 
@@ -29,7 +28,6 @@ import {
 import { usePlayQueueAdd } from '/@/renderer/features/player';
 import { LibraryBackgroundOverlay } from '/@/renderer/features/shared/components/library-background-overlay';
 import { useAppFocus, useContainerQuery } from '/@/renderer/hooks';
-import { useGenreRoute } from '/@/renderer/hooks/use-genre-route';
 import { AppRoute } from '/@/renderer/router/routes';
 import { useCurrentServer, useCurrentSong, useCurrentStatus } from '/@/renderer/store';
 import {
@@ -40,7 +38,6 @@ import {
 } from '/@/renderer/store/settings.store';
 import { replaceURLWithHTMLLinks } from '/@/renderer/utils/linkify';
 import { ActionIcon } from '/@/shared/components/action-icon/action-icon';
-import { Button } from '/@/shared/components/button/button';
 import { Group } from '/@/shared/components/group/group';
 import { Popover } from '/@/shared/components/popover/popover';
 import { Spoiler } from '/@/shared/components/spoiler/spoiler';
@@ -74,7 +71,6 @@ export const AlbumDetailContent = ({ background, tableRef }: AlbumDetailContentP
     const status = useCurrentStatus();
     const isFocused = useAppFocus();
     const currentSong = useCurrentSong();
-    const genreRoute = useGenreRoute();
 
     const columnDefs = useMemo(
         () => getColumnDefs(tableConfig.columns, false, 'albumDetail'),
@@ -242,7 +238,6 @@ export const AlbumDetailContent = ({ background, tableRef }: AlbumDetailContentP
         });
     };
 
-    const showGenres = detailQuery?.data?.genres ? detailQuery?.data?.genres.length !== 0 : false;
     const comment = detailQuery?.data?.comment;
 
     const onColumnMoved = useCallback(() => {
@@ -293,26 +288,6 @@ export const AlbumDetailContent = ({ background, tableRef }: AlbumDetailContentP
                         </Popover>
                     </Group>
                 </section>
-                {showGenres && (
-                    <section>
-                        <Group gap="sm">
-                            {detailQuery?.data?.genres?.map((genre) => (
-                                <Button
-                                    component={Link}
-                                    key={`genre-${genre.id}`}
-                                    radius="md"
-                                    size="compact-md"
-                                    to={generatePath(genreRoute, {
-                                        genreId: genre.id,
-                                    })}
-                                    variant="outline"
-                                >
-                                    {genre.name}
-                                </Button>
-                            ))}
-                        </Group>
-                    </section>
-                )}
                 {comment && (
                     <section>
                         <Spoiler maxHeight={75}>{replaceURLWithHTMLLinks(comment)}</Spoiler>

--- a/src/renderer/features/albums/components/album-detail-content.tsx
+++ b/src/renderer/features/albums/components/album-detail-content.tsx
@@ -4,7 +4,7 @@ import { RowDoubleClickedEvent, RowHeightParams, RowNode } from '@ag-grid-commun
 import { useSetState } from '@mantine/hooks';
 import { MutableRefObject, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { generatePath, useParams } from 'react-router';
+import { useParams } from 'react-router';
 
 import styles from './album-detail-content.module.css';
 
@@ -36,7 +36,6 @@ import {
     useTableSettings,
 } from '/@/renderer/store/settings.store';
 import { replaceURLWithHTMLLinks } from '/@/renderer/utils/linkify';
-import { Group } from '/@/shared/components/group/group';
 import { Spoiler } from '/@/shared/components/spoiler/spoiler';
 import { Stack } from '/@/shared/components/stack/stack';
 import {

--- a/src/renderer/features/albums/components/album-detail-content.tsx
+++ b/src/renderer/features/albums/components/album-detail-content.tsx
@@ -21,20 +21,12 @@ import { useCurrentSongRowStyles } from '/@/renderer/components/virtual-table/ho
 import { useAlbumDetail } from '/@/renderer/features/albums/queries/album-detail-query';
 import { useAlbumList } from '/@/renderer/features/albums/queries/album-list-query';
 import {
-    useHandleGeneralContextMenu,
     useHandleTableContextMenu,
 } from '/@/renderer/features/context-menu';
 import {
-    ALBUM_CONTEXT_MENU_ITEMS,
     SONG_CONTEXT_MENU_ITEMS,
 } from '/@/renderer/features/context-menu/context-menu-items';
 import { usePlayQueueAdd } from '/@/renderer/features/player';
-import {
-    PlayButton,
-    useCreateFavorite,
-    useDeleteFavorite,
-    useSetRating,
-} from '/@/renderer/features/shared';
 import { LibraryBackgroundOverlay } from '/@/renderer/features/shared/components/library-background-overlay';
 import { useAppFocus, useContainerQuery } from '/@/renderer/hooks';
 import { useGenreRoute } from '/@/renderer/hooks/use-genre-route';
@@ -42,7 +34,6 @@ import { AppRoute } from '/@/renderer/router/routes';
 import { useCurrentServer, useCurrentSong, useCurrentStatus } from '/@/renderer/store';
 import {
     PersistedTableColumn,
-    useGeneralSettings,
     usePlayButtonBehavior,
     useSettingsStoreActions,
     useTableSettings,
@@ -52,7 +43,6 @@ import { ActionIcon } from '/@/shared/components/action-icon/action-icon';
 import { Button } from '/@/shared/components/button/button';
 import { Group } from '/@/shared/components/group/group';
 import { Popover } from '/@/shared/components/popover/popover';
-import { Rating } from '/@/shared/components/rating/rating';
 import { Spoiler } from '/@/shared/components/spoiler/spoiler';
 import { Stack } from '/@/shared/components/stack/stack';
 import {
@@ -60,10 +50,8 @@ import {
     AlbumListSort,
     LibraryItem,
     QueueSong,
-    ServerType,
     SortOrder,
 } from '/@/shared/types/domain-types';
-import { Play } from '/@/shared/types/types';
 
 const isFullWidthRow = (node: RowNode) => {
     return node.id?.startsWith('disc-');
@@ -86,7 +74,6 @@ export const AlbumDetailContent = ({ background, tableRef }: AlbumDetailContentP
     const status = useCurrentStatus();
     const isFocused = useAppFocus();
     const currentSong = useCurrentSong();
-    const { externalLinks, lastFM, musicBrainz } = useGeneralSettings();
     const genreRoute = useGenreRoute();
 
     const columnDefs = useMemo(
@@ -237,13 +224,6 @@ export const AlbumDetailContent = ({ background, tableRef }: AlbumDetailContentP
     ];
     const playButtonBehavior = usePlayButtonBehavior();
 
-    const handlePlay = async (playType?: Play) => {
-        handlePlayQueueAdd?.({
-            byData: detailQuery?.data?.songs,
-            playType: playType || playButtonBehavior,
-        });
-    };
-
     const onCellContextMenu = useHandleTableContextMenu(LibraryItem.SONG, SONG_CONTEXT_MENU_ITEMS);
 
     const handleRowDoubleClick = (e: RowDoubleClickedEvent<QueueSong>) => {
@@ -262,54 +242,8 @@ export const AlbumDetailContent = ({ background, tableRef }: AlbumDetailContentP
         });
     };
 
-    const createFavoriteMutation = useCreateFavorite({});
-    const deleteFavoriteMutation = useDeleteFavorite({});
-
-    const handleFavorite = () => {
-        if (!detailQuery?.data) return;
-
-        if (detailQuery.data.userFavorite) {
-            deleteFavoriteMutation.mutate({
-                query: {
-                    id: [detailQuery.data.id],
-                    type: LibraryItem.ALBUM,
-                },
-                serverId: detailQuery.data.serverId,
-            });
-        } else {
-            createFavoriteMutation.mutate({
-                query: {
-                    id: [detailQuery.data.id],
-                    type: LibraryItem.ALBUM,
-                },
-                serverId: detailQuery.data.serverId,
-            });
-        }
-    };
-
-    const showRating = detailQuery?.data?.serverType === ServerType.NAVIDROME;
-
-    const updateRatingMutation = useSetRating({});
-
-    const handleUpdateRating = (rating: number) => {
-        if (!detailQuery?.data) return;
-
-        updateRatingMutation.mutate({
-            query: {
-                item: [detailQuery.data],
-                rating,
-            },
-            serverId: detailQuery.data.serverId,
-        });
-    };
-
     const showGenres = detailQuery?.data?.genres ? detailQuery?.data?.genres.length !== 0 : false;
     const comment = detailQuery?.data?.comment;
-
-    const handleGeneralContextMenu = useHandleGeneralContextMenu(
-        LibraryItem.ALBUM,
-        ALBUM_CONTEXT_MENU_ITEMS,
-    );
 
     const onColumnMoved = useCallback(() => {
         const { columnApi } = tableRef?.current || {};
@@ -339,99 +273,16 @@ export const AlbumDetailContent = ({ background, tableRef }: AlbumDetailContentP
 
     const { rowClassRules } = useCurrentSongRowStyles({ tableRef });
 
-    const mbzId = detailQuery?.data?.mbzId;
-
     return (
         <div className={styles.contentContainer} ref={cq.ref}>
             <LibraryBackgroundOverlay backgroundColor={background} />
             <div className={styles.detailContainer}>
                 <section>
-                    <Group gap="sm" justify="space-between">
-                        <Group>
-                            <PlayButton onClick={() => handlePlay(playButtonBehavior)} />
-                            <Group gap="xs">
-                                <ActionIcon
-                                    icon="favorite"
-                                    iconProps={{
-                                        fill: detailQuery?.data?.userFavorite
-                                            ? 'primary'
-                                            : undefined,
-                                    }}
-                                    loading={
-                                        createFavoriteMutation.isLoading ||
-                                        deleteFavoriteMutation.isLoading
-                                    }
-                                    onClick={handleFavorite}
-                                    size="lg"
-                                    variant="transparent"
-                                />
-                                {showRating && (
-                                    <Rating
-                                        onChange={handleUpdateRating}
-                                        readOnly={
-                                            detailQuery?.isFetching ||
-                                            updateRatingMutation.isLoading
-                                        }
-                                        value={detailQuery?.data?.userRating || 0}
-                                    />
-                                )}
-                                {externalLinks && lastFM && (
-                                    <ActionIcon
-                                        component="a"
-                                        href={`https://www.last.fm/music/${encodeURIComponent(
-                                            detailQuery?.data?.albumArtist || '',
-                                        )}/${encodeURIComponent(detailQuery.data?.name || '')}`}
-                                        icon="brandLastfm"
-                                        iconProps={{
-                                            fill: 'default',
-                                            size: 'lg',
-                                        }}
-                                        rel="noopener noreferrer"
-                                        size="lg"
-                                        target="_blank"
-                                        tooltip={{
-                                            label: t('action.openIn.lastfm'),
-                                        }}
-                                        variant="transparent"
-                                    />
-                                )}
-                                {externalLinks && mbzId && musicBrainz && (
-                                    <ActionIcon
-                                        component="a"
-                                        href={`https://musicbrainz.org/release/${mbzId}`}
-                                        icon="brandMusicBrainz"
-                                        iconProps={{
-                                            fill: 'default',
-                                            size: 'lg',
-                                        }}
-                                        rel="noopener noreferrer"
-                                        size="lg"
-                                        target="_blank"
-                                        tooltip={{
-                                            label: t('action.openIn.musicbrainz'),
-                                        }}
-                                        variant="transparent"
-                                    />
-                                )}
-                                <ActionIcon
-                                    icon="ellipsisHorizontal"
-                                    onClick={(e) => {
-                                        if (!detailQuery?.data) return;
-                                        handleGeneralContextMenu(e, [detailQuery.data!]);
-                                    }}
-                                    size="lg"
-                                    variant="transparent"
-                                />
-                            </Group>
-                        </Group>
+                    <Group gap="sm" justify="flex-end">
                         <Popover position="bottom-end">
                             <Popover.Target>
                                 <ActionIcon
                                     icon="settings"
-                                    onClick={(e) => {
-                                        if (!detailQuery?.data) return;
-                                        handleGeneralContextMenu(e, [detailQuery.data!]);
-                                    }}
                                     size="lg"
                                     variant="transparent"
                                 />

--- a/src/renderer/features/albums/components/album-detail-content.tsx
+++ b/src/renderer/features/albums/components/album-detail-content.tsx
@@ -12,7 +12,6 @@ import { queryKeys } from '/@/renderer/api/query-keys';
 import { MemoizedSwiperGridCarousel } from '/@/renderer/components/grid-carousel/grid-carousel';
 import {
     getColumnDefs,
-    TableConfigDropdown,
     VirtualTable,
 } from '/@/renderer/components/virtual-table';
 import { FullWidthDiscCell } from '/@/renderer/components/virtual-table/cells/full-width-disc-cell';
@@ -37,9 +36,7 @@ import {
     useTableSettings,
 } from '/@/renderer/store/settings.store';
 import { replaceURLWithHTMLLinks } from '/@/renderer/utils/linkify';
-import { ActionIcon } from '/@/shared/components/action-icon/action-icon';
 import { Group } from '/@/shared/components/group/group';
-import { Popover } from '/@/shared/components/popover/popover';
 import { Spoiler } from '/@/shared/components/spoiler/spoiler';
 import { Stack } from '/@/shared/components/stack/stack';
 import {
@@ -272,22 +269,6 @@ export const AlbumDetailContent = ({ background, tableRef }: AlbumDetailContentP
         <div className={styles.contentContainer} ref={cq.ref}>
             <LibraryBackgroundOverlay backgroundColor={background} />
             <div className={styles.detailContainer}>
-                <section>
-                    <Group gap="sm" justify="flex-end">
-                        <Popover position="bottom-end">
-                            <Popover.Target>
-                                <ActionIcon
-                                    icon="settings"
-                                    size="lg"
-                                    variant="transparent"
-                                />
-                            </Popover.Target>
-                            <Popover.Dropdown>
-                                <TableConfigDropdown type="albumDetail" />
-                            </Popover.Dropdown>
-                        </Popover>
-                    </Group>
-                </section>
                 {comment && (
                     <section>
                         <Spoiler maxHeight={75}>{replaceURLWithHTMLLinks(comment)}</Spoiler>

--- a/src/renderer/features/albums/components/album-detail-header.tsx
+++ b/src/renderer/features/albums/components/album-detail-header.tsx
@@ -178,7 +178,7 @@ export const AlbumDetailHeader = forwardRef(
                     {...background}
                 >
                     <Stack gap="sm">
-                        <Group gap="sm">
+                        <Group gap="sm" style={{ marginBottom: '10px' }}>
                             {detailQuery?.data?.albumArtists.map((artist, index) => (
                                 <Fragment key={`artist-${artist.id}`}>
                                     {index > 0 && <Text isNoSelect>•</Text>}

--- a/src/renderer/features/albums/components/album-detail-header.tsx
+++ b/src/renderer/features/albums/components/album-detail-header.tsx
@@ -11,7 +11,7 @@ import { useSongChange } from '/@/renderer/hooks/use-song-change';
 import { queryClient } from '/@/renderer/lib/react-query';
 import { AppRoute } from '/@/renderer/router/routes';
 import { useCurrentServer } from '/@/renderer/store';
-import { formatDateAbsoluteUTC, formatDurationString } from '/@/renderer/utils';
+import { formatDurationString } from '/@/renderer/utils';
 import { Group } from '/@/shared/components/group/group';
 import { Stack } from '/@/shared/components/stack/stack';
 import { Text } from '/@/shared/components/text/text';
@@ -32,14 +32,6 @@ export const AlbumDetailHeader = forwardRef(
         const detailQuery = useAlbumDetail({ query: { id: albumId }, serverId: server?.id });
         const cq = useContainerQuery();
         const { t } = useTranslation();
-
-        const originalDifferentFromRelease =
-            detailQuery.data?.originalDate &&
-            detailQuery.data.originalDate !== detailQuery.data.releaseDate;
-
-        const releasePrefix = originalDifferentFromRelease
-            ? t('page.albumDetail.released', { postProcess: 'sentenceCase' })
-            : '♫';
 
         const songIds = useMemo(() => {
             return new Set(detailQuery.data?.songs?.map((song) => song.id));
@@ -73,10 +65,8 @@ export const AlbumDetailHeader = forwardRef(
 
         const metadataItems = [
             {
-                id: 'releaseDate',
-                value:
-                    detailQuery?.data?.releaseDate &&
-                    `${releasePrefix} ${formatDateAbsoluteUTC(detailQuery?.data?.releaseDate)}`,
+                id: 'releaseYear',
+                value: detailQuery?.data?.releaseYear,
             },
             {
                 id: 'songCount',
@@ -96,14 +86,6 @@ export const AlbumDetailHeader = forwardRef(
                 }),
             },
         ];
-
-        if (originalDifferentFromRelease) {
-            const formatted = `♫ ${formatDateAbsoluteUTC(detailQuery!.data!.originalDate)}`;
-            metadataItems.splice(0, 0, {
-                id: 'originalDate',
-                value: formatted,
-            });
-        }
 
         return (
             <Stack ref={cq.ref}>

--- a/src/renderer/features/albums/components/album-detail-header.tsx
+++ b/src/renderer/features/albums/components/album-detail-header.tsx
@@ -20,6 +20,7 @@ import {
     useSetRating,
 } from '/@/renderer/features/shared';
 import { useContainerQuery } from '/@/renderer/hooks';
+import { useGenreRoute } from '/@/renderer/hooks/use-genre-route';
 import { useSongChange } from '/@/renderer/hooks/use-song-change';
 import { queryClient } from '/@/renderer/lib/react-query';
 import { AppRoute } from '/@/renderer/router/routes';
@@ -27,6 +28,7 @@ import { useCurrentServer, useGeneralSettings } from '/@/renderer/store';
 import { usePlayButtonBehavior } from '/@/renderer/store/settings.store';
 import { formatDurationString } from '/@/renderer/utils';
 import { ActionIcon } from '/@/shared/components/action-icon/action-icon';
+import { Button } from '/@/shared/components/button/button';
 import { Group } from '/@/shared/components/group/group';
 import { Rating } from '/@/shared/components/rating/rating';
 import { Stack } from '/@/shared/components/stack/stack';
@@ -52,6 +54,7 @@ export const AlbumDetailHeader = forwardRef(
         const { externalLinks, lastFM, musicBrainz } = useGeneralSettings();
         const playButtonBehavior = usePlayButtonBehavior();
         const handlePlayQueueAdd = usePlayQueueAdd();
+        const genreRoute = useGenreRoute();
 
         const songIds = useMemo(() => {
             return new Set(detailQuery.data?.songs?.map((song) => song.id));
@@ -137,6 +140,7 @@ export const AlbumDetailHeader = forwardRef(
         );
 
         const mbzId = detailQuery?.data?.mbzId;
+        const showGenres = detailQuery?.data?.genres ? detailQuery?.data?.genres.length !== 0 : false;
 
         const metadataItems = [
             {
@@ -276,6 +280,24 @@ export const AlbumDetailHeader = forwardRef(
                                 />
                             </Group>
                         </Group>
+                        {showGenres && (
+                            <Group gap="sm">
+                                {detailQuery?.data?.genres?.map((genre) => (
+                                    <Button
+                                        component={Link}
+                                        key={`genre-${genre.id}`}
+                                        radius="md"
+                                        size="compact-md"
+                                        to={generatePath(genreRoute, {
+                                            genreId: genre.id,
+                                        })}
+                                        variant="outline"
+                                    >
+                                        {genre.name}
+                                    </Button>
+                                ))}
+                            </Group>
+                        )}
                     </Stack>
                 </LibraryHeader>
             </Stack>

--- a/src/renderer/features/albums/components/album-detail-header.tsx
+++ b/src/renderer/features/albums/components/album-detail-header.tsx
@@ -4,6 +4,7 @@ import { generatePath, useParams } from 'react-router';
 import { Link } from 'react-router-dom';
 
 import { queryKeys } from '/@/renderer/api/query-keys';
+import { TableConfigDropdown } from '/@/renderer/components/virtual-table';
 import { useAlbumDetail } from '/@/renderer/features/albums/queries/album-detail-query';
 import {
     useHandleGeneralContextMenu,
@@ -30,6 +31,7 @@ import { formatDurationString } from '/@/renderer/utils';
 import { ActionIcon } from '/@/shared/components/action-icon/action-icon';
 import { Button } from '/@/shared/components/button/button';
 import { Group } from '/@/shared/components/group/group';
+import { Popover } from '/@/shared/components/popover/popover';
 import { Rating } from '/@/shared/components/rating/rating';
 import { Stack } from '/@/shared/components/stack/stack';
 import { Text } from '/@/shared/components/text/text';
@@ -280,24 +282,38 @@ export const AlbumDetailHeader = forwardRef(
                                 />
                             </Group>
                         </Group>
-                        {showGenres && (
-                            <Group gap="sm">
-                                {detailQuery?.data?.genres?.map((genre) => (
-                                    <Button
-                                        component={Link}
-                                        key={`genre-${genre.id}`}
-                                        radius="md"
-                                        size="compact-md"
-                                        to={generatePath(genreRoute, {
-                                            genreId: genre.id,
-                                        })}
-                                        variant="outline"
-                                    >
-                                        {genre.name}
-                                    </Button>
-                                ))}
-                            </Group>
-                        )}
+                        <Group gap="sm" justify="space-between">
+                            {showGenres && (
+                                <Group gap="sm">
+                                    {detailQuery?.data?.genres?.map((genre) => (
+                                        <Button
+                                            component={Link}
+                                            key={`genre-${genre.id}`}
+                                            radius="md"
+                                            size="compact-md"
+                                            to={generatePath(genreRoute, {
+                                                genreId: genre.id,
+                                            })}
+                                            variant="outline"
+                                        >
+                                            {genre.name}
+                                        </Button>
+                                    ))}
+                                </Group>
+                            )}
+                            <Popover position="bottom-end">
+                                <Popover.Target>
+                                    <ActionIcon
+                                        icon="settings"
+                                        size="lg"
+                                        variant="transparent"
+                                    />
+                                </Popover.Target>
+                                <Popover.Dropdown>
+                                    <TableConfigDropdown type="albumDetail" />
+                                </Popover.Dropdown>
+                            </Popover>
+                        </Group>
                     </Stack>
                 </LibraryHeader>
             </Stack>

--- a/src/renderer/features/albums/components/album-detail-header.tsx
+++ b/src/renderer/features/albums/components/album-detail-header.tsx
@@ -114,30 +114,14 @@ export const AlbumDetailHeader = forwardRef(
                     title={detailQuery?.data?.name || ''}
                     {...background}
                 >
-                    <Stack gap="sm">
-                        <Group gap="sm">
-                            {metadataItems.map((item, index) => (
-                                <Fragment key={`item-${item.id}-${index}`}>
-                                    {index > 0 && <Text isNoSelect>•</Text>}
-                                    <Text>{item.value}</Text>
-                                </Fragment>
-                            ))}
-                        </Group>
-                        <Group
-                            gap="md"
-                            mah="4rem"
-                            style={{
-                                overflow: 'hidden',
-                                WebkitBoxOrient: 'vertical',
-                                WebkitLineClamp: 2,
-                            }}
-                        >
-                            {detailQuery?.data?.albumArtists.map((artist) => (
+                    <Group gap="sm">
+                        {detailQuery?.data?.albumArtists.map((artist, index) => (
+                            <Fragment key={`artist-${artist.id}`}>
+                                {index > 0 && <Text isNoSelect>•</Text>}
                                 <Text
                                     component={Link}
                                     fw={600}
                                     isLink
-                                    key={`artist-${artist.id}`}
                                     to={generatePath(AppRoute.LIBRARY_ALBUM_ARTISTS_DETAIL, {
                                         albumArtistId: artist.id,
                                     })}
@@ -145,9 +129,18 @@ export const AlbumDetailHeader = forwardRef(
                                 >
                                     {artist.name}
                                 </Text>
-                            ))}
-                        </Group>
-                    </Stack>
+                            </Fragment>
+                        ))}
+                        {detailQuery?.data?.albumArtists && detailQuery.data.albumArtists.length > 0 && (
+                            <Text isNoSelect>•</Text>
+                        )}
+                        {metadataItems.map((item, index) => (
+                            <Fragment key={`item-${item.id}-${index}`}>
+                                {index > 0 && <Text isNoSelect>•</Text>}
+                                <Text>{item.value}</Text>
+                            </Fragment>
+                        ))}
+                    </Group>
                 </LibraryHeader>
             </Stack>
         );

--- a/src/renderer/features/albums/components/album-detail-header.tsx
+++ b/src/renderer/features/albums/components/album-detail-header.tsx
@@ -5,17 +5,34 @@ import { Link } from 'react-router-dom';
 
 import { queryKeys } from '/@/renderer/api/query-keys';
 import { useAlbumDetail } from '/@/renderer/features/albums/queries/album-detail-query';
-import { LibraryHeader } from '/@/renderer/features/shared';
+import {
+    useHandleGeneralContextMenu,
+} from '/@/renderer/features/context-menu';
+import {
+    ALBUM_CONTEXT_MENU_ITEMS,
+} from '/@/renderer/features/context-menu/context-menu-items';
+import { usePlayQueueAdd } from '/@/renderer/features/player';
+import {
+    LibraryHeader,
+    PlayButton,
+    useCreateFavorite,
+    useDeleteFavorite,
+    useSetRating,
+} from '/@/renderer/features/shared';
 import { useContainerQuery } from '/@/renderer/hooks';
 import { useSongChange } from '/@/renderer/hooks/use-song-change';
 import { queryClient } from '/@/renderer/lib/react-query';
 import { AppRoute } from '/@/renderer/router/routes';
-import { useCurrentServer } from '/@/renderer/store';
+import { useCurrentServer, useGeneralSettings } from '/@/renderer/store';
+import { usePlayButtonBehavior } from '/@/renderer/store/settings.store';
 import { formatDurationString } from '/@/renderer/utils';
+import { ActionIcon } from '/@/shared/components/action-icon/action-icon';
 import { Group } from '/@/shared/components/group/group';
+import { Rating } from '/@/shared/components/rating/rating';
 import { Stack } from '/@/shared/components/stack/stack';
 import { Text } from '/@/shared/components/text/text';
-import { AlbumDetailResponse, LibraryItem } from '/@/shared/types/domain-types';
+import { AlbumDetailResponse, LibraryItem, ServerType } from '/@/shared/types/domain-types';
+import { Play } from '/@/shared/types/types';
 
 interface AlbumDetailHeaderProps {
     background: {
@@ -32,6 +49,9 @@ export const AlbumDetailHeader = forwardRef(
         const detailQuery = useAlbumDetail({ query: { id: albumId }, serverId: server?.id });
         const cq = useContainerQuery();
         const { t } = useTranslation();
+        const { externalLinks, lastFM, musicBrainz } = useGeneralSettings();
+        const playButtonBehavior = usePlayButtonBehavior();
+        const handlePlayQueueAdd = usePlayQueueAdd();
 
         const songIds = useMemo(() => {
             return new Set(detailQuery.data?.songs?.map((song) => song.id));
@@ -62,6 +82,61 @@ export const AlbumDetailHeader = forwardRef(
                 handleSongChange(ids[0]);
             }
         }, detailQuery.data !== undefined);
+
+        const handlePlay = async (playType?: Play) => {
+            handlePlayQueueAdd?.({
+                byData: detailQuery?.data?.songs,
+                playType: playType || playButtonBehavior,
+            });
+        };
+
+        const createFavoriteMutation = useCreateFavorite({});
+        const deleteFavoriteMutation = useDeleteFavorite({});
+
+        const handleFavorite = () => {
+            if (!detailQuery?.data) return;
+
+            if (detailQuery.data.userFavorite) {
+                deleteFavoriteMutation.mutate({
+                    query: {
+                        id: [detailQuery.data.id],
+                        type: LibraryItem.ALBUM,
+                    },
+                    serverId: detailQuery.data.serverId,
+                });
+            } else {
+                createFavoriteMutation.mutate({
+                    query: {
+                        id: [detailQuery.data.id],
+                        type: LibraryItem.ALBUM,
+                    },
+                    serverId: detailQuery.data.serverId,
+                });
+            }
+        };
+
+        const showRating = detailQuery?.data?.serverType === ServerType.NAVIDROME;
+
+        const updateRatingMutation = useSetRating({});
+
+        const handleUpdateRating = (rating: number) => {
+            if (!detailQuery?.data) return;
+
+            updateRatingMutation.mutate({
+                query: {
+                    item: [detailQuery.data],
+                    rating,
+                },
+                serverId: detailQuery.data.serverId,
+            });
+        };
+
+        const handleGeneralContextMenu = useHandleGeneralContextMenu(
+            LibraryItem.ALBUM,
+            ALBUM_CONTEXT_MENU_ITEMS,
+        );
+
+        const mbzId = detailQuery?.data?.mbzId;
 
         const metadataItems = [
             {
@@ -96,33 +171,112 @@ export const AlbumDetailHeader = forwardRef(
                     title={detailQuery?.data?.name || ''}
                     {...background}
                 >
-                    <Group gap="sm">
-                        {detailQuery?.data?.albumArtists.map((artist, index) => (
-                            <Fragment key={`artist-${artist.id}`}>
-                                {index > 0 && <Text isNoSelect>•</Text>}
-                                <Text
-                                    component={Link}
-                                    fw={600}
-                                    isLink
-                                    to={generatePath(AppRoute.LIBRARY_ALBUM_ARTISTS_DETAIL, {
-                                        albumArtistId: artist.id,
-                                    })}
-                                    variant="subtle"
-                                >
-                                    {artist.name}
-                                </Text>
-                            </Fragment>
-                        ))}
-                        {detailQuery?.data?.albumArtists && detailQuery.data.albumArtists.length > 0 && (
-                            <Text isNoSelect>•</Text>
-                        )}
-                        {metadataItems.map((item, index) => (
-                            <Fragment key={`item-${item.id}-${index}`}>
-                                {index > 0 && <Text isNoSelect>•</Text>}
-                                <Text>{item.value}</Text>
-                            </Fragment>
-                        ))}
-                    </Group>
+                    <Stack gap="sm">
+                        <Group gap="sm">
+                            {detailQuery?.data?.albumArtists.map((artist, index) => (
+                                <Fragment key={`artist-${artist.id}`}>
+                                    {index > 0 && <Text isNoSelect>•</Text>}
+                                    <Text
+                                        component={Link}
+                                        fw={600}
+                                        isLink
+                                        to={generatePath(AppRoute.LIBRARY_ALBUM_ARTISTS_DETAIL, {
+                                            albumArtistId: artist.id,
+                                        })}
+                                        variant="subtle"
+                                    >
+                                        {artist.name}
+                                    </Text>
+                                </Fragment>
+                            ))}
+                            {detailQuery?.data?.albumArtists && detailQuery.data.albumArtists.length > 0 && (
+                                <Text isNoSelect>•</Text>
+                            )}
+                            {metadataItems.map((item, index) => (
+                                <Fragment key={`item-${item.id}-${index}`}>
+                                    {index > 0 && <Text isNoSelect>•</Text>}
+                                    <Text>{item.value}</Text>
+                                </Fragment>
+                            ))}
+                        </Group>
+                        <Group gap="sm">
+                            <PlayButton onClick={() => handlePlay(playButtonBehavior)} />
+                            <Group gap="xs">
+                                <ActionIcon
+                                    icon="favorite"
+                                    iconProps={{
+                                        fill: detailQuery?.data?.userFavorite
+                                            ? 'primary'
+                                            : undefined,
+                                    }}
+                                    loading={
+                                        createFavoriteMutation.isLoading ||
+                                        deleteFavoriteMutation.isLoading
+                                    }
+                                    onClick={handleFavorite}
+                                    size="lg"
+                                    variant="transparent"
+                                />
+                                {showRating && (
+                                    <Rating
+                                        onChange={handleUpdateRating}
+                                        readOnly={
+                                            detailQuery?.isFetching ||
+                                            updateRatingMutation.isLoading
+                                        }
+                                        value={detailQuery?.data?.userRating || 0}
+                                    />
+                                )}
+                                {externalLinks && lastFM && (
+                                    <ActionIcon
+                                        component="a"
+                                        href={`https://www.last.fm/music/${encodeURIComponent(
+                                            detailQuery?.data?.albumArtist || '',
+                                        )}/${encodeURIComponent(detailQuery.data?.name || '')}`}
+                                        icon="brandLastfm"
+                                        iconProps={{
+                                            fill: 'default',
+                                            size: 'lg',
+                                        }}
+                                        rel="noopener noreferrer"
+                                        size="lg"
+                                        target="_blank"
+                                        tooltip={{
+                                            label: t('action.openIn.lastfm'),
+                                        }}
+                                        variant="transparent"
+                                    />
+                                )}
+                                {externalLinks && mbzId && musicBrainz && (
+                                    <ActionIcon
+                                        component="a"
+                                        href={`https://musicbrainz.org/release/${mbzId}`}
+                                        icon="brandMusicBrainz"
+                                        iconProps={{
+                                            fill: 'default',
+                                            size: 'lg',
+                                        }}
+                                        rel="noopener noreferrer"
+                                        size="lg"
+                                        target="_blank"
+                                        tooltip={{
+                                            label: t('action.openIn.musicbrainz'),
+                                        }}
+                                        variant="transparent"
+                                    />
+                                )}
+                                <ActionIcon
+                                    icon="ellipsisHorizontal"
+                                    onClick={(e) => {
+                                        if (!detailQuery?.data) return;
+                                        handleGeneralContextMenu(e, [detailQuery.data!]);
+                                    }}
+                                    size="lg"
+                                    variant="transparent"
+                                />
+                            </Group>
+                        </Group>
+                    </Stack>
                 </LibraryHeader>
             </Stack>
         );

--- a/src/renderer/features/albums/components/album-detail-header.tsx
+++ b/src/renderer/features/albums/components/album-detail-header.tsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
 
 import { queryKeys } from '/@/renderer/api/query-keys';
 import { useAlbumDetail } from '/@/renderer/features/albums/queries/album-detail-query';
-import { LibraryHeader, useSetRating } from '/@/renderer/features/shared';
+import { LibraryHeader } from '/@/renderer/features/shared';
 import { useContainerQuery } from '/@/renderer/hooks';
 import { useSongChange } from '/@/renderer/hooks/use-song-change';
 import { queryClient } from '/@/renderer/lib/react-query';
@@ -13,10 +13,9 @@ import { AppRoute } from '/@/renderer/router/routes';
 import { useCurrentServer } from '/@/renderer/store';
 import { formatDateAbsoluteUTC, formatDurationString } from '/@/renderer/utils';
 import { Group } from '/@/shared/components/group/group';
-import { Rating } from '/@/shared/components/rating/rating';
 import { Stack } from '/@/shared/components/stack/stack';
 import { Text } from '/@/shared/components/text/text';
-import { AlbumDetailResponse, LibraryItem, ServerType } from '/@/shared/types/domain-types';
+import { AlbumDetailResponse, LibraryItem } from '/@/shared/types/domain-types';
 
 interface AlbumDetailHeaderProps {
     background: {
@@ -33,8 +32,6 @@ export const AlbumDetailHeader = forwardRef(
         const detailQuery = useAlbumDetail({ query: { id: albumId }, serverId: server?.id });
         const cq = useContainerQuery();
         const { t } = useTranslation();
-
-        const showRating = detailQuery?.data?.serverType === ServerType.NAVIDROME;
 
         const originalDifferentFromRelease =
             detailQuery.data?.originalDate &&
@@ -108,20 +105,6 @@ export const AlbumDetailHeader = forwardRef(
             });
         }
 
-        const updateRatingMutation = useSetRating({});
-
-        const handleUpdateRating = (rating: number) => {
-            if (!detailQuery?.data) return;
-
-            updateRatingMutation.mutate({
-                query: {
-                    item: [detailQuery.data],
-                    rating,
-                },
-                serverId: detailQuery.data.serverId,
-            });
-        };
-
         return (
             <Stack ref={cq.ref}>
                 <LibraryHeader
@@ -139,19 +122,6 @@ export const AlbumDetailHeader = forwardRef(
                                     <Text>{item.value}</Text>
                                 </Fragment>
                             ))}
-                            {showRating && (
-                                <>
-                                    <Text isNoSelect>•</Text>
-                                    <Rating
-                                        onChange={handleUpdateRating}
-                                        readOnly={
-                                            detailQuery?.isFetching ||
-                                            updateRatingMutation.isLoading
-                                        }
-                                        value={detailQuery?.data?.userRating || 0}
-                                    />
-                                </>
-                            )}
                         </Group>
                         <Group
                             gap="md"

--- a/src/renderer/features/albums/components/album-detail-header.tsx
+++ b/src/renderer/features/albums/components/album-detail-header.tsx
@@ -166,7 +166,7 @@ export const AlbumDetailHeader = forwardRef(
                     count: detailQuery?.data?.playCount as number,
                 }),
             },
-        ];
+        ].filter((item) => item.value !== undefined && item.value !== null && item.value !== '');
 
         return (
             <Stack ref={cq.ref}>
@@ -244,6 +244,7 @@ export const AlbumDetailHeader = forwardRef(
                                             fill: 'default',
                                             size: 'lg',
                                         }}
+                                        aria-label="Open in Last.fm"
                                         rel="noopener noreferrer"
                                         size="lg"
                                         target="_blank"
@@ -262,6 +263,7 @@ export const AlbumDetailHeader = forwardRef(
                                             fill: 'default',
                                             size: 'lg',
                                         }}
+                                        aria-label="Open in MusicBrainz"
                                         rel="noopener noreferrer"
                                         size="lg"
                                         target="_blank"

--- a/src/renderer/features/albums/components/album-detail-header.tsx
+++ b/src/renderer/features/albums/components/album-detail-header.tsx
@@ -6,12 +6,8 @@ import { Link } from 'react-router-dom';
 import { queryKeys } from '/@/renderer/api/query-keys';
 import { TableConfigDropdown } from '/@/renderer/components/virtual-table';
 import { useAlbumDetail } from '/@/renderer/features/albums/queries/album-detail-query';
-import {
-    useHandleGeneralContextMenu,
-} from '/@/renderer/features/context-menu';
-import {
-    ALBUM_CONTEXT_MENU_ITEMS,
-} from '/@/renderer/features/context-menu/context-menu-items';
+import { useHandleGeneralContextMenu } from '/@/renderer/features/context-menu';
+import { ALBUM_CONTEXT_MENU_ITEMS } from '/@/renderer/features/context-menu/context-menu-items';
 import { usePlayQueueAdd } from '/@/renderer/features/player';
 import {
     LibraryHeader,
@@ -142,7 +138,9 @@ export const AlbumDetailHeader = forwardRef(
         );
 
         const mbzId = detailQuery?.data?.mbzId;
-        const showGenres = detailQuery?.data?.genres ? detailQuery?.data?.genres.length !== 0 : false;
+        const showGenres = detailQuery?.data?.genres
+            ? detailQuery?.data?.genres.length !== 0
+            : false;
 
         const metadataItems = [
             {
@@ -195,9 +193,10 @@ export const AlbumDetailHeader = forwardRef(
                                     </Text>
                                 </Fragment>
                             ))}
-                            {detailQuery?.data?.albumArtists && detailQuery.data.albumArtists.length > 0 && (
-                                <Text isNoSelect>•</Text>
-                            )}
+                            {detailQuery?.data?.albumArtists &&
+                                detailQuery.data.albumArtists.length > 0 && (
+                                    <Text isNoSelect>•</Text>
+                                )}
                             {metadataItems.map((item, index) => (
                                 <Fragment key={`item-${item.id}-${index}`}>
                                     {index > 0 && <Text isNoSelect>•</Text>}
@@ -235,6 +234,7 @@ export const AlbumDetailHeader = forwardRef(
                                 )}
                                 {externalLinks && lastFM && (
                                     <ActionIcon
+                                        aria-label={t('action.openIn.lastfm')}
                                         component="a"
                                         href={`https://www.last.fm/music/${encodeURIComponent(
                                             detailQuery?.data?.albumArtist || '',
@@ -244,7 +244,6 @@ export const AlbumDetailHeader = forwardRef(
                                             fill: 'default',
                                             size: 'lg',
                                         }}
-                                        aria-label="Open in Last.fm"
                                         rel="noopener noreferrer"
                                         size="lg"
                                         target="_blank"
@@ -256,6 +255,7 @@ export const AlbumDetailHeader = forwardRef(
                                 )}
                                 {externalLinks && mbzId && musicBrainz && (
                                     <ActionIcon
+                                        aria-label={t('action.openIn.musicbrainz')}
                                         component="a"
                                         href={`https://musicbrainz.org/release/${mbzId}`}
                                         icon="brandMusicBrainz"
@@ -263,7 +263,6 @@ export const AlbumDetailHeader = forwardRef(
                                             fill: 'default',
                                             size: 'lg',
                                         }}
-                                        aria-label="Open in MusicBrainz"
                                         rel="noopener noreferrer"
                                         size="lg"
                                         target="_blank"
@@ -305,11 +304,7 @@ export const AlbumDetailHeader = forwardRef(
                             )}
                             <Popover position="bottom-end">
                                 <Popover.Target>
-                                    <ActionIcon
-                                        icon="settings"
-                                        size="lg"
-                                        variant="transparent"
-                                    />
+                                    <ActionIcon icon="settings" size="lg" variant="transparent" />
                                 </Popover.Target>
                                 <Popover.Dropdown>
                                     <TableConfigDropdown type="albumDetail" />

--- a/src/renderer/features/shared/components/library-header.module.css
+++ b/src/renderer/features/shared/components/library-header.module.css
@@ -27,7 +27,7 @@
         grid-template-columns: 175px minmax(0, 1fr);
 
         h1 {
-            height: 40px;
+            height: 45px;
         }
 
         .image {
@@ -45,7 +45,7 @@
         grid-template-columns: 200px minmax(0, 1fr);
 
         h1 {
-            height: 80px;
+            height: 60px;
         }
 
         .image {
@@ -63,7 +63,7 @@
         grid-template-columns: 225px minmax(0, 1fr);
 
         h1 {
-            height: 100px;
+            height: 65px;
         }
 
         .image {

--- a/src/renderer/features/shared/components/library-header.module.css
+++ b/src/renderer/features/shared/components/library-header.module.css
@@ -99,7 +99,7 @@
     grid-area: image;
     align-items: center;
     justify-content: center;
-    height: 100%;
+    height: auto;
     filter: drop-shadow(0 0 8px rgb(0 0 0 / 50%));
 }
 

--- a/src/renderer/features/shared/components/library-header.module.css
+++ b/src/renderer/features/shared/components/library-header.module.css
@@ -5,7 +5,7 @@
     grid-template-rows: 100%;
     grid-template-columns: 175px minmax(0, 1fr);
     gap: 1rem;
-    align-items: flex-end;
+    align-items: center;
     width: 100%;
     max-width: 100%;
     height: 30vh;
@@ -97,7 +97,7 @@
     z-index: 15;
     display: flex;
     grid-area: image;
-    align-items: flex-end;
+    align-items: center;
     justify-content: center;
     height: 100%;
     filter: drop-shadow(0 0 8px rgb(0 0 0 / 50%));
@@ -108,7 +108,7 @@
     display: flex;
     flex-direction: column;
     grid-area: info;
-    justify-content: flex-end;
+    justify-content: center;
     width: 100%;
 }
 

--- a/src/renderer/features/shared/components/library-header.module.css
+++ b/src/renderer/features/shared/components/library-header.module.css
@@ -11,7 +11,7 @@
     height: 30vh;
     min-height: 340px;
     max-height: 500px;
-    padding: 5rem 2rem 2rem;
+    padding: 5rem 2rem 5rem;
 
     :global(.item-image-placeholder) {
         width: 175px !important;

--- a/src/renderer/features/shared/components/library-header.tsx
+++ b/src/renderer/features/shared/components/library-header.tsx
@@ -63,7 +63,12 @@ export const LibraryHeader = forwardRef(
         }, [imageUrl, isImageError]);
 
         return (
-            <div className={styles.libraryHeader} ref={ref}>
+            <div
+                className={styles.libraryHeader}
+                data-library-item-route={item.route}
+                data-library-item-type={item.type}
+                ref={ref}
+            >
                 <div
                     className={styles.background}
                     style={{ background, filter: `blur(${blur ?? 0}rem)` }}

--- a/src/renderer/features/shared/components/library-header.tsx
+++ b/src/renderer/features/shared/components/library-header.tsx
@@ -2,15 +2,12 @@ import { closeAllModals, openModal } from '@mantine/modals';
 import { AutoTextSize } from 'auto-text-size';
 import clsx from 'clsx';
 import { forwardRef, ReactNode, Ref, useCallback, useState } from 'react';
-import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
 
 import styles from './library-header.module.css';
 
 import { useGeneralSettings } from '/@/renderer/store';
 import { Center } from '/@/shared/components/center/center';
 import { Image } from '/@/shared/components/image/image';
-import { Text } from '/@/shared/components/text/text';
 import { LibraryItem } from '/@/shared/types/domain-types';
 
 interface LibraryHeaderProps {
@@ -29,29 +26,11 @@ export const LibraryHeader = forwardRef(
         { background, blur, children, imageUrl, item, title }: LibraryHeaderProps,
         ref: Ref<HTMLDivElement>,
     ) => {
-        const { t } = useTranslation();
         const [isImageError, setIsImageError] = useState<boolean | null>(false);
         const { albumBackground } = useGeneralSettings();
 
         const onImageError = () => {
             setIsImageError(true);
-        };
-
-        const itemTypeString = () => {
-            switch (item.type) {
-                case LibraryItem.ALBUM:
-                    return t('entity.album', { count: 1 });
-                case LibraryItem.ALBUM_ARTIST:
-                    return t('entity.albumArtist', { count: 1 });
-                case LibraryItem.ARTIST:
-                    return t('entity.artist', { count: 1 });
-                case LibraryItem.PLAYLIST:
-                    return t('entity.playlist', { count: 1 });
-                case LibraryItem.SONG:
-                    return t('entity.track', { count: 1 });
-                default:
-                    return t('common.unknown');
-            }
         };
 
         const openImage = useCallback(() => {
@@ -116,16 +95,6 @@ export const LibraryHeader = forwardRef(
                 </div>
                 {title && (
                     <div className={styles.metadataSection}>
-                        <Text
-                            component={Link}
-                            fw={600}
-                            isLink
-                            size="md"
-                            to={item.route}
-                            tt="uppercase"
-                        >
-                            {itemTypeString()}
-                        </Text>
                         <h1 className={styles.title}>
                             <AutoTextSize maxFontSizePx={50} mode="box">
                                 {title}

--- a/src/renderer/features/shared/components/library-header.tsx
+++ b/src/renderer/features/shared/components/library-header.tsx
@@ -127,7 +127,7 @@ export const LibraryHeader = forwardRef(
                             {itemTypeString()}
                         </Text>
                         <h1 className={styles.title}>
-                            <AutoTextSize maxFontSizePx={80} mode="box">
+                            <AutoTextSize maxFontSizePx={50} mode="box">
                                 {title}
                             </AutoTextSize>
                         </h1>

--- a/src/shared/styles/ag-grid.css
+++ b/src/shared/styles/ag-grid.css
@@ -3,7 +3,7 @@
     top: 65px;
     z-index: 15;
     padding: 0 2rem;
-    margin: 0 -2rem;
+    margin: 0;
     box-shadow: 0 -1px 0 0 #181818;
     transition: position 0.2s ease-in-out;
 }


### PR DESCRIPTION
This PR introduces changes to album page. It aimed to use vertical space better by clever elements placing. Each commit in this PR represents a small change, so we can easily revert any change in case we don't like it. 

What changed:
- Album title is not enormous anymore
- Like and star rating buttons are placed near each other because they represent same feature
- Album metadata rethought and combined with main artist name 

Other small changes visible on screenshots.

**Before**
![before](https://github.com/user-attachments/assets/d375a55a-5451-4fa4-b264-2ae8d2953f64)

**After**
![after](https://github.com/user-attachments/assets/3b68b8da-e6b4-47bd-9f7c-ed881729ac3b)
