### PR TITLE
Add support for disc subtitles from OpenSubsonic discTitles field

### DIFF
--- a/src/shared/api/subsonic/subsonic-normalize.ts
+++ b/src/shared/api/subsonic/subsonic-normalize.ts
@@ -134,6 +134,7 @@ const normalizeSong = (
     pathReplace?: string,
     pathReplaceWith?: string,
     playlistIndex?: number,
+    discTitleMap?: Map<number, string>,
 ): Song => {
     const participants = getParticipants(item);
 
@@ -156,7 +157,7 @@ const normalizeSong = (
         container: item.contentType,
         createdAt: item.created,
         discNumber: item.discNumber || 1,
-        discSubtitle: null,
+        discSubtitle: discTitleMap?.get(item.discNumber ?? 1) ?? null,
         duration: item.duration ? item.duration * 1000 : 0,
         explicitStatus:
             item.explicitStatus === 'explicit'
@@ -267,6 +268,12 @@ const normalizeAlbum = (
     pathReplace?: string,
     pathReplaceWith?: string,
 ): Album => {
+    const discTitleMap = new Map<number, string>();
+
+    (item as z.infer<typeof ssType._response.album>).discTitles?.forEach((discTitle) => {
+        discTitleMap.set(discTitle.disc, discTitle.title);
+    });
+
     const releaseDate =
         item.releaseDate &&
         typeof item.releaseDate.year === 'number' &&
@@ -312,7 +319,7 @@ const normalizeAlbum = (
         songCount: item.songCount,
         songs:
             (item as z.infer<typeof ssType._response.album>).song?.map((song) =>
-                normalizeSong(song, server, pathReplace, pathReplaceWith),
+                normalizeSong(song, server, pathReplace, pathReplaceWith, undefined, discTitleMap),
             ) || [],
         tags: null,
         updatedAt: item.created,

--- a/src/shared/api/subsonic/subsonic-types.ts
+++ b/src/shared/api/subsonic/subsonic-types.ts
@@ -153,6 +153,14 @@ const album = z.object({
     contributors: z.array(contributor).optional(),
     coverArt: z.string(),
     created: z.string(),
+    discTitles: z
+        .array(
+            z.object({
+                disc: z.number(),
+                title: z.string(),
+            }),
+        )
+        .optional(),
     duration: z.number(),
     explicitStatus: z.string().optional(),
     genre: z.string().optional(),


### PR DESCRIPTION
This PR adds support for `discTitles` field in `getAlbum` API which is part of the OpenSubsonic spec.
If no `discTitle` field is included in `getAlbum` response, or no title for a given disc number is found, only "Disc X" is shown, like before. If a disc title exists, show "Disc X - <disctitle>".