### PR TITLE
forcing string value for EP to always be upper case

### DIFF
--- a/src/renderer/features/artists/components/album-artist-detail-content.tsx
+++ b/src/renderer/features/artists/components/album-artist-detail-content.tsx
@@ -1165,7 +1165,7 @@ const ArtistAlbums = ({ albumsQuery }: ArtistAlbumsProps) => {
                         break;
                     case 'ep':
                         displayName = t('releaseType.primary.ep', {
-                            postProcess: 'sentenceCase',
+                            postProcess: 'upperCase',
                         });
                         break;
                     case 'field recording':


### PR DESCRIPTION
Using `sentenceCase` was causing it to always show up like this: "Ep". From looking at the translations some have it as "ep" and some as "EP" so having it use `upperCase` would make sure it always shows up as "EP".

fixes https://github.com/jeffvli/feishin/issues/1470