### PR TITLE
Disable media session on Linux only

### DIFF
--- a/src/main/features/core/player/media-keys.ts
+++ b/src/main/features/core/player/media-keys.ts
@@ -25,10 +25,10 @@ export const enableMediaKeys = (window: BrowserWindow | null) => {
         }
     }
 
-    const enableWindowsMediaSession = store.get('mediaSession', false) as boolean;
+    const enableMediaSession = store.get('mediaSession', false) as boolean;
     const playbackType = store.get('playbackType', PlaybackType.WEB) as PlaybackType;
 
-    if (!enableWindowsMediaSession || !isWindows() || playbackType !== PlaybackType.WEB) {
+    if (!enableMediaSession || !isWindows() || playbackType !== PlaybackType.WEB) {
         globalShortcut.register('MediaStop', () => {
             window?.webContents.send('renderer-player-stop');
         });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -548,10 +548,10 @@ async function createWindow(first = true): Promise<void> {
     }
 }
 
-const enableWindowsMediaSession = store.get('mediaSession', false) as boolean;
+const enableMediaSession = store.get('mediaSession', false) as boolean;
 const playbackType = store.get('playbackType', PlaybackType.WEB) as PlaybackType;
 const shouldDisableMediaFeatures =
-    isLinux() || !enableWindowsMediaSession || playbackType !== PlaybackType.WEB;
+    isLinux() || !enableMediaSession || playbackType !== PlaybackType.WEB;
 if (shouldDisableMediaFeatures) {
     app.commandLine.appendSwitch(
         'disable-features',

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -551,7 +551,7 @@ async function createWindow(first = true): Promise<void> {
 const enableWindowsMediaSession = store.get('mediaSession', false) as boolean;
 const playbackType = store.get('playbackType', PlaybackType.WEB) as PlaybackType;
 const shouldDisableMediaFeatures =
-    !isWindows() || !enableWindowsMediaSession || playbackType !== PlaybackType.WEB;
+    isLinux() || !enableWindowsMediaSession || playbackType !== PlaybackType.WEB;
 if (shouldDisableMediaFeatures) {
     app.commandLine.appendSwitch(
         'disable-features',

--- a/src/renderer/features/settings/components/hotkeys/window-hotkey-settings.tsx
+++ b/src/renderer/features/settings/components/hotkeys/window-hotkey-settings.tsx
@@ -16,7 +16,7 @@ export const WindowHotkeySettings = () => {
     const { t } = useTranslation();
     const settings = useHotkeySettings();
     const { setSettings } = useSettingsStoreActions();
-    const { mediaSession: enableWindowsMediaSession, type: playbackType } = usePlaybackSettings();
+    const { mediaSession: enableMediaSession, type: playbackType } = usePlaybackSettings();
 
     const options: SettingOption[] = [
         {
@@ -25,9 +25,7 @@ export const WindowHotkeySettings = () => {
                     defaultChecked={settings.globalMediaHotkeys}
                     disabled={
                         !isElectron() ||
-                        (enableWindowsMediaSession &&
-                            isWindows &&
-                            playbackType === PlaybackType.WEB)
+                        (enableMediaSession && isWindows && playbackType === PlaybackType.WEB)
                     }
                     onChange={(e) => {
                         setSettings({

--- a/src/renderer/features/settings/components/playback/media-session-settings.tsx
+++ b/src/renderer/features/settings/components/playback/media-session-settings.tsx
@@ -9,7 +9,7 @@ import { usePlaybackSettings, useSettingsStoreActions } from '/@/renderer/store/
 import { Switch } from '/@/shared/components/switch/switch';
 import { PlaybackType } from '/@/shared/types/types';
 
-const isWindows = isElectron() ? window.api.utils.isWindows() : null;
+const isLinux = isElectron() ? window.api.utils.isLinux() : null;
 const isDesktop = isElectron();
 const ipc = isElectron() ? window.api.ipc : null;
 
@@ -30,7 +30,7 @@ export const MediaSessionSettings = () => {
                 <Switch
                     aria-label="Toggle media Session"
                     defaultChecked={mediaSession}
-                    disabled={!isWindows || !isDesktop || playbackType !== PlaybackType.WEB}
+                    disabled={isLinux || !isDesktop || playbackType !== PlaybackType.WEB}
                     onChange={handleMediaSessionChange}
                 />
             ),
@@ -38,7 +38,7 @@ export const MediaSessionSettings = () => {
                 context: 'description',
                 postProcess: 'sentenceCase',
             }),
-            isHidden: !isWindows || !isDesktop,
+            isHidden: isLinux || !isDesktop,
             note: t('common.restartRequired', { postProcess: 'sentenceCase' }),
             title: t('setting.mediaSession', { postProcess: 'sentenceCase' }),
         },


### PR DESCRIPTION
This PR changes the condition that are checked to disable the MediaSession : now, only Linux user are excluded from using the media session (as there is already something to interact with MPRIS from what I have understood from the previous PR/issues)

I'm doing this PR because mediaSession works well with the [NowPlaying API](https://developer.apple.com/documentation/mediaplayer/becoming-a-now-playable-app) (or MediaRemote?) of Apple devices and I wanted to be able to interact with Feishin on other apps that also uses this API (like [BoringNotch](https://github.com/TheBoredTeam/boring.notch))

This is my first ever PR on an open source project so please tell me if anything is wrong.

PS: I was about to commit the translation (as I think we do not need to precise that Media Session is Windows only now) but I saw that there is Weblate configured and I don't know how it works...