### PR TITLE
feat: add 'preservePitch' toggle to playback speed "dropdown"

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,7 +42,7 @@
         "dist/**/*": true
     },
     "i18n-ally.localesPaths": ["src/i18n", "src/i18n/locales"],
-    "typescript.tsdk": "node_modules\\typescript\\lib",
+    "typescript.tsdk": "node_modules/typescript/lib",
     "typescript.preferences.importModuleSpecifier": "non-relative",
     "stylelint.config": null,
     "stylelint.validate": ["css", "postcss"],

--- a/src/renderer/features/player/components/right-controls.tsx
+++ b/src/renderer/features/player/components/right-controls.tsx
@@ -14,8 +14,10 @@ import {
     useCurrentSong,
     useHotkeySettings,
     useMuted,
+    usePlaybackSettings,
     usePreviousSong,
     useSettingsStore,
+    useSettingsStoreActions,
     useSidebarStore,
     useSpeed,
     useVolume,
@@ -24,8 +26,10 @@ import { ActionIcon } from '/@/shared/components/action-icon/action-icon';
 import { DropdownMenu } from '/@/shared/components/dropdown-menu/dropdown-menu';
 import { Flex } from '/@/shared/components/flex/flex';
 import { Group } from '/@/shared/components/group/group';
+import { Option } from '/@/shared/components/option/option';
 import { Rating } from '/@/shared/components/rating/rating';
 import { Slider } from '/@/shared/components/slider/slider';
+import { Switch } from '/@/shared/components/switch/switch';
 import { LibraryItem, QueueSong, ServerType, Song } from '/@/shared/types/domain-types';
 
 const ipc = isElectron() ? window.api.ipc : null;
@@ -50,9 +54,12 @@ export const RightControls = () => {
         handleVolumeUp,
         handleVolumeWheel,
     } = useRightControls();
+    const { setSettings } = useSettingsStoreActions();
+    const playbackSettings = usePlaybackSettings();
 
     const speed = useSpeed();
     const volumeWidth = useSettingsStore((state) => state.general.volumeWidth);
+    const speedPreservePitch = useSettingsStore((state) => state.playback.preservePitch);
 
     const updateRatingMutation = useSetRating({});
     const addToFavoritesMutation = useCreateFavorite({});
@@ -227,6 +234,26 @@ export const RightControls = () => {
                         />
                     </DropdownMenu.Target>
                     <DropdownMenu.Dropdown>
+                        <Option>
+                            <Option.Label>
+                                {t('setting.preservePitch', {
+                                    postProcess: 'sentenceCase',
+                                })}
+                            </Option.Label>
+                            <Option.Control>
+                                <Switch
+                                    defaultChecked={speedPreservePitch}
+                                    onChange={(e) => {
+                                        setSettings({
+                                            playback: {
+                                                ...playbackSettings,
+                                                preservePitch: e.currentTarget.checked,
+                                            },
+                                        });
+                                    }}
+                                />
+                            </Option.Control>
+                        </Option>
                         <Slider
                             label={formatPlaybackSpeedSliderLabel}
                             marks={[

--- a/src/renderer/features/player/components/right-controls.tsx
+++ b/src/renderer/features/player/components/right-controls.tsx
@@ -15,6 +15,7 @@ import {
     useHotkeySettings,
     useMuted,
     usePlaybackSettings,
+    usePlaybackType,
     usePreviousSong,
     useSettingsStore,
     useSettingsStoreActions,
@@ -31,6 +32,7 @@ import { Rating } from '/@/shared/components/rating/rating';
 import { Slider } from '/@/shared/components/slider/slider';
 import { Switch } from '/@/shared/components/switch/switch';
 import { LibraryItem, QueueSong, ServerType, Song } from '/@/shared/types/domain-types';
+import { PlaybackType } from '/@/shared/types/types';
 
 const ipc = isElectron() ? window.api.ipc : null;
 const remote = isElectron() ? window.api.remote : null;
@@ -56,6 +58,7 @@ export const RightControls = () => {
     } = useRightControls();
     const { setSettings } = useSettingsStoreActions();
     const playbackSettings = usePlaybackSettings();
+    const playbackType = usePlaybackType();
 
     const speed = useSpeed();
     const volumeWidth = useSettingsStore((state) => state.general.volumeWidth);
@@ -234,26 +237,28 @@ export const RightControls = () => {
                         />
                     </DropdownMenu.Target>
                     <DropdownMenu.Dropdown>
-                        <Option>
-                            <Option.Label>
-                                {t('setting.preservePitch', {
-                                    postProcess: 'sentenceCase',
-                                })}
-                            </Option.Label>
-                            <Option.Control>
-                                <Switch
-                                    defaultChecked={speedPreservePitch}
-                                    onChange={(e) => {
-                                        setSettings({
-                                            playback: {
-                                                ...playbackSettings,
-                                                preservePitch: e.currentTarget.checked,
-                                            },
-                                        });
-                                    }}
-                                />
-                            </Option.Control>
-                        </Option>
+                        {playbackType === PlaybackType.WEB && (
+                            <Option>
+                                <Option.Label>
+                                    {t('setting.preservePitch', {
+                                        postProcess: 'sentenceCase',
+                                    })}
+                                </Option.Label>
+                                <Option.Control>
+                                    <Switch
+                                        defaultChecked={speedPreservePitch}
+                                        onChange={(e) => {
+                                            setSettings({
+                                                playback: {
+                                                    ...playbackSettings,
+                                                    preservePitch: e.currentTarget.checked,
+                                                },
+                                            });
+                                        }}
+                                    />
+                                </Option.Control>
+                            </Option>
+                        )}
                         <Slider
                             label={formatPlaybackSpeedSliderLabel}
                             marks={[


### PR DESCRIPTION
This PR adds the 'preservePitch' setting to the "dropdown" (dropup). I've found myself (as well as a few other friends who use Feishin) wanting a toggle for this quickly accessible in the dropup menu, so I thought I would PR it.

This only shows when the web player is selected. It does not show for the Mpv player.

<img width="601" height="209" alt="image" src="https://github.com/user-attachments/assets/a0abd874-1afe-47bb-b4b4-6074771c4433" />

I'm not sure the way I'm doing this is up to par with what standards are being used in this codebase. I could abstract the settings part and make it similar to `useSetCurrentSpeed`?


