### PR TITLE
Fix API parameter for Jellyfin 10.12 and up

### DIFF
--- a/src/renderer/api/jellyfin/jellyfin-controller.ts
+++ b/src/renderer/api/jellyfin/jellyfin-controller.ts
@@ -38,12 +38,6 @@ const MAX_ITEMS_PER_PLAYLIST_ADD = 50;
 
 const VERSION_INFO: VersionInfo = [
     [
-        '10.12.0',
-        {
-            [ServerFeature.API_KEY_CAMELCASE]: [1],
-        },
-    ],
-    [
         '10.9.0',
         {
             [ServerFeature.LYRICS_SINGLE_STRUCTURED]: [1],
@@ -52,13 +46,6 @@ const VERSION_INFO: VersionInfo = [
     ],
     ['10.0.0', { [ServerFeature.TAGS]: [1] }],
 ];
-
-const getApiKeyParam = (server: any): string => {
-    if (hasFeature(server, ServerFeature.API_KEY_CAMELCASE)) {
-        return 'ApiKey';
-    }
-    return 'api_key';
-};
 
 export const JellyfinController: InternalControllerEndpoint = {
     addToPlaylist: async (args) => {
@@ -441,9 +428,8 @@ export const JellyfinController: InternalControllerEndpoint = {
         }).then((result) => result!.totalRecordCount!),
     getDownloadUrl: (args) => {
         const { apiClientProps, query } = args;
-        const apiKeyParam = getApiKeyParam(apiClientProps.server);
 
-        return `${apiClientProps.server?.url}/items/${query.id}/download?${apiKeyParam}=${apiClientProps.server?.credential}`;
+        return `${apiClientProps.server?.url}/items/${query.id}/download?apiKey=${apiClientProps.server?.credential}`;
     },
     getFolder: async ({ apiClientProps, query }) => {
         const userId = apiClientProps.server?.userId;
@@ -1106,9 +1092,8 @@ export const JellyfinController: InternalControllerEndpoint = {
     getStreamUrl: ({ apiClientProps: { server }, query }) => {
         const { bitrate, format, id, transcode } = query;
         const deviceId = '';
-        const apiKeyParam = getApiKeyParam(server);
 
-        let url = `${server?.url}/Items/${id}/Download?${apiKeyParam}=${server?.credential}&playSessionId=${deviceId}`;
+        let url = `${server?.url}/Items/${id}/Download?apiKey=${server?.credential}&playSessionId=${deviceId}`;
 
         if (transcode) {
             // Some format appears to be required. Fall back to trusty MP3 if not specified

--- a/src/renderer/api/jellyfin/jellyfin-controller.ts
+++ b/src/renderer/api/jellyfin/jellyfin-controller.ts
@@ -38,6 +38,12 @@ const MAX_ITEMS_PER_PLAYLIST_ADD = 50;
 
 const VERSION_INFO: VersionInfo = [
     [
+        '10.11.0',
+        {
+            [ServerFeature.API_KEY_CAMELCASE]: [1],
+        },
+    ],
+    [
         '10.9.0',
         {
             [ServerFeature.LYRICS_SINGLE_STRUCTURED]: [1],
@@ -46,6 +52,13 @@ const VERSION_INFO: VersionInfo = [
     ],
     ['10.0.0', { [ServerFeature.TAGS]: [1] }],
 ];
+
+const getApiKeyParam = (server: any): string => {
+    if (hasFeature(server, ServerFeature.API_KEY_CAMELCASE)) {
+        return 'ApiKey';
+    }
+    return 'api_key';
+};
 
 export const JellyfinController: InternalControllerEndpoint = {
     addToPlaylist: async (args) => {
@@ -428,8 +441,9 @@ export const JellyfinController: InternalControllerEndpoint = {
         }).then((result) => result!.totalRecordCount!),
     getDownloadUrl: (args) => {
         const { apiClientProps, query } = args;
+        const apiKeyParam = getApiKeyParam(apiClientProps.server);
 
-        return `${apiClientProps.server?.url}/items/${query.id}/download?api_key=${apiClientProps.server?.credential}`;
+        return `${apiClientProps.server?.url}/items/${query.id}/download?${apiKeyParam}=${apiClientProps.server?.credential}`;
     },
     getFolder: async ({ apiClientProps, query }) => {
         const userId = apiClientProps.server?.userId;
@@ -1092,8 +1106,9 @@ export const JellyfinController: InternalControllerEndpoint = {
     getStreamUrl: ({ apiClientProps: { server }, query }) => {
         const { bitrate, format, id, transcode } = query;
         const deviceId = '';
+        const apiKeyParam = getApiKeyParam(server);
 
-        let url = `${server?.url}/Items/${id}/Download?api_key=${server?.credential}&playSessionId=${deviceId}`;
+        let url = `${server?.url}/Items/${id}/Download?${apiKeyParam}=${server?.credential}&playSessionId=${deviceId}`;
 
         if (transcode) {
             // Some format appears to be required. Fall back to trusty MP3 if not specified

--- a/src/renderer/api/jellyfin/jellyfin-controller.ts
+++ b/src/renderer/api/jellyfin/jellyfin-controller.ts
@@ -38,7 +38,7 @@ const MAX_ITEMS_PER_PLAYLIST_ADD = 50;
 
 const VERSION_INFO: VersionInfo = [
     [
-        '10.11.0',
+        '10.12.0',
         {
             [ServerFeature.API_KEY_CAMELCASE]: [1],
         },

--- a/src/shared/types/features-types.ts
+++ b/src/shared/types/features-types.ts
@@ -1,6 +1,7 @@
 // Should follow a strict naming convention: "<FEATURE GROUP>_<FEATURE NAME>"
 // For example: <FEATURE GROUP>: "Playlists", <FEATURE NAME>: "Smart" = "PLAYLISTS_SMART"
 export enum ServerFeature {
+    API_KEY_CAMELCASE = 'apiKeyCamelCase',
     BFR = 'bfr',
     LYRICS_MULTIPLE_STRUCTURED = 'lyricsMultipleStructured',
     LYRICS_SINGLE_STRUCTURED = 'lyricsSingleStructured',

--- a/src/shared/types/features-types.ts
+++ b/src/shared/types/features-types.ts
@@ -1,7 +1,6 @@
 // Should follow a strict naming convention: "<FEATURE GROUP>_<FEATURE NAME>"
 // For example: <FEATURE GROUP>: "Playlists", <FEATURE NAME>: "Smart" = "PLAYLISTS_SMART"
 export enum ServerFeature {
-    API_KEY_CAMELCASE = 'apiKeyCamelCase',
     BFR = 'bfr',
     LYRICS_MULTIPLE_STRUCTURED = 'lyricsMultipleStructured',
     LYRICS_SINGLE_STRUCTURED = 'lyricsSingleStructured',


### PR DESCRIPTION
Added a version check for Jellyfin servers 10.11+ to use the new "ApiKey" syntax.
Also added a API_KEY_CAMELCASE feature flag for this case.

Marked as draft because I've only tested it on my machine with my server.