### PR TITLE
Fix Lyric Translation Not Resetting

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -735,6 +735,8 @@
         "translationApiKey_description": "api key for translation (Support global service endpoint only)",
         "translationTargetLanguage": "translation target language",
         "translationTargetLanguage_description": "target language for translation",
+        "enableAutoTranslation": "enable auto translation",
+        "enableAutoTranslation_description": "enable translation automatically when lyrics are loaded",
         "trayEnabled": "show tray",
         "trayEnabled_description": "show/hide tray icon/menu. if disabled, also disables minimize/exit to tray",
         "useSystemTheme": "use system theme",

--- a/src/renderer/features/settings/components/playback/lyric-settings.tsx
+++ b/src/renderer/features/settings/components/playback/lyric-settings.tsx
@@ -214,6 +214,28 @@ export const LyricSettings = () => {
             isHidden: !isElectron(),
             title: t('setting.translationApiKey', { postProcess: 'sentenceCase' }),
         },
+        {
+            control: (
+                <Switch
+                    aria-label="Enable auto translation"
+                    defaultChecked={settings.enableAutoTranslation}
+                    onChange={(e) => {
+                        setSettings({
+                            lyrics: {
+                                ...settings,
+                                enableAutoTranslation: e.currentTarget.checked,
+                            },
+                        });
+                    }}
+                />
+            ),
+            description: t('setting.enableAutoTranslation', {
+                context: 'description',
+                postProcess: 'sentenceCase',
+            }),
+            isHidden: !isElectron(),
+            title: t('setting.enableAutoTranslation', { postProcess: 'sentenceCase' }),
+        },
     ];
 
     return <SettingsSection divider={false} options={lyricOptions} />;

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -280,6 +280,7 @@ export interface SettingsState {
     lyrics: {
         alignment: 'center' | 'left' | 'right';
         delayMs: number;
+        enableAutoTranslation: boolean;
         enableNeteaseTranslation: boolean;
         fetch: boolean;
         follow: boolean;
@@ -474,6 +475,7 @@ const initialState: SettingsState = {
     lyrics: {
         alignment: 'center',
         delayMs: 0,
+        enableAutoTranslation: false,
         enableNeteaseTranslation: false,
         fetch: false,
         follow: true,


### PR DESCRIPTION
Currently, lyric translation would not reset and would directly pass the translation of the last song to the next.

This PR does the following:

- Clear the lyric translation cache and disable it when changing tracks
- Added a toggle (users who would not like translation to be enabled automatically could still use the translation button that is only temporary for the current track playing) for auto translation, so users no longer need to click translation every time a new track is playing (same behavior as fetch lyric from internet source)
- Trivial lyric translation logic fix and reuse code for fetching lyric translation api responses