### PR TITLE
Change AUMID to the static appid instead of the file path on windows

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -505,7 +505,7 @@ async function createWindow(first = true): Promise<void> {
     });
 
     if (isWindows()) {
-        app.setAppUserModelId(process.execPath);
+        app.setAppUserModelId('org.jeffvli.feishin');
     }
 
     if (isMacOS()) {


### PR DESCRIPTION
This makes it so it actually shows the app name and icon when looking at the media session on Windows instead of saying "Unknown app".
Before:
<img width="354" height="172" alt="yC4DSmvG17" src="https://github.com/user-attachments/assets/06c5c5e5-73b8-4d2d-b105-936b28812cf2" />
After:
<img width="354" height="171" alt="yQwHfSvNZu" src="https://github.com/user-attachments/assets/d42932dc-f01b-4d7b-97f5-fea53ea95c5a" />
