### PR TITLE
Improve network error detection and reduced retry delay

### DIFF
--- a/src/renderer/hooks/use-server-authenticated.ts
+++ b/src/renderer/hooks/use-server-authenticated.ts
@@ -17,17 +17,23 @@ import { AuthState } from '/@/shared/types/types';
 const localSettings = isElectron() ? window.api.localSettings : null;
 
 const MIN_AUTH_DELAY_MS = 1000;
-const MAX_NETWORK_RETRIES = 3;
-const NETWORK_RETRY_DELAY_MS = 2000;
+const MAX_NETWORK_RETRIES = 1;
+const NETWORK_RETRY_DELAY_MS = 500;
 
 const isNetworkError = (error: any): boolean => {
+    const message =
+        error.message && typeof error.message === 'string' ? (error.message as string) : null;
+    const messageLower = message?.toLowerCase();
+
+    if (messageLower?.includes('network') || messageLower?.includes('timeout')) {
+        return true;
+    }
+
     return (
         isAxiosError(error) &&
         (error.code === 'ERR_NETWORK' ||
             error.code === 'ECONNABORTED' ||
             error.code === 'ETIMEDOUT' ||
-            error.message?.toLowerCase().includes('network') ||
-            error.message?.toLowerCase().includes('timeout') ||
             !navigator.onLine)
     );
 };


### PR DESCRIPTION
When a Jellyfin server is fully offline, an Axios error won't be returned, so `isNetworkError()` will always be false. I moved the string checks to run even if the error isn't an Axios error.

This isn't really that good of a fix, to be honest if the error isn't an Axios error it probably is a connection error.

I also reduced the amount of retries and the time between said retries, since it slows down the interface quite a bit.

Ideally this should be merged alongside #1435, since a network error redirects to that route, which doesn't have translation strings at the moment, and isn't that usable.

Fixes #1433 