### PR TITLE
feat: Add support for player controls in macOS dock menu

### DIFF
--- a/src/main/features/darwin/dock-menu.ts
+++ b/src/main/features/darwin/dock-menu.ts
@@ -1,0 +1,57 @@
+import { app, ipcMain, Menu } from 'electron';
+
+import { getMainWindow } from '/@/main/index';
+import { PlayerStatus } from '/@/shared/types/types';
+
+let currentStatus: PlayerStatus = PlayerStatus.PAUSED;
+
+const updateDockMenu = () => {
+    if (!app.dock) return;
+
+    const isPlaying = currentStatus === PlayerStatus.PLAYING;
+
+    const dockMenu = Menu.buildFromTemplate([
+        {
+            click: () => {
+                getMainWindow()?.webContents.send('renderer-player-play-pause');
+            },
+            label: isPlaying ? 'Pause' : 'Play',
+        },
+        {
+            type: 'separator',
+        },
+        {
+            click: () => {
+                getMainWindow()?.webContents.send('renderer-player-next');
+            },
+            label: 'Next',
+        },
+        {
+            click: () => {
+                getMainWindow()?.webContents.send('renderer-player-previous');
+            },
+            label: 'Previous',
+        },
+        {
+            type: 'separator',
+        },
+        {
+            click: () => {
+                getMainWindow()?.webContents.send('renderer-player-stop');
+            },
+            label: 'Stop',
+        },
+    ]);
+
+    app.dock.setMenu(dockMenu);
+};
+
+ipcMain.on('update-playback', (_event, status: PlayerStatus) => {
+    currentStatus = status;
+    updateDockMenu();
+});
+
+// Initialize dock menu after app is ready
+app.whenReady().then(() => {
+    updateDockMenu();
+});

--- a/src/main/features/darwin/index.ts
+++ b/src/main/features/darwin/index.ts
@@ -1,0 +1,1 @@
+import './dock-menu';

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -186,6 +186,39 @@ const createWinThumbarButtons = () => {
     }
 };
 
