### PR TITLE
Bump electron version

### DIFF
--- a/electron-builder-beta.yml
+++ b/electron-builder-beta.yml
@@ -1,7 +1,7 @@
 appId: org.jeffvli.feishin
 productName: Feishin
 artifactName: ${productName}-${version}-${os}-${arch}.${ext}
-electronVersion: 38.5.0
+electronVersion: 39.2.7
 directories:
     buildResources: assets
 files:

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,7 +1,7 @@
 appId: org.jeffvli.feishin
 productName: Feishin
 artifactName: ${productName}-${version}-${os}-${arch}.${ext}
-electronVersion: 38.5.0
+electronVersion: 39.2.7
 directories:
     buildResources: assets
 files:

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
         "@vitejs/plugin-react": "^5.1.1",
         "concurrently": "^9.2.1",
         "cross-env": "^10.1.0",
-        "electron": "^38.5.0",
+        "electron": "^39.2.7",
         "electron-builder": "^26.0.12",
         "electron-devtools-installer": "^4.0.0",
         "electron-vite": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,10 +19,10 @@ importers:
         version: 1.1.0
       '@electron-toolkit/preload':
         specifier: ^3.0.1
-        version: 3.0.2(electron@38.5.0)
+        version: 3.0.2(electron@39.2.7)
       '@electron-toolkit/utils':
         specifier: ^4.0.0
-        version: 4.0.0(electron@38.5.0)
+        version: 4.0.0(electron@39.2.7)
       '@mantine/colors-generator':
         specifier: ^8.3.8
         version: 8.3.8(chroma-js@3.1.2)
@@ -271,8 +271,8 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0
       electron:
-        specifier: ^38.5.0
-        version: 38.5.0
+        specifier: ^39.2.7
+        version: 39.2.7
       electron-builder:
         specifier: ^26.0.12
         version: 26.0.12(electron-builder-squirrel-windows@26.0.12)
@@ -2866,8 +2866,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@38.5.0:
-    resolution: {integrity: sha512-dbC7V+eZweerYMJfxQldzHOg37a1VdNMCKxrJxlkp3cA30gOXtXSg4ZYs07L5+QwI19WOy1uyvtEUgbw1RRsCQ==}
+  electron@39.2.7:
+    resolution: {integrity: sha512-KU0uFS6LSTh4aOIC3miolcbizOFP7N1M46VTYVfqIgFiuA2ilfNaOHLDS9tCMvwwHRowAsvqBrh9NgMXcTOHCQ==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
@@ -6693,17 +6693,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron-toolkit/preload@3.0.2(electron@38.5.0)':
+  '@electron-toolkit/preload@3.0.2(electron@39.2.7)':
     dependencies:
-      electron: 38.5.0
+      electron: 39.2.7
 
   '@electron-toolkit/tsconfig@2.0.0(@types/node@24.10.1)':
     dependencies:
       '@types/node': 24.10.1
 
-  '@electron-toolkit/utils@4.0.0(electron@38.5.0)':
+  '@electron-toolkit/utils@4.0.0(electron@39.2.7)':
     dependencies:
-      electron: 38.5.0
+      electron: 39.2.7
 
   '@electron/asar@3.2.18':
     dependencies:
@@ -7612,7 +7612,7 @@ snapshots:
 
   '@types/electron-localshortcut@3.1.3':
     dependencies:
-      electron: 38.5.0
+      electron: 39.2.7
     transitivePeerDependencies:
       - supports-color
 
@@ -8775,7 +8775,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@38.5.0:
+  electron@39.2.7:
     dependencies:
       '@electron/get': 2.0.3
       '@types/node': 22.15.32


### PR DESCRIPTION
This solves an issue I ran into while packaging Feishin on Solus where Feishin's main window would never appear under Wayland. It also may solve #1295 (as in, I can't reproduce that bug running Electron 39.2.7, but I couldn't get Wayland support to work at all before... so the two *might* be unrelated). 