### PR TITLE
Fix typos in Docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ docker run --name feishin -p 9180:9180 feishin
 
 #### Docker Compose
 
-To install via Docker Compose use the following snippit. This also works on Portainer.
+To install via Docker Compose, use the following snippet. This also works on Portainer.
 
 ```yaml
 services:
@@ -126,7 +126,7 @@ services:
 2. After restarting the app, you will be prompted to select a server. Click the `Open menu` button and select `Manage servers`. Click the `Add server` button in the popup and fill out all applicable details. You will need to enter the full URL to your server, including the protocol and port if applicable (e.g. `https://navidrome.my-server.com` or `http://192.168.0.1:4533`).
 
 - **Navidrome** - For the best experience, select "Save password" when creating the server and configure the `SessionTimeout` setting in your Navidrome config to a larger value (e.g. 72h).
-    - **Linux users** - The default password store uses `libsecret`. `kwallet4/5/6` are also supported, but must be explicitly set in Settings > Window > Passwords/secret score.
+    - **Linux users** - The default password store uses `libsecret`. `kwallet4/5/6` are also supported, but must be explicitly set in Settings > Window > Passwords/secret store.
 
 3. _Optional_ - If you want to host Feishin on a subpath (not `/`), then pass in the following environment variable: `PUBLIC_PATH=PATH`. For example, to host on `/feishin`, pass in `PUBLIC_PATH=/feishin`.
 


### PR DESCRIPTION
Fix typos and grammar issues in README.md

To install via Docker Compose use the following snippit. --)  snippet, missing comma
Password/secret score. --) secret store
