### PR TITLE
Add install script for AppImage

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,15 +59,27 @@ For media keys to work, you will be prompted to allow Feishin to be a Trusted Ac
 
 #### Linux Notes
 
-If you're using a Linux device, a `.desktop` file is recommended for easy launching of Feishin.
+We provide a small install script to download the latest `.AppImage`, make it executable, and also download the icons required by Desktop Environments. Finally, it generates a `.desktop` file to add Feishin to your Application Launcher.
 
-Download the [latest release (AppImage)](https://github.com/jeffvli/feishin/releases) and [application icon](https://github.com/jeffvli/feishin/blob/development/resources/icon.png?raw=true) to your `~/applications/` folder. This folder may need to be created if it does not already exist.
+Simply run the installer like this:
+```sh
+dir=/your/application/directory
+curl 'https://raw.githubusercontent.com/jeffvli/feishin/refs/heads/development/install-feishin-appimage' | sh -s -- "$dir"
+```
 
-Rename the icon to `Feishin-linux-x86_64.png`.
+The script also has an option to add launch arguments to run Feishin in native Wayland mode. Note that this is experimental in Electron and therefore not officially supported. If you want to use it, run this instead:
+```sh
+dir=/your/application/directory
+curl 'https://raw.githubusercontent.com/jeffvli/feishin/refs/heads/development/install-feishin-appimage' | sh -s -- "$dir" wayland-native
+```
 
-Save the [example desktop file](https://raw.githubusercontent.com/jeffvli/feishin/refs/heads/development/feishin.desktop) as `~/.local/share/applications/feishin.desktop`.
+It also provides a simple uninstall routine, removing the downloaded files:
+```sh
+dir=/your/application/directory
+curl 'https://raw.githubusercontent.com/jeffvli/feishin/refs/heads/development/install-feishin-appimage' | sh -s -- "$dir" remove
+```
 
-You will now see Feishin show up in your menu. The properties in the example desktop file may need to be modified to match your system.
+The entry should show up in your Application Launcher immediately. If it does not, simply log out, wait 10 seconds, and log back in. Your Desktop Environment may alternatively provide a way to reload entries.
 
 ### Web and Docker
 

--- a/feishin.desktop
+++ b/feishin.desktop
@@ -1,9 +1,0 @@
-[Desktop Entry]
-Name=Feishin
-Comment=An Electron-based music streaming app
-Exec=/home/username/.applications/Feishin-linux-x86_64.AppImage
-Icon=/home/username/.applications/Feishin-linux-x86_64.png
-Terminal=false
-Type=Application
-Categories=AudioVideo;Audio;Music;Player;
-StartupNotify=true

--- a/install-feishin-appimage
+++ b/install-feishin-appimage
@@ -1,0 +1,74 @@
+#!/bin/sh
+
+dir=$1
+arg=$2
+arch=$(uname -m)
+
+if [ "$arch" != "x86_64" ] && [ "$arch" != "aarch64" ]; then
+	echo "CPU architecture not recognised (not x86_64 or aarch64). Aborting."
+	exit 1
+fi
+
+# workaround if we're not renaming the artifact
+if [ "$arch" = "aarch64" ]; then
+	arch='arm64'
+fi
+
+if [ ! -d "${dir}" ]; then
+	echo "${dir}} is not a directory or does not exist. Please provide an existing directory."
+	exit 1
+fi
+
+localShare="$HOME/.local/share"
+localShareIcons="${localShare}/icons/hicolor"
+
+if [ "${arg}" = "remove" ]; then
+	rm -v \
+		"${localShareIcons}"/512x512/apps/org.jeffvli.feishin.png \
+		"${localShareIcons}"/256x256/apps/org.jeffvli.feishin.png \
+		"${localShareIcons}"/128x128/apps/org.jeffvli.feishin.png \
+		"${localShareIcons}"/64x64/apps/org.jeffvli.feishin.png \
+		"${localShareIcons}"/32x32/apps/org.jeffvli.feishin.png \
+		"${localShare}"/applications/org.jeffvli.feishin.desktop \
+		"${dir}./Feishin-linux-${arch}.AppImage"
+	exit 0
+fi
+
+curl -L --create-dirs --write-out '%{filename_effective}\n' \
+	-o "${dir}/Feishin-linux-${arch}.AppImage" "https://github.com/jeffvli/feishin/releases/latest/download/Feishin-linux-${arch}.AppImage" \
+	-o "${localShareIcons}"/512x512/apps/org.jeffvli.feishin.png 'https://github.com/jeffvli/feishin/blob/development/assets/icons/512x512.png?raw=true' \
+	-o "${localShareIcons}"/256x256/apps/org.jeffvli.feishin.png 'https://github.com/jeffvli/feishin/blob/development/assets/icons/256x256.png?raw=true' \
+	-o "${localShareIcons}"/128x128/apps/org.jeffvli.feishin.png 'https://github.com/jeffvli/feishin/blob/development/assets/icons/128x128.png?raw=true' \
+	-o "${localShareIcons}"/64x64/apps/org.jeffvli.feishin.png 'https://github.com/jeffvli/feishin/blob/development/assets/icons/64x64.png?raw=true' \
+	-o "${localShareIcons}"/32x32/apps/org.jeffvli.feishin.png 'https://github.com/jeffvli/feishin/blob/development/assets/icons/32x32.png?raw=true'
+chmod -v u+x "${dir}/Feishin-linux-${arch}.AppImage"
+
+waylandFlags=''
+if [ "${arg}" = "wayland-native" ]; then
+	waylandFlags=' --enable-features=UseOzonePlatform,WaylandWindowDecorations --ozone-platform-hint=auto'
+fi
+
+# this is for Debian-based kernels and ALT respectively
+# https://unix.stackexchange.com/a/303214/145722
+sandboxFlag=''
+if [ "$(sysctl kernel.unprivileged_userns_clone 2>/dev/null)" = "0" ] \
+	|| [ "$(sysctl kernel.userns_restrict 2>/dev/null)" = "1" ]; then
+	sandboxFlag=' --no-sandbox'
+fi
+
+mkdir -pv "${localShare}"/applications
+cat > "${localShare}"/applications/org.jeffvli.feishin.desktop << EOL
+[Desktop Entry]
+Name=Feishin
+GenericName=Music player
+Exec=${dir}/Feishin-linux-${arch}.AppImage${sandboxFlag}${waylandFlags}
+TryExec=${dir}/Feishin-linux-${arch}.AppImage
+Terminal=false
+Type=Application
+Icon=org.jeffvli.feishin
+StartupWMClass=feishin
+SingleMainWindow=true
+Categories=AudioVideo;Audio;Player;Music;
+Keywords=Navidrome;Jellyfin;Subsonic;OpenSubsonic
+Comment=A player for your self-hosted music server
+EOL


### PR DESCRIPTION
This essentially supersedes #1020 and addresses my concerns raised there. Basically, it's suggested the provided `.desktop` file will just work, but that's not the case.

This PR addresses this:

* adjusts to CPU architecture by reading `uname -m`
* `wayland-native` option for Wayland flags
* `remove` option to delete downloaded files
* generates Desktop entry from template
* downloads various icon sizes to correct locations
  * uses reverse DNS notation so icon can be overridden by icon themes (can technically be done with any filename, but providing a filename from the project side makes it "official" for theme authors)
* add `GenericName`, `Comment`, and `Keywords` to Desktop file
  * The `Comment` is what shows up here:
    <img width="275" height="48" alt="image" src="https://github.com/user-attachments/assets/e18f97ed-52e9-43bd-9a74-f308e1974207" />
  * The `GenericName` is an alternate name some DE's application launchers can show when enabled (IDK who uses this, but y'know, it's part of the spec):
    <img width="275" height="125" alt="image" src="https://github.com/user-attachments/assets/ba4f8e75-ffd9-4297-a0a3-a07c19f19167" />
  * `Keywords` per the spec:
    > A list of strings which may be used in addition to other metadata to describe this entry. This can be useful e.g. to facilitate searching through entries. The values are not meant for display, and should not be redundant with the values of `Name` or `GenericName`.
    <img width="430" height="130" alt="image" src="https://github.com/user-attachments/assets/2e0af461-a98e-4207-93ab-f8d24733e289" />
* update accompanying README instructions
* remove previous example `.desktop` file

Final `.desktop` file also validates:
```sh
❯ desktop-file-validate org.jeffvli.feishin.desktop
❯ echo $?
0
```

---

One small thing:
The `Comment` string can be localised:
```ini
Comment=A player for your self-hosted music server
Comment[de_DE]=<German TL here>
Comment[fr_FR]=<French TL here>
…
```
But I don't know if/how that can be integrated to Weblate.

---

For testing, you need to use a link from my branch:
```sh
curl 'https://raw.githubusercontent.com/mihawk90/feishin/refs/heads/install-appimage/install-feishin-appimage' | sh
```