### PR TITLE
fix: correct propagation on settings menu

### DIFF
--- a/src/renderer/features/player/components/player-config.tsx
+++ b/src/renderer/features/player/components/player-config.tsx
@@ -406,8 +406,8 @@ export const PlayerConfig = () => {
                     iconProps={{
                         size: 'lg',
                     }}
-                    stopsPropagation
                     size="sm"
+                    stopsPropagation
                     tooltip={{
                         label: t('common.setting_other', { postProcess: 'titleCase' }),
                         openDelay: 0,

--- a/src/renderer/features/player/components/player-config.tsx
+++ b/src/renderer/features/player/components/player-config.tsx
@@ -406,6 +406,7 @@ export const PlayerConfig = () => {
                     iconProps={{
                         size: 'lg',
                     }}
+                    stopsPropagation
                     size="sm"
                     tooltip={{
                         label: t('common.setting_other', { postProcess: 'titleCase' }),

--- a/src/renderer/features/player/components/right-controls.tsx
+++ b/src/renderer/features/player/components/right-controls.tsx
@@ -95,7 +95,10 @@ const AutoDJButton = () => {
 
     return (
         <Button
-            onClick={toggleAutoDJ}
+            onClick={(e) => {
+                e.stopPropagation();
+                toggleAutoDJ();
+            }}
             size="compact-xs"
             style={{ color: settings.enabled ? 'var(--theme-colors-primary)' : undefined }}
             uppercase

--- a/src/renderer/features/shared/components/list-config-menu.tsx
+++ b/src/renderer/features/shared/components/list-config-menu.tsx
@@ -207,8 +207,8 @@ export const ListConfigTable = ({
             variant="vertical"
             withColumnBorders={false}
             withRowBorders={false}
-            withTableBorder={false}
             onClick={(e) => e.stopPropagation()}
+            withTableBorder={false}
         >
             <Table.Tbody>
                 {options.map((option) => {

--- a/src/renderer/features/shared/components/list-config-menu.tsx
+++ b/src/renderer/features/shared/components/list-config-menu.tsx
@@ -202,12 +202,12 @@ export const ListConfigTable = ({
 }) => {
     return (
         <Table
+            onClick={(e) => e.stopPropagation()}
             style={{ borderRadius: '1rem' }}
             styles={{ th: { backgroundColor: 'initial', padding: 'var(--theme-spacing-md) 0' } }}
             variant="vertical"
             withColumnBorders={false}
             withRowBorders={false}
-            onClick={(e) => e.stopPropagation()}
             withTableBorder={false}
         >
             <Table.Tbody>

--- a/src/renderer/features/shared/components/list-config-menu.tsx
+++ b/src/renderer/features/shared/components/list-config-menu.tsx
@@ -208,6 +208,7 @@ export const ListConfigTable = ({
             withColumnBorders={false}
             withRowBorders={false}
             withTableBorder={false}
+            onClick={(e) => e.stopPropagation()}
         >
             <Table.Tbody>
                 {options.map((option) => {

--- a/src/shared/components/action-icon/action-icon.tsx
+++ b/src/shared/components/action-icon/action-icon.tsx
@@ -16,8 +16,8 @@ export interface ActionIconProps
         MantineActionIconProps {
     icon?: keyof typeof AppIcon;
     iconProps?: Omit<IconProps, 'icon'>;
-    tooltip?: Omit<TooltipProps, 'children'>;
     stopsPropagation?: boolean;
+    tooltip?: Omit<TooltipProps, 'children'>;
 }
 
 const _ActionIcon = forwardRef<HTMLButtonElement, ActionIconProps>(
@@ -28,10 +28,10 @@ const _ActionIcon = forwardRef<HTMLButtonElement, ActionIconProps>(
             icon,
             iconProps,
             size = 'sm',
-            tooltip,
             stopsPropagation,
-            variant = 'default',
+            tooltip,
             onClick,
+            variant = 'default',
             ...props
         },
         ref,

--- a/src/shared/components/action-icon/action-icon.tsx
+++ b/src/shared/components/action-icon/action-icon.tsx
@@ -27,10 +27,10 @@ const _ActionIcon = forwardRef<HTMLButtonElement, ActionIconProps>(
             classNames,
             icon,
             iconProps,
+            onClick,
             size = 'sm',
             stopsPropagation,
             tooltip,
-            onClick,
             variant = 'default',
             ...props
         },

--- a/src/shared/components/action-icon/action-icon.tsx
+++ b/src/shared/components/action-icon/action-icon.tsx
@@ -17,6 +17,7 @@ export interface ActionIconProps
     icon?: keyof typeof AppIcon;
     iconProps?: Omit<IconProps, 'icon'>;
     tooltip?: Omit<TooltipProps, 'children'>;
+    stopsPropagation?: boolean;
 }
 
 const _ActionIcon = forwardRef<HTMLButtonElement, ActionIconProps>(
@@ -28,11 +29,18 @@ const _ActionIcon = forwardRef<HTMLButtonElement, ActionIconProps>(
             iconProps,
             size = 'sm',
             tooltip,
+            stopsPropagation,
             variant = 'default',
+            onClick,
             ...props
         },
         ref,
     ) => {
+        const handleClick = (e: any) => {
+            if (stopsPropagation) e.stopPropagation();
+            if (onClick) onClick(e);
+        };
+
         const actionIconProps: ActionIconProps = {
             classNames: {
                 root: styles.root,
@@ -41,6 +49,7 @@ const _ActionIcon = forwardRef<HTMLButtonElement, ActionIconProps>(
             size,
             variant,
             ...props,
+            onClick: handleClick,
         };
 
         if (tooltip && icon) {


### PR DESCRIPTION
In the latest betas, if you have "Playerbar toggles fullscreen player" enabled, it clicking the DJ and player settings buttons did not correctly work. This change fixes that and adds a `stopsPropagation` attribute to IconButtons for future use if required.

Does not change lyric drawer button because that behavior is intended