### PR TITLE
Small light theme fixes

### DIFF
--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -189,7 +189,7 @@ export const App = () => {
     }, [language]);
 
     return (
-        <MantineProvider defaultColorScheme={mode as 'dark' | 'light'} theme={theme}>
+        <MantineProvider forceColorScheme={mode} theme={theme}>
             <Notifications
                 containerWidth="300px"
                 position="bottom-center"

--- a/src/renderer/features/shared/components/filter-bar.module.css
+++ b/src/renderer/features/shared/components/filter-bar.module.css
@@ -1,5 +1,12 @@
 .filter-bar {
     z-index: 1;
     padding: var(--theme-spacing-md) var(--theme-spacing-sm);
-    box-shadow: 0 5px 15px rgb(0 0 0 / 65%);
+
+    @mixin dark {
+        box-shadow: 0 5px 15px rgb(0 0 0 / 65%);
+    }
+
+    @mixin light {
+        box-shadow: 0 2px 0 var(--theme-colors-border);
+    }
 }


### PR DESCRIPTION
Just two small issues I noticed while using Feishin.

1. The filter bar had a big black shadow in the light theme, this PR replaces it by a grey border 

Before / after:
<img width="1942" height="866" alt="CleanShot 2025-11-08 at 00 22 23@2x" src="https://github.com/user-attachments/assets/5ad62fda-aa9b-4322-9d8d-432e42d1c57c" />
<img width="1936" height="902" alt="CleanShot 2025-11-08 at 00 22 05@2x" src="https://github.com/user-attachments/assets/ceeb6c60-96c7-4c97-b243-c5e596577a53" />


2. The color scheme applied to `MantineProvider` seems to stay "stuck" if you switch between light/dark color scheme without restarting the app (which I do during the day), which causes some color variables to not update properly. I mostly noticed it happening to icons in the application menu but maybe it happens in other places.

Before: 

https://github.com/user-attachments/assets/e05839f1-b445-4e0f-90ea-fda3f26ff68f

After:

https://github.com/user-attachments/assets/39937aa9-4985-4730-95ac-f488e2483a30

