### PR TITLE
fix: bring back linux deb

### DIFF
--- a/electron-builder-beta.yml
+++ b/electron-builder-beta.yml
@@ -44,6 +44,7 @@ dmg:
 linux:
     target:
         - AppImage
+        - deb
         - tar.xz
     category: AudioVideo;Audio;Player
     icon: assets/icons/icon.png

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -44,6 +44,7 @@ dmg:
 linux:
     target:
         - AppImage
+        - deb
         - tar.xz
     category: AudioVideo;Audio;Player
     icon: assets/icons/icon.png

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "license": "GPL-3.0",
     "author": {
         "name": "jeffvli",
+        "email": "feishin@users.noreply.github.com",
         "url": "https://github.com/jeffvli/"
     },
     "main": "./out/main/index.js",


### PR DESCRIPTION
This simply brings back deb release, which works automatically with auto updates.
I tested (using it right now) locally and it works great