### PR TITLE
feat: show record label copyright at bottom of track listing

### DIFF
--- a/src/renderer/api/jellyfin/jellyfin-controller.ts
+++ b/src/renderer/api/jellyfin/jellyfin-controller.ts
@@ -360,7 +360,7 @@ export const JellyfinController: InternalControllerEndpoint = {
             },
             query: {
                 ...artistQuery,
-                Fields: 'People, Tags',
+                Fields: 'People, Tags, Studios',
                 GenreIds: query.genreIds ? query.genreIds.join(',') : undefined,
                 IncludeItemTypes: 'MusicAlbum',
                 IsFavorite: query.favorite,

--- a/src/renderer/features/albums/components/album-detail-content.module.css
+++ b/src/renderer/features/albums/components/album-detail-content.module.css
@@ -79,3 +79,8 @@
         overflow-y: auto;
     }
 }
+
+.release-label {
+    font-size: var(--theme-font-size-sm);
+    color: var(--theme-colors-foreground-muted);
+}

--- a/src/renderer/features/albums/components/album-detail-content.module.css
+++ b/src/renderer/features/albums/components/album-detail-content.module.css
@@ -79,8 +79,3 @@
         overflow-y: auto;
     }
 }
-
-.release-label {
-    font-size: var(--theme-font-size-sm);
-    color: var(--theme-colors-foreground-muted);
-}

--- a/src/renderer/features/albums/components/album-detail-content.tsx
+++ b/src/renderer/features/albums/components/album-detail-content.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from '@tanstack/react-query';
-import clsx from 'clsx';
 import { ReactNode, Suspense, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { generatePath, useParams } from 'react-router';
@@ -403,7 +402,7 @@ export const AlbumDetailContent = () => {
                 {labels && (
                     <Stack gap="xs">
                         {labels.map((label) => (
-                            <Text className={clsx(styles.releaseLabel)} key={`label-${label}`}>
+                            <Text isMuted key={`label-${label}`} size="sm">
                                 ℗{releaseYear ? ` ${releaseYear}` : ''} {label}
                             </Text>
                         ))}

--- a/src/renderer/features/albums/components/album-detail-content.tsx
+++ b/src/renderer/features/albums/components/album-detail-content.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import clsx from 'clsx';
 import { ReactNode, Suspense, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { generatePath, useParams } from 'react-router';
@@ -362,6 +363,9 @@ export const AlbumDetailContent = () => {
 
     const comment = detailQuery?.data?.comment;
 
+    const releaseYear = detailQuery?.data?.releaseYear;
+    const labels = detailQuery?.data?.recordLabels;
+
     const mbzId = detailQuery?.data?.mbzId;
 
     return (
@@ -396,7 +400,14 @@ export const AlbumDetailContent = () => {
                         </Stack>
                     </div>
                 </div>
-
+                <Stack gap="xs">
+                    {labels &&
+                        labels.map((label) => (
+                            <Text className={clsx(styles.releaseLabel)} key={`label-${label}`}>
+                                ©{releaseYear ? ` ${releaseYear}` : ''} {label}
+                            </Text>
+                        ))}
+                </Stack>
                 <Stack gap="lg" mt="3rem">
                     {cq.height || cq.width ? (
                         <Suspense fallback={<Spinner container />}>

--- a/src/renderer/features/albums/components/album-detail-content.tsx
+++ b/src/renderer/features/albums/components/album-detail-content.tsx
@@ -404,7 +404,7 @@ export const AlbumDetailContent = () => {
                     <Stack gap="xs">
                         {labels.map((label) => (
                             <Text className={clsx(styles.releaseLabel)} key={`label-${label}`}>
-                                ©{releaseYear ? ` ${releaseYear}` : ''} {label}
+                                ℗{releaseYear ? ` ${releaseYear}` : ''} {label}
                             </Text>
                         ))}
                     </Stack>

--- a/src/renderer/features/albums/components/album-detail-content.tsx
+++ b/src/renderer/features/albums/components/album-detail-content.tsx
@@ -400,14 +400,15 @@ export const AlbumDetailContent = () => {
                         </Stack>
                     </div>
                 </div>
-                <Stack gap="xs">
-                    {labels &&
-                        labels.map((label) => (
+                {labels && (
+                    <Stack gap="xs">
+                        {labels.map((label) => (
                             <Text className={clsx(styles.releaseLabel)} key={`label-${label}`}>
                                 ©{releaseYear ? ` ${releaseYear}` : ''} {label}
                             </Text>
                         ))}
-                </Stack>
+                    </Stack>
+                )}
                 <Stack gap="lg" mt="3rem">
                     {cq.height || cq.width ? (
                         <Suspense fallback={<Spinner container />}>

--- a/src/shared/api/jellyfin/jellyfin-normalize.ts
+++ b/src/shared/api/jellyfin/jellyfin-normalize.ts
@@ -323,7 +323,7 @@ const normalizeAlbum = (
         originalDate: null,
         participants: getPeople(item),
         playCount: item.UserData?.PlayCount || 0,
-        recordLabels: [],
+        recordLabels: item.Studios?.map((entry) => entry.Name) || [],
         releaseDate: item.PremiereDate || null,
         releaseTypes: [],
         releaseYear: item.ProductionYear || null,

--- a/src/shared/api/jellyfin/jellyfin-types.ts
+++ b/src/shared/api/jellyfin/jellyfin-types.ts
@@ -525,6 +525,11 @@ const albumArtist = z.object({
     UserData: userData.optional(),
 });
 
+const studio = z.object({
+    Id: z.string(),
+    Name: z.string(),
+});
+
 const albumDetailParameters = baseParameters;
 
 const album = z.object({
@@ -555,6 +560,7 @@ const album = z.object({
     RunTimeTicks: z.number(),
     ServerId: z.string(),
     Songs: z.array(song).optional(), // This is not a native Jellyfin property -- this is used for combined album detail
+    Studios: z.array(studio),
     Tags: z.string().array().optional(),
     Type: z.string(),
     UserData: userData.optional(),


### PR DESCRIPTION
This PR adds a very basic copyright listing of each record label associated with a given album, with examples as such:

<img width="350" height="87" alt="image" src="https://github.com/user-attachments/assets/d44e6a89-7d5c-4300-af5a-79bc5f45f118" /> <br>
<img width="345" height="101" alt="image" src="https://github.com/user-attachments/assets/07d134c7-0259-43ee-a96e-159d2e5e4326" /> <br>
<img width="218" height="86" alt="image" src="https://github.com/user-attachments/assets/acb105ed-63d0-4344-97a0-0f017dd2e644" />

If no labels are present on the given album, nothing will be displayed and no extra space will be taken up.
Additionally, if a release year is not present on the album, it will be left out while the label name remains.