### PR TITLE
fix(rpc): truncate certain fields

### DIFF
--- a/src/renderer/features/discord-rpc/use-discord-rpc.ts
+++ b/src/renderer/features/discord-rpc/use-discord-rpc.ts
@@ -18,6 +18,11 @@ import { PlayerStatus } from '/@/shared/types/types';
 const discordRpc = isElectron() ? window.api.discordRpc : null;
 type ActivityState = [QueueSong | undefined, number, PlayerStatus];
 
+const MAX_FIELD_LENGTH = 125;
+
+const truncate = (field: string) =>
+    field.length <= 125 ? field : field.substring(0, MAX_FIELD_LENGTH) + '...';
+
 export const useDiscordRpc = () => {
     const discordSettings = useDiscordSettings();
     const generalSettings = useGeneralSettings();
@@ -66,13 +71,15 @@ export const useDiscordRpc = () => {
                 };
 
                 const activity: SetActivity = {
-                    details: (song?.name && song.name.padEnd(2, ' ')) || 'Idle',
+                    details: truncate((song?.name && song.name.padEnd(2, ' ')) || 'Idle'),
                     instance: false,
                     largeImageKey: undefined,
-                    largeImageText: (song?.album && song.album.padEnd(2, ' ')) || 'Unknown album',
+                    largeImageText: truncate(
+                        (song?.album && song.album.padEnd(2, ' ')) || 'Unknown album',
+                    ),
                     smallImageKey: undefined,
                     smallImageText: sentenceCase(current[2]),
-                    state: (artists && artists.padEnd(2, ' ')) || 'Unknown artist',
+                    state: truncate((artists && artists.padEnd(2, ' ')) || 'Unknown artist'),
                     statusDisplayType: statusDisplayMap[discordSettings.displayType],
                     // I would love to use the actual type as opposed to hardcoding to 2,
                     // but manually installing the discord-types package appears to break things

--- a/src/renderer/features/discord-rpc/use-discord-rpc.ts
+++ b/src/renderer/features/discord-rpc/use-discord-rpc.ts
@@ -21,7 +21,7 @@ type ActivityState = [QueueSong | undefined, number, PlayerStatus];
 const MAX_FIELD_LENGTH = 125;
 
 const truncate = (field: string) =>
-    field.length <= 125 ? field : field.substring(0, MAX_FIELD_LENGTH) + '...';
+    field.length <= MAX_FIELD_LENGTH ? field : field.substring(0, MAX_FIELD_LENGTH - 1) + '...';
 
 export const useDiscordRpc = () => {
     const discordSettings = useDiscordSettings();

--- a/src/renderer/features/discord-rpc/use-discord-rpc.ts
+++ b/src/renderer/features/discord-rpc/use-discord-rpc.ts
@@ -18,10 +18,10 @@ import { PlayerStatus } from '/@/shared/types/types';
 const discordRpc = isElectron() ? window.api.discordRpc : null;
 type ActivityState = [QueueSong | undefined, number, PlayerStatus];
 
-const MAX_FIELD_LENGTH = 125;
+const MAX_FIELD_LENGTH = 127;
 
 const truncate = (field: string) =>
-    field.length <= MAX_FIELD_LENGTH ? field : field.substring(0, MAX_FIELD_LENGTH - 1) + '...';
+    field.length <= MAX_FIELD_LENGTH ? field : field.substring(0, MAX_FIELD_LENGTH - 1) + '…';
 
 export const useDiscordRpc = () => {
     const discordSettings = useDiscordSettings();


### PR DESCRIPTION
Apparently, the max length for some fields is 128. Truncate text fields of discord rpc to 127, with `'…';`