### PR TITLE
fix: stop volume slider clicks from opening full screen

### DIFF
--- a/src/renderer/features/player/components/right-controls.tsx
+++ b/src/renderer/features/player/components/right-controls.tsx
@@ -456,6 +456,9 @@ const VolumeButton = () => {
                     min={0}
                     onChange={handleVolumeSlider}
                     onWheel={handleVolumeWheel}
+                    onClick={(e) => {
+                        e.stopPropagation();
+                    }}
                     size={6}
                     value={sliderValue}
                     w={volumeWidth}

--- a/src/renderer/features/player/components/right-controls.tsx
+++ b/src/renderer/features/player/components/right-controls.tsx
@@ -455,10 +455,10 @@ const VolumeButton = () => {
                     max={100}
                     min={0}
                     onChange={handleVolumeSlider}
-                    onWheel={handleVolumeWheel}
                     onClick={(e) => {
                         e.stopPropagation();
                     }}
+                    onWheel={handleVolumeWheel}
                     size={6}
                     value={sliderValue}
                     w={volumeWidth}


### PR DESCRIPTION
Only three lines added, stops clicks on the volume bar for counting towards "Playerbar fullscreen toggle" (or anything else)
Fixes: #1584

Before:
![Feishin_OEl7vC3acL](https://github.com/user-attachments/assets/19d9f904-dc2f-4f10-b069-03e3738715fd)

After:
![electron_4mqi44YIKG](https://github.com/user-attachments/assets/79080eda-27ab-42b6-9196-f7bc4f83e088)
