### PR TITLE
auto-publish to winget-pkgs

### DIFF
--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -1,0 +1,21 @@
+name: Publish release to WinGet
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Specific tag name"
+        required: false
+        type: string
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: jeffvli.Feishin
+          installers-regex: 'Feishin-*-win-x64\.exe'
+          token: ${{ secrets.WINGET_ACC_TOKEN }}
+          


### PR DESCRIPTION
This PR uses [winget-releaser](https://github.com/vedantmgoyal9/winget-releaser) (which uses Komac). It requires a `Classic Github Personal Access Token` with `public_repo` scope is created, following [this link](https://github.com/settings/tokens/new), then the Token can be added to the repo as a secret named `WINGET_ACC_TOKEN`. See below, that user also will have to fork the winget-pkgs repository.