+const createDockMenu = () => {
+    if (!isMacOS() || !app.dock) return;
+
+    const dockMenu = Menu.buildFromTemplate([
+        {
+            click: () => {
+                getMainWindow()?.webContents.send('renderer-player-play-pause');
+            },
+            label: 'Play/Pause',
+        },
+        {
+            click: () => {
+                getMainWindow()?.webContents.send('renderer-player-next');
+            },
+            label: 'Next Track',
+        },
+        {
+            click: () => {
+                getMainWindow()?.webContents.send('renderer-player-previous');
+            },
+            label: 'Previous Track',
+        },
+        {
+            click: () => {
+                getMainWindow()?.webContents.send('renderer-player-stop');
+            },
+            label: 'Stop',
+        },
+    ]);
+
+    app.dock.setMenu(dockMenu);
+};
+
 const createTray = () => {
     let trayIcon: Electron.NativeImage | string;
 
@@ -687,6 +720,7 @@ if (!singleInstance) {
             if (store.get('window_enable_tray', true)) {
                 createTray();
             }
+            createDockMenu();
             app.on('activate', () => {
                 // On macOS it's common to re-create a window in the app when the
                 // dock icon is clicked and there are no other windows open.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -186,39 +186,6 @@ const createWinThumbarButtons = () => {
     }
 };
 
-const createDockMenu = () => {
-    if (!isMacOS() || !app.dock) return;
-
-    const dockMenu = Menu.buildFromTemplate([
-        {
-            click: () => {
-                getMainWindow()?.webContents.send('renderer-player-play-pause');
-            },
-            label: 'Play/Pause',
-        },
-        {
-            click: () => {
-                getMainWindow()?.webContents.send('renderer-player-next');
-            },
-            label: 'Next Track',
-        },
-        {
-            click: () => {
-                getMainWindow()?.webContents.send('renderer-player-previous');
-            },
-            label: 'Previous Track',
-        },
-        {
-            click: () => {
-                getMainWindow()?.webContents.send('renderer-player-stop');
-            },
-            label: 'Stop',
-        },
-    ]);
-
-    app.dock.setMenu(dockMenu);
-};
-
 const createTray = () => {
     let trayIcon: Electron.NativeImage | string;
 
@@ -720,7 +687,6 @@ if (!singleInstance) {
             if (store.get('window_enable_tray', true)) {
                 createTray();
             }
-            createDockMenu();
             app.on('activate', () => {
                 // On macOS it's common to re-create a window in the app when the
                 // dock icon is clicked and there are no other windows open.

--- a/src/renderer/features/player/hooks/use-mpris.ts
+++ b/src/renderer/features/player/hooks/use-mpris.ts
@@ -102,6 +102,7 @@ export const useMPRIS = () => {
             releaseYear: null,
             sampleRate: null,
             size: 0,
+            sortName: title,
             tags: null,
             trackNumber: 0,
             trackSubtitle: null,

--- a/src/renderer/features/player/hooks/use-mpris.ts
+++ b/src/renderer/features/player/hooks/use-mpris.ts
@@ -13,7 +13,7 @@ import { PlayerShuffle, ServerType } from '/@/shared/types/types';
 
 const ipc = isElectron() ? window.api.ipc : null;
 const utils = isElectron() ? window.api.utils : null;
-const mpris = isElectron() && utils?.isLinux() ? window.api.mpris : null;
+const mpris = isElectron() && (utils?.isLinux() || utils?.isMacOS()) ? window.api.mpris : null;
 
 export const useMPRIS = () => {
     const player = usePlayerStore();
@@ -221,7 +221,7 @@ const MPRISHookInner = () => {
 export const MPRISHook = () => {
     const isElectronEnv = isElectron();
     const utils = isElectronEnv ? window.api.utils : null;
-    const mpris = isElectronEnv && utils?.isLinux() ? window.api.mpris : null;
+    const mpris = isElectronEnv && (utils?.isLinux() || utils?.isMacOS()) ? window.api.mpris : null;
 
     if (mpris === null) {
         return null;


### PR DESCRIPTION
Hi! 
I've added a feature I've been missing on macOS - namely support for player controls in the macOS dock (play/pause/next/previous/stop) 🤓  This is a feature Spotify and Tidal have (and likely many others too), and is something I think many Mac users (myself included) is used to or even expecting to see (I know, we are honestly the worst - I'm seriously considering switching to Linux!)

**Screenshots:**

<img width="451" height="398" alt="Screenshot 2026-01-30 at 15 23 49" src="https://github.com/user-attachments/assets/f6b86b16-b85c-46f5-8c36-155745c7834a" />
<img width="614" height="466" alt="Screenshot 2026-01-30 at 15 24 32" src="https://github.com/user-attachments/assets/e8b5ff0b-2d7c-4078-9668-6e7f087ac66e" />


**Technical considerations**
I exposed the ``use-mpris.ts`` hook to macOS (previously Linux only). From my limited knowledge and understanding of the codebase it could appear that the MPRIS name is a bit misleading in this hook - but I just "slapped" on a simple ``isMacOs()`` check that hopefully won't create problems on other platforms. The TypeScript compiler also complained about a missing ``sortName`` property which I fixed by adding ``sortName: title`` as a separate commit that can be omitted. 


**UX considerations for adding this**
Although the "tray" feature offers similar functionality this is in my opinion oftentimes a poor replacement for the more native experience that is having a menu on the Dock-icon (at least for more seasoned users). Lately a lot of apps adds unnecessary icons to the menu bar which I assume is because a lot of them is Electron-based and this is the default cross-platform behavior. Having both options however is trivial, as the tray functionality can be turned off and the dock menu isn't really intrusive. However it might lead to _slightly_ more code to maintain - but the code could eventually be shared with the tray variant to minimize this.

**Closing words**
Forgive me if my PR structure is a bit rough in the edges here. I couldn't really find a contribution guide, so I just did my best with previous knowledge. Besides that I just wanted to say I really love this application and the great work that's been put into it so far. After boycotting Spotify and switching to Tidal the user experience have been rough. Feishin however is punching way above it's class here (and I'd love to contribute to make it even better). 

In the future, adding something like Repeat and Shuffle might be something to consider - but for me personally that are actions I use less frequently and don't mind open the app to adjust. 
