### PR TITLE
fixed favorites tracks/albums/artists selection

### DIFF
--- a/src/renderer/components/page-header/page-header.module.css
+++ b/src/renderer/components/page-header/page-header.module.css
@@ -37,6 +37,18 @@
     input {
         -webkit-app-region: no-drag;
     }
+
+    [role='button'] {
+        -webkit-app-region: no-drag;
+    }
+
+    a {
+        -webkit-app-region: no-drag;
+    }
+
+    [style*='cursor: pointer'] {
+        -webkit-app-region: no-drag;
+    }
 }
 
 .header.pad-right {


### PR DESCRIPTION
when using "Web (hidden)" as window bar style, the favorites selection (tracks, albums, artists) was not clickable on macOS. didn't test Windows