### PR TITLE
Use grid/table data to build queue when playing from Albums view

### DIFF
--- a/src/renderer/components/virtual-grid/virtual-infinite-grid.tsx
+++ b/src/renderer/components/virtual-grid/virtual-infinite-grid.tsx
@@ -18,6 +18,7 @@ import { AnyLibraryItem, Genre, LibraryItem } from '/@/shared/types/domain-types
 import { ListDisplayType } from '/@/shared/types/types';
 
 export type VirtualInfiniteGridRef = {
+    getItemData: () => (LibraryItemOrGenre | undefined)[];
     resetLoadMoreItemsCache: () => void;
     scrollTo: (index: number) => void;
     setItemData: (data: LibraryItemOrGenre[]) => void;
@@ -143,6 +144,9 @@ export const VirtualInfiniteGrid = forwardRef(
         const debouncedLoadMoreItems = debounce(loadMoreItems, 500);
 
         useImperativeHandle(ref, () => ({
+            getItemData: () => {
+                return itemData;
+            },
             resetLoadMoreItemsCache: () => {
                 if (loader.current) {
                     loader.current.resetloadMoreItemsCache(false);

--- a/src/renderer/features/albums/routes/album-list-route.tsx
+++ b/src/renderer/features/albums/routes/album-list-route.tsx
@@ -1,12 +1,11 @@
 import type { AgGridReact as AgGridReactType } from '@ag-grid-community/react/lib/agGridReact';
 
 import { useQuery } from '@tanstack/react-query';
+import { compact } from 'lodash';
 import isEmpty from 'lodash/isEmpty';
 import { useCallback, useMemo, useRef } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 
-import { api } from '/@/renderer/api';
-import { queryKeys } from '/@/renderer/api/query-keys';
 import { VirtualInfiniteGridRef } from '/@/renderer/components/virtual-grid/virtual-infinite-grid';
 import { ListContext } from '/@/renderer/context/list-context';
 import { albumQueries } from '/@/renderer/features/albums/api/album-api';
@@ -15,7 +14,6 @@ import { AlbumListHeader } from '/@/renderer/features/albums/components/album-li
 import { genresQueries } from '/@/renderer/features/genres/api/genres-api';
 import { usePlayQueueAdd } from '/@/renderer/features/player/hooks/use-playqueue-add';
 import { AnimatedPage } from '/@/renderer/features/shared/components/animated-page';
-import { queryClient } from '/@/renderer/lib/react-query';
 import { useCurrentServer, useListFilterByKey } from '/@/renderer/store';
 import {
     AlbumListQuery,
@@ -95,36 +93,19 @@ const AlbumListRoute = () => {
 
     const handlePlay = useCallback(
         async (args: { initialSongId?: string; playType: Play }) => {
-            if (!itemCount || itemCount === 0) return;
+            const albumsFromGrid = compact(gridRef.current?.getItemData());
+            if (!itemCount || itemCount === 0 || albumsFromGrid.length === 0) return;
             const { playType } = args;
-            const query = {
-                ...albumListFilter,
-                ...customFilters,
-                startIndex: 0,
-            };
-            const queryKey = queryKeys.albums.list(server?.id || '', query);
-
-            const albumListRes = await queryClient.fetchQuery({
-                queryFn: ({ signal }) => {
-                    return api.controller.getAlbumList({
-                        apiClientProps: { serverId: server?.id || '', signal },
-                        query,
-                    });
-                },
-                queryKey,
-            });
-
-            const albumIds = albumListRes?.items?.map((a) => a.id) || [];
 
             handlePlayQueueAdd?.({
                 byItemType: {
-                    id: albumIds,
+                    id: albumsFromGrid.map((a) => a.id),
                     type: LibraryItem.ALBUM,
                 },
                 playType,
             });
         },
-        [albumListFilter, customFilters, handlePlayQueueAdd, itemCount, server],
+        [handlePlayQueueAdd, itemCount],
     );
 
     const providerValue = useMemo(() => {

--- a/src/renderer/features/albums/routes/album-list-route.tsx
+++ b/src/renderer/features/albums/routes/album-list-route.tsx
@@ -91,15 +91,36 @@ const AlbumListRoute = () => {
 
     const itemCount = itemCountCheck.data === null ? undefined : itemCountCheck.data;
 
+    const getAlbumIdsFromTable = () => {
+        if (!tableRef.current?.api) {
+            return undefined;
+        }
+        const items: string[] = [];
+
+        tableRef.current?.api.forEachNode((row) => {
+            if (row.id) {
+                items.push(row.id);
+            }
+        });
+        return items;
+    };
+    const getAlbumIdsFromGrid = () => {
+        if (!gridRef.current) {
+            return undefined;
+        }
+
+        return compact(gridRef.current.getItemData()).map((i) => i.id);
+    };
+
     const handlePlay = useCallback(
         async (args: { initialSongId?: string; playType: Play }) => {
-            const albumsFromGrid = compact(gridRef.current?.getItemData());
-            if (!itemCount || itemCount === 0 || albumsFromGrid.length === 0) return;
+            const albumIdsFromView = getAlbumIdsFromGrid() || getAlbumIdsFromTable() || [];
+            if (!itemCount || itemCount === 0 || albumIdsFromView.length === 0) return;
             const { playType } = args;
 
             handlePlayQueueAdd?.({
                 byItemType: {
-                    id: albumsFromGrid.map((a) => a.id),
+                    id: albumIdsFromView,
                     type: LibraryItem.ALBUM,
                 },
                 playType,

--- a/src/renderer/features/player/hooks/use-handle-playqueue-add.ts
+++ b/src/renderer/features/player/hooks/use-handle-playqueue-add.ts
@@ -1,5 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import isElectron from 'is-electron';
+import { sortBy } from 'lodash';
 import { nanoid } from 'nanoid/non-secure';
 import { useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -168,6 +169,13 @@ export const useHandlePlayQueueAdd = () => {
 
                 songs =
                     songList?.items?.map((song: Song) => ({ ...song, uniqueId: nanoid() })) || null;
+
+                // Special case for albums since we want the order of album ids to be respected when building the queue.
+                if (itemType === LibraryItem.ALBUM) {
+                    songs = sortBy(songs, (song) => {
+                        return id.indexOf(song.albumId);
+                    });
+                }
             } else if (byData) {
                 songs = byData.map((song) => ({ ...song, uniqueId: nanoid() })) || null;
             }


### PR DESCRIPTION
This started as a way to fix https://github.com/audioling/audioling/issues/49 https://github.com/jeffvli/feishin/issues/1246 but ended up fixing more UX issues (IMO) with Feishin's albums view. 

As of right now, pressing "play" at the top of the Albums view is kind of unpredictable because the queue that gets built doesn't match what the user sees. 

This PR changes that by using the grid/table's data to build the list of album IDs passed to `handlePlayQueueAdd` which enables a bunch of cool behaviors:
- Queue random albums by switching the list to the "random" sort and pressing play (fixes https://github.com/audioling/audioling/issues/49 https://github.com/jeffvli/feishin/issues/1246)
- Queue that respects the sorting and filtering used

Here's a demo video showing the behavior

https://github.com/user-attachments/assets/0a11fce2-054c-40a3-a9db-20e32ef8df12
