### PR TITLE
Fix: correct app name in Windows notification

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -295,6 +295,10 @@ async function createWindow(first = true): Promise<void> {
         ...(nativeFrame && isWindows() && nativeFrameConfig.windows),
     });
 
+    if (process.platform === 'win32') {
+        app.setAppUserModelId(app.name);
+    }
+
     // From https://github.com/electron/electron/issues/526#issuecomment-1663959513
     const bounds = store.get('bounds') as Rectangle | undefined;
     if (bounds) {


### PR DESCRIPTION
Hi!
On Windows, when enabled, the path to the executable appeared in the name of the notification application instead of the actual name.

Before:

https://github.com/user-attachments/assets/885877c1-223c-4068-bc45-a72a276dd714

After:

https://github.com/user-attachments/assets/c185d7fb-1692-4c85-b3b7-0657701f20f3

It's a small change, but I think it could be useful for those who are meticulous (or for those who use Windows).
Thanks!

