### PR TITLE
Added sorting by Disc Number and Track Number for SongListSort.COMMENT

### DIFF
--- a/src/shared/api/utils.ts
+++ b/src/shared/api/utils.ts
@@ -180,7 +180,11 @@ export const sortSongList = (songs: Song[], sortBy: SongListSort, sortOrder: Sor
             break;
 
         case SongListSort.COMMENT:
-            results = orderBy(results, ['comment'], [order]);
+            results = orderBy(
+                results,
+                ['comment', 'discNumber', 'trackNumber'],
+                [order, order, 'asc', 'asc'],
+            );
             break;
 
         case SongListSort.DURATION:


### PR DESCRIPTION
Reason: for electronic music I often use "comment" as a duplicate for "catalog number" value. This fix is useful when songs are sorted by comment (i.e. catalog number) to be also sorted by track number