### PR TITLE
fix: Use .ico file on Windows

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -15,7 +15,7 @@ win:
     target:
         - zip
         - nsis
-    icon: assets/icons/icon.png
+    icon: assets/icons/icon.ico
 
 nsis:
     allowToChangeInstallationDirectory: true

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -275,7 +275,9 @@ async function createWindow(first = true): Promise<void> {
         autoHideMenuBar: true,
         frame: false,
         height: 900,
-        icon: getAssetPath('icons/icon.png'),
+        icon: isWindows()
+            ? getAssetPath('icons/icon.ico')
+            : getAssetPath('icons/icon.png'),
         minHeight: 640,
         minWidth: 480,
         show: false,
@@ -435,7 +437,9 @@ async function createWindow(first = true): Promise<void> {
     });
 
     if (isWindows()) {
-        app.setAppUserModelId('org.jeffvli.feishin');
+        app.setAppUserModelId(
+            is.dev ? 'org.jeffvli.feishin.dev' : 'org.jeffvli.feishin',
+        );
     }
 
     if (isMacOS()) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -275,9 +275,7 @@ async function createWindow(first = true): Promise<void> {
         autoHideMenuBar: true,
         frame: false,
         height: 900,
-        icon: isWindows()
-            ? getAssetPath('icons/icon.ico')
-            : getAssetPath('icons/icon.png'),
+        icon: isWindows() ? getAssetPath('icons/icon.ico') : getAssetPath('icons/icon.png'),
         minHeight: 640,
         minWidth: 480,
         show: false,
@@ -437,9 +435,7 @@ async function createWindow(first = true): Promise<void> {
     });
 
     if (isWindows()) {
-        app.setAppUserModelId(
-            is.dev ? 'org.jeffvli.feishin.dev' : 'org.jeffvli.feishin',
-        );
+        app.setAppUserModelId('org.jeffvli.feishin');
     }
 
     if (isMacOS()) {


### PR DESCRIPTION
Windows prefers .ico files to .pngs, so when using a .png as the icon, it gets compressed badly during the resize. This PR modifies the icon path to use the existing .ico file on Windows.

Note that there's an argument that macOS should be changed to use the .icns file for similar reasons, but I can't test the macOS so I haven't added that change. 