### PR TITLE
Improve file container display

### DIFF
--- a/src/renderer/features/player/components/full-screen-player-image.tsx
+++ b/src/renderer/features/player/components/full-screen-player-image.tsx
@@ -211,17 +211,12 @@ export const FullScreenPlayerImage = () => {
                     ))}
                 </Text>
                 <Group justify="center" mt="sm">
-                    {(currentSong?.container && currentSong?.bitRate && (
+                    {currentSong?.container && (
                         <Badge variant="transparent">
-                            {currentSong?.container.replace('audio/', '')}{' '}
-                            {Math.round(currentSong.bitRate / 100) * 100}
+                            {currentSong?.container.replace('audio/', '')}
+                            {currentSong?.bitRate && Math.round(currentSong.bitRate / 100) * 100}
                         </Badge>
-                    )) ||
-                        (currentSong?.container && (
-                            <Badge variant="transparent">
-                                {currentSong?.container.replace('audio/', '')}
-                            </Badge>
-                        ))}
+                    )}
                     {currentSong?.releaseYear && (
                         <Badge variant="transparent">{currentSong?.releaseYear}</Badge>
                     )}

--- a/src/renderer/features/player/components/full-screen-player-image.tsx
+++ b/src/renderer/features/player/components/full-screen-player-image.tsx
@@ -214,7 +214,7 @@ export const FullScreenPlayerImage = () => {
                     {currentSong?.container && (
                         <Badge variant="transparent">
                             {currentSong?.container.replace('audio/', '')}
-                            {currentSong?.bitRate && Math.round(currentSong.bitRate / 100) * 100}
+                            {currentSong?.bitRate && ` ${Math.round(currentSong.bitRate / 100) * 100}`}
                         </Badge>
                     )}
                     {currentSong?.releaseYear && (

--- a/src/renderer/features/player/components/full-screen-player-image.tsx
+++ b/src/renderer/features/player/components/full-screen-player-image.tsx
@@ -214,7 +214,8 @@ export const FullScreenPlayerImage = () => {
                     {currentSong?.container && (
                         <Badge variant="transparent">
                             {currentSong?.container.replace('audio/', '')}
-                            {currentSong?.bitRate && ` ${Math.round(currentSong.bitRate / 100) * 100}`}
+                            {currentSong?.bitRate &&
+                                ` ${Math.round(currentSong.bitRate / 100) * 100}`}
                         </Badge>
                     )}
                     {currentSong?.releaseYear && (

--- a/src/renderer/features/player/components/full-screen-player-image.tsx
+++ b/src/renderer/features/player/components/full-screen-player-image.tsx
@@ -211,11 +211,17 @@ export const FullScreenPlayerImage = () => {
                     ))}
                 </Text>
                 <Group justify="center" mt="sm">
-                    {(currentSong?.container && currentSong?.bitRate) && (
-                        <Badge variant="transparent">{currentSong?.container.replace("audio/", "")} {Math.round(currentSong.bitRate / 100) * 100}</Badge>
-                    ) || currentSong?.container && (
-                        <Badge variant="transparent">{currentSong?.container.replace("audio/", "")}</Badge>
-                    )}
+                    {(currentSong?.container && currentSong?.bitRate && (
+                        <Badge variant="transparent">
+                            {currentSong?.container.replace('audio/', '')}{' '}
+                            {Math.round(currentSong.bitRate / 100) * 100}
+                        </Badge>
+                    )) ||
+                        (currentSong?.container && (
+                            <Badge variant="transparent">
+                                {currentSong?.container.replace('audio/', '')}
+                            </Badge>
+                        ))}
                     {currentSong?.releaseYear && (
                         <Badge variant="transparent">{currentSong?.releaseYear}</Badge>
                     )}

--- a/src/renderer/features/player/components/full-screen-player-image.tsx
+++ b/src/renderer/features/player/components/full-screen-player-image.tsx
@@ -211,8 +211,10 @@ export const FullScreenPlayerImage = () => {
                     ))}
                 </Text>
                 <Group justify="center" mt="sm">
-                    {currentSong?.container && (
-                        <Badge variant="transparent">{currentSong?.container}</Badge>
+                    {(currentSong?.container && currentSong?.bitRate) && (
+                        <Badge variant="transparent">{currentSong?.container.replace("audio/", "")} {Math.round(currentSong.bitRate / 100) * 100}</Badge>
+                    ) || currentSong?.container && (
+                        <Badge variant="transparent">{currentSong?.container.replace("audio/", "")}</Badge>
                     )}
                     {currentSong?.releaseYear && (
                         <Badge variant="transparent">{currentSong?.releaseYear}</Badge>


### PR DESCRIPTION
This PR changes the file type display on the fullscreen player to remove the AUDIO/ prefix (present sometimes) and adds a rounded bitrate to it. If the server does not provide bitrate, it is simply not displayed (falls back to just the file type).

Before | after
<img width="1200" height="890" alt="image" src="https://github.com/user-attachments/assets/436cbcf7-970b-417a-af21-2d77cad7b09a" />
