### PR TITLE
feat(subsonic): support form post

### DIFF
--- a/src/renderer/api/subsonic/subsonic-api.ts
+++ b/src/renderer/api/subsonic/subsonic-api.ts
@@ -1,13 +1,15 @@
 import { initClient, initContract } from '@ts-rest/core';
-import axios, { AxiosError, AxiosResponse, isAxiosError, Method } from 'axios';
+import axios, { AxiosError, AxiosRequestConfig, AxiosResponse, isAxiosError } from 'axios';
 import omitBy from 'lodash/omitBy';
 import qs from 'qs';
 import { z } from 'zod';
 
 import i18n from '/@/i18n/i18n';
 import { ssType } from '/@/shared/api/subsonic/subsonic-types';
+import { hasFeature } from '/@/shared/api/utils';
 import { toast } from '/@/shared/components/toast/toast';
 import { ServerListItemWithCredential } from '/@/shared/types/domain-types';
+import { ServerFeature } from '/@/shared/types/features-types';
 
 const c = initContract();
 
@@ -312,7 +314,7 @@ export const ssApiClient = (args: {
     const { server, signal, silent, url } = args;
 
     return initClient(contract, {
-        api: async ({ body, headers, method, path }) => {
+        api: async ({ headers, method, path }) => {
             let baseUrl: string | undefined;
             const authParams: Record<string, any> = {};
 
@@ -334,25 +336,36 @@ export const ssApiClient = (args: {
                 baseUrl = url;
             }
 
+            const request: AxiosRequestConfig = {
+                headers,
+                signal,
+                // In cases where we have a fallback, don't notify the error
+                transformResponse: silent ? silentlyTransformResponse : undefined,
+                url: `${baseUrl}/${api}`,
+            };
+
+            const data = {
+                c: 'Feishin',
+                f: 'json',
+                v: '1.13.0',
+                ...authParams,
+                ...params,
+            };
+
+            if (hasFeature(server, ServerFeature.FORM_POST)) {
+                headers['Content-Type'] = 'application/x-www-form-urlencoded';
+                request.method = 'POST';
+                request.data = qs.stringify(data, { arrayFormat: 'repeat' });
+            } else {
+                request.method = method;
+                request.params = data;
+            }
+
             try {
-                const result = await axiosClient.request<
-                    z.infer<typeof ssType._response.baseResponse>
-                >({
-                    data: body,
-                    headers,
-                    method: method as Method,
-                    params: {
-                        c: 'Feishin',
-                        f: 'json',
-                        v: '1.13.0',
-                        ...authParams,
-                        ...params,
-                    },
-                    signal,
-                    // In cases where we have a fallback, don't notify the error
-                    transformResponse: silent ? silentlyTransformResponse : undefined,
-                    url: `${baseUrl}/${api}`,
-                });
+                const result =
+                    await axiosClient.request<z.infer<typeof ssType._response.baseResponse>>(
+                        request,
+                    );
 
                 return {
                     body: result.data['subsonic-response'],

--- a/src/renderer/api/subsonic/subsonic-api.ts
+++ b/src/renderer/api/subsonic/subsonic-api.ts
@@ -352,7 +352,7 @@ export const ssApiClient = (args: {
                 ...params,
             };
 
-            if (hasFeature(server, ServerFeature.FORM_POST)) {
+            if (hasFeature(server, ServerFeature.OS_FORM_POST)) {
                 headers['Content-Type'] = 'application/x-www-form-urlencoded';
                 request.method = 'POST';
                 request.data = qs.stringify(data, { arrayFormat: 'repeat' });

--- a/src/renderer/api/subsonic/subsonic-controller.ts
+++ b/src/renderer/api/subsonic/subsonic-controller.ts
@@ -997,6 +997,10 @@ export const SubsonicController: InternalControllerEndpoint = {
             features.lyricsMultipleStructured = [1];
         }
 
+        if (subsonicFeatures[SubsonicExtensions.FORM_POST]) {
+            features.formPost = [1];
+        }
+
         return { features, id: apiClientProps.server?.id, version: ping.body.serverVersion };
     },
     getSimilarSongs: async (args) => {

--- a/src/shared/types/features-types.ts
+++ b/src/shared/types/features-types.ts
@@ -2,10 +2,10 @@
 // For example: <FEATURE GROUP>: "Playlists", <FEATURE NAME>: "Smart" = "PLAYLISTS_SMART"
 export enum ServerFeature {
     BFR = 'bfr',
-    FORM_POST = 'formPost',
     LYRICS_MULTIPLE_STRUCTURED = 'lyricsMultipleStructured',
     LYRICS_SINGLE_STRUCTURED = 'lyricsSingleStructured',
     MUSIC_FOLDER_MULTISELECT = 'musicFolderMultiselect',
+    OS_FORM_POST = 'osFormPost',
     PLAYLISTS_SMART = 'playlistsSmart',
     PUBLIC_PLAYLIST = 'publicPlaylist',
     SHARING_ALBUM_SONG = 'sharingAlbumSong',

--- a/src/shared/types/features-types.ts
+++ b/src/shared/types/features-types.ts
@@ -2,6 +2,7 @@
 // For example: <FEATURE GROUP>: "Playlists", <FEATURE NAME>: "Smart" = "PLAYLISTS_SMART"
 export enum ServerFeature {
     BFR = 'bfr',
+    FORM_POST = 'formPost',
     LYRICS_MULTIPLE_STRUCTURED = 'lyricsMultipleStructured',
     LYRICS_SINGLE_STRUCTURED = 'lyricsSingleStructured',
     MUSIC_FOLDER_MULTISELECT = 'musicFolderMultiselect',


### PR DESCRIPTION
Automatically use url-encoded form post for OpenSubsonic servers that support it.

Making this a PR instead of a push, for additional testing.