### PR TITLE
Potential fix for mpv causing the queue to clear

### DIFF
--- a/src/main/features/core/player/index.ts
+++ b/src/main/features/core/player/index.ts
@@ -114,7 +114,7 @@ const createMpv = async (data: {
     mpv.on('status', (status) => {
         if (status.property === 'playlist-pos') {
             if (status.value === -1) {
-                mpv?.stop();
+                mpv?.pause();
             }
 
             if (status.value !== 0) {

--- a/src/renderer/features/player/audio-player/engine/mpv-player-engine.tsx
+++ b/src/renderer/features/player/audio-player/engine/mpv-player-engine.tsx
@@ -156,9 +156,11 @@ export const MpvPlayerEngine = (props: MpvPlayerEngineProps) => {
                 mpvPlayer.setQueue(currentSrc, nextSrc, playerStatus !== PlayerStatus.PLAYING);
                 setPreviousCurrentSrc(currentSrc);
             } else {
-                // Clear queue if no current song
-                mpvPlayer.setQueue(undefined, undefined, true);
-                setPreviousCurrentSrc(undefined);
+                // Only clear queue if we had a previous currentSrc (intentional clear)
+                if (previousCurrentSrc !== undefined) {
+                    mpvPlayer.setQueue(undefined, undefined, true);
+                    setPreviousCurrentSrc(undefined);
+                }
             }
         } else {
             // If currentSrc hasn't changed but nextSrc has, update position 1


### PR DESCRIPTION
In some cases when the queue finishes, the mpv.stop command would cause the queue to clear.