### PR TITLE
Set minimum length in the available server list in <ServerRequired> to 1 instead of 2

### DIFF
--- a/src/renderer/features/action-required/components/server-required.tsx
+++ b/src/renderer/features/action-required/components/server-required.tsx
@@ -30,7 +30,7 @@ export const ServerRequired = () => {
 
     const isServerLock = Boolean(window.SERVER_LOCK) || false;
 
-    if (Object.keys(serverList).length > 1) {
+    if (Object.keys(serverList).length > 0) {
         return (
             <ScrollArea>
                 <Stack miw="300px">


### PR DESCRIPTION
The server list in ServerRequired was expecting at least 2 items before it was shown, meaning that if you are on the login screen, you couldn't select your configured server and had to add another one.

Related to #1433, although I found a more permanent fix for the issue I found there, and will open a separate PR for it.