### PR TITLE
bugfix: remove duplicate scrobbling when there is only one item in the queue

### DIFF
--- a/src/renderer/features/player/hooks/use-scrobble.ts
+++ b/src/renderer/features/player/hooks/use-scrobble.ts
@@ -268,6 +268,7 @@ export const useScrobble = () => {
                 }
             } else {
                 const isLastTrackInQueue = usePlayerStore.getState().actions.checkIsLastTrack();
+                const isFisrtTrackInQueue = usePlayerStore.getState().actions.checkIsFirstTrack();
                 const previousTimeSec = previous[1];
 
                 // If not already scrobbled, send a 'submission' scrobble if conditions are met
@@ -275,8 +276,12 @@ export const useScrobble = () => {
                     scrobbleAtDurationMs: (scrobbleSettings?.scrobbleAtDuration ?? 0) * 1000,
                     scrobbleAtPercentage: scrobbleSettings?.scrobbleAtPercentage,
                     // If scrobbling the last song in the queue, use the previous time instead of the current time since otherwise time value will be 0
+                    // Note that if the queue has one item (both first and last), use the elapsed time, as this will otherwise result
+                    // in duplicate scrobbles in tandem with handleScrobbleFromSongChange
                     songCompletedDurationMs:
-                        (isLastTrackInQueue ? previousTimeSec : currentTimeSec) * 1000,
+                        (isLastTrackInQueue && !isFisrtTrackInQueue
+                            ? previousTimeSec
+                            : currentTimeSec) * 1000,
                     songDurationMs: currentSong.duration,
                 });
 


### PR DESCRIPTION
Resolves #1213
Previously, if there was one track in the queue and the queue is not set to loop, both `handleScrobbleFromSongChange` and `handleScrobbleFromStatusChange` would fire. This prevents the second function from firing, by checking if the queue is only one track and then using standard rules to check for scrobbling.