### PR TITLE
Fix for Jellyfin genres

### DIFF
--- a/src/renderer/api/jellyfin/jellyfin-controller.ts
+++ b/src/renderer/api/jellyfin/jellyfin-controller.ts
@@ -395,7 +395,9 @@ export const JellyfinController: InternalControllerEndpoint = {
 
         const res = await jfApiClient(apiClientProps).getGenreList({
             query: {
+                EnableTotalRecordCount: true,
                 Fields: 'ItemCounts',
+                Limit: query.limit,
                 ParentId: query?.musicFolderId,
                 Recursive: true,
                 SearchTerm: query?.searchTerm,


### PR DESCRIPTION
I am not sure if it was the recent Jellyfin update or an update in Feishin that caused this, but for the last couple weeks the Genres view has returned no data. It appears to be caused by the fact that `TotalRecordCount` is only returned when specifying both a `Limit` and `EnableTotalRecordCount=true`. Since these two parameters were defined as part of the generic query params, but missing from the actual `getGenreList` implementation, adding them to that method seems to have resolved the issue.

Note: I have hardcoded `EnableTotalRecordCount` to `true` since it appears to have no ill effects _and_ the TotalRecordCount is only returned when also specifying a `Limit`. I'm unsure if JF is actually calculating the count on the backend in the "Limit not included" scenario, but if there is any heartburn here, I'd be happy to change it to a proper argument.