### PR TITLE
Increase ItemCard image resolution to 300x300 in 'poster' mode

### DIFF
--- a/src/renderer/components/item-card/item-card.tsx
+++ b/src/renderer/components/item-card/item-card.tsx
@@ -70,6 +70,11 @@ export const ItemCard = ({
     const imageUrl = getImageUrl(data);
     const rows = providedRows || [];
 
+    const upsizedImageUrl = imageUrl
+        ?.replace(/&size=\d+/, '&size=300')
+        .replace(/\?width=\d+/, '?width=300')
+        .replace(/&height=\d+/, '&height=300');
+
     switch (type) {
         case 'compact':
             return (
@@ -95,7 +100,7 @@ export const ItemCard = ({
                     enableDrag={enableDrag}
                     enableExpansion={enableExpansion}
                     enableNavigation={enableNavigation}
-                    imageUrl={imageUrl}
+                    imageUrl={upsizedImageUrl}
                     internalState={internalState}
                     isRound={isRound}
                     itemType={itemType}
@@ -112,7 +117,7 @@ export const ItemCard = ({
                     enableDrag={enableDrag}
                     enableExpansion={enableExpansion}
                     enableNavigation={enableNavigation}
-                    imageUrl={imageUrl}
+                    imageUrl={upsizedImageUrl}
                     internalState={internalState}
                     isRound={isRound}
                     itemType={itemType}


### PR DESCRIPTION
Increased the resolution slightly for tracks in the search view (when using grid displayType). I used the same pattern as in other places where we need a certain resolution.


### Before
<img width="1174" height="579" alt="Screenshot 2025-12-11 at 14 23 41" src="https://github.com/user-attachments/assets/cf68d53f-8b86-4a91-bc7c-835abd67ea65" />


### After
<img width="1106" height="557" alt="Screenshot 2025-12-11 at 14 20 35" src="https://github.com/user-attachments/assets/80968335-f976-4972-9759-9f9770cd45ba" />

Closes #1330