### PR TITLE
fix: Sort top songs by play count instead of community rating

### DIFF
--- a/src/renderer/api/jellyfin/jellyfin-controller.ts
+++ b/src/renderer/api/jellyfin/jellyfin-controller.ts
@@ -1257,7 +1257,7 @@ export const JellyfinController: InternalControllerEndpoint = {
                 IncludeItemTypes: 'Audio',
                 Limit: query.limit,
                 Recursive: true,
-                SortBy: 'CommunityRating,SortName',
+                SortBy: 'PlayCount,SortName',
                 SortOrder: 'Descending',
                 UserId: apiClientProps.server?.userId,
             },


### PR DESCRIPTION
## Summary
- Changes the "Top Songs" sort from `CommunityRating` to `PlayCount` for Jellyfin servers

## Problem
The Top Songs section in the album artist view was sorting songs by `CommunityRating,SortName` instead of by play count. This meant the songs displayed as "Top Songs" weren't actually the most played songs, which is the expected behavior for this feature.

## Solution
Changed the `SortBy` parameter in `getTopSongs` for the Jellyfin controller from `CommunityRating,SortName` to `PlayCount,SortName`. This ensures songs are ordered by their actual play count (descending), showing the most played songs first.

## Test plan
- [x] Verify Top Songs section shows songs ordered by play count
- [x] Verify sorting works correctly with Jellyfin server

Fixes #1512

🤖 Generated with [Claude Code](https://claude.com/claude-code)