### PR TITLE
Fix Discord details url exceeding max length

### DIFF
--- a/src/renderer/features/discord-rpc/use-discord-rpc.ts
+++ b/src/renderer/features/discord-rpc/use-discord-rpc.ts
@@ -26,6 +26,7 @@ const discordRpc = isElectron() ? window.api.discordRpc : null;
 type ActivityState = [QueueSong | undefined, number, PlayerStatus];
 
 const MAX_FIELD_LENGTH = 127;
+const MAX_URL_LENGTH = 256;
 
 const truncate = (field: string) =>
     field.length <= MAX_FIELD_LENGTH ? field : field.substring(0, MAX_FIELD_LENGTH - 1) + '…';
@@ -163,24 +164,35 @@ export const useDiscordRpc = () => {
                 ) {
                     activity.stateUrl =
                         'https://www.last.fm/music/' + encodeURIComponent(song.artists[0].name);
-                    activity.detailsUrl =
+
+                    const detailsUrl =
                         'https://www.last.fm/music/' +
                         encodeURIComponent(song.albumArtists[0].name) +
                         '/' +
                         encodeURIComponent(song.album || '_') +
                         '/' +
                         encodeURIComponent(song.name);
+
+                    // The details URL has a max length, only set it if it doesn't exceed it
+                    if (detailsUrl.length <= MAX_URL_LENGTH) {
+                        activity.detailsUrl = detailsUrl;
+                    }
                 }
 
                 if (
                     discordSettings.linkType == DiscordLinkType.MBZ ||
                     discordSettings.linkType == DiscordLinkType.MBZ_LAST_FM
                 ) {
+                    let detailsUrl: string | undefined = undefined;
                     if (song?.mbzTrackId) {
-                        activity.detailsUrl = 'https://musicbrainz.org/track/' + song.mbzTrackId;
+                        detailsUrl = 'https://musicbrainz.org/track/' + song.mbzTrackId;
                     } else if (song?.mbzRecordingId) {
-                        activity.detailsUrl =
-                            'https://musicbrainz.org/recording/' + song.mbzRecordingId;
+                        detailsUrl = 'https://musicbrainz.org/recording/' + song.mbzRecordingId;
+                    }
+
+                    // The details URL has a max length, only set it if it doesn't exceed it
+                    if (detailsUrl && detailsUrl.length <= MAX_URL_LENGTH) {
+                        activity.detailsUrl = detailsUrl;
                     }
                 }
 

--- a/src/renderer/features/discord-rpc/use-discord-rpc.ts
+++ b/src/renderer/features/discord-rpc/use-discord-rpc.ts
@@ -183,16 +183,11 @@ export const useDiscordRpc = () => {
                     discordSettings.linkType == DiscordLinkType.MBZ ||
                     discordSettings.linkType == DiscordLinkType.MBZ_LAST_FM
                 ) {
-                    let detailsUrl: string | undefined = undefined;
                     if (song?.mbzTrackId) {
-                        detailsUrl = 'https://musicbrainz.org/track/' + song.mbzTrackId;
+                        activity.detailsUrl = 'https://musicbrainz.org/track/' + song.mbzTrackId;
                     } else if (song?.mbzRecordingId) {
-                        detailsUrl = 'https://musicbrainz.org/recording/' + song.mbzRecordingId;
-                    }
-
-                    // The details URL has a max length, only set it if it doesn't exceed it
-                    if (detailsUrl && detailsUrl.length <= MAX_URL_LENGTH) {
-                        activity.detailsUrl = detailsUrl;
+                        activity.detailsUrl =
+                            'https://musicbrainz.org/recording/' + song.mbzRecordingId;
                     }
                 }
 


### PR DESCRIPTION
The Discord integration currently breaks for titles with very long non-Unicode names, such as the song `お勉強しといてよ` by `ずっと真夜中でいいのに。` on the album `朗らかな皮膚とて不服 [初回生産限定盤]`. The URI encoding of those Japanese characters results in URLs that are too long for Discord to handle (1). As a result, the activity isn't being displayed for those songs.

Since I don't think it's possible to work around the limitation, I believe it's best to only set the details URL if it doesn't exceed Discord's limit of 256 characters. The PR is one potential implementation of that fix. It might be worth logging when the URLs aren't being applied to prevent potential confusion, but I wasn't sure how logging is best handled in this project.

The issue might also apply to other URLs, but the state URL seems a lot shorter in comparison, Musicbrainz links are effectively fixed-length, and the image URLs don't seem to be affected by this from what I can tell.

(1) the link for that song is https://www.last.fm/music/%E3%81%9A%E3%81%A3%E3%81%A8%E7%9C%9F%E5%A4%9C%E4%B8%AD%E3%81%A7%E3%81%84%E3%81%84%E3%81%AE%E3%81%AB%E3%80%82/%E6%9C%97%E3%82%89%E3%81%8B%E3%81%AA%E7%9A%AE%E8%86%9A%E3%81%A8%E3%81%A6%E4%B8%8D%E6%9C%8D%20%5B%E5%88%9D%E5%9B%9E%E7%94%9F%E7%94%A3%E9%99%90%E5%AE%9A%E7%9B%A4%5D/%E3%81%8A%E5%8B%89%E5%BC%B7%E3%81%97%E3%81%A8%E3%81%84%E3%81%A6%E3%82%88 (370 characters)