### PR TITLE
Use a re-usable Intl.Collator instance for locale compare when possible

### DIFF
--- a/src/renderer/api/jellyfin/jellyfin-controller.ts
+++ b/src/renderer/api/jellyfin/jellyfin-controller.ts
@@ -39,7 +39,8 @@ const formatCommaDelimitedString = (value: string[]) => {
 const MAX_ITEMS_PER_PLAYLIST_ADD = 50;
 
 // Defining a re-usable Collator instance for performance reasons.
-const collator = new Intl.Collator(undefined, { numeric: true });
+const numericSortCollator = new Intl.Collator(undefined, { numeric: true });
+const collator = new Intl.Collator();
 
 const VERSION_INFO: VersionInfo = [
     [
@@ -1254,7 +1255,10 @@ export const JellyfinController: InternalControllerEndpoint = {
             tags.push({
                 name: 'Tags',
                 options: res.body.Tags.sort((a, b) => {
-                    return collator.compare(a.toLocaleLowerCase(), b.toLocaleLowerCase());
+                    return numericSortCollator.compare(
+                        a.toLocaleLowerCase(),
+                        b.toLocaleLowerCase(),
+                    );
                 }).map((tag) => ({ id: tag, name: tag })),
             });
         }
@@ -1263,7 +1267,7 @@ export const JellyfinController: InternalControllerEndpoint = {
             tags.push({
                 name: 'Studios',
                 options: studioRes.body.Items.sort((a, b) =>
-                    a.Name.toLocaleLowerCase().localeCompare(b.Name.toLocaleLowerCase()),
+                    collator.compare(a.Name.toLocaleLowerCase(), b.Name.toLocaleLowerCase()),
                 ).map((option) => ({ id: option.Name, name: option.Name })),
             });
         }

--- a/src/renderer/api/jellyfin/jellyfin-controller.ts
+++ b/src/renderer/api/jellyfin/jellyfin-controller.ts
@@ -38,6 +38,9 @@ const formatCommaDelimitedString = (value: string[]) => {
 // not the POST body
 const MAX_ITEMS_PER_PLAYLIST_ADD = 50;
 
+// Defining a re-usable Collator instance for performance reasons.
+const collator = new Intl.Collator(undefined, { numeric: true });
+
 const VERSION_INFO: VersionInfo = [
     [
         '10.9.0',
@@ -1250,11 +1253,9 @@ export const JellyfinController: InternalControllerEndpoint = {
         if (res.body.Tags?.length) {
             tags.push({
                 name: 'Tags',
-                options: res.body.Tags.sort((a, b) =>
-                    a
-                        .toLocaleLowerCase()
-                        .localeCompare(b.toLocaleLowerCase(), undefined, { numeric: true }),
-                ).map((tag) => ({ id: tag, name: tag })),
+                options: res.body.Tags.sort((a, b) => {
+                    return collator.compare(a.toLocaleLowerCase(), b.toLocaleLowerCase());
+                }).map((tag) => ({ id: tag, name: tag })),
             });
         }
 

--- a/src/renderer/api/navidrome/navidrome-controller.ts
+++ b/src/renderer/api/navidrome/navidrome-controller.ts
@@ -71,6 +71,9 @@ const EXCLUDED_ALBUM_TAGS = new Set<string>([
 
 const EXCLUDED_SONG_TAGS = new Set<string>(['disctotal', 'tracktotal']);
 
+// Defining a re-usable Collator instance for performance reasons.
+const collator = new Intl.Collator(undefined, { numeric: true });
+
 // Tags that use IDs as values as opposed to the tag value
 const ID_TAGS = new Set<string>(['albumversion', 'mood']);
 
@@ -780,13 +783,12 @@ export const NavidromeController: InternalControllerEndpoint = {
             .map((data) => ({
                 name: data[0],
                 options: data[1]
-                    .sort((a, b) =>
-                        a.name
-                            .toLocaleLowerCase()
-                            .localeCompare(b.name.toLocaleLowerCase(), undefined, {
-                                numeric: true,
-                            }),
-                    )
+                    .sort((a, b) => {
+                        return collator.compare(
+                            a.name.toLocaleLowerCase(),
+                            b.name.toLocaleLowerCase(),
+                        );
+                    })
                     .map((option) => ({ id: option.id, name: option.name })),
             }))
             .sort((a, b) => a.name.toLocaleLowerCase().localeCompare(b.name.toLocaleLowerCase()));

--- a/src/renderer/api/navidrome/navidrome-controller.ts
+++ b/src/renderer/api/navidrome/navidrome-controller.ts
@@ -72,7 +72,8 @@ const EXCLUDED_ALBUM_TAGS = new Set<string>([
 const EXCLUDED_SONG_TAGS = new Set<string>(['disctotal', 'tracktotal']);
 
 // Defining a re-usable Collator instance for performance reasons.
-const collator = new Intl.Collator(undefined, { numeric: true });
+const numericSortCollator = new Intl.Collator(undefined, { numeric: true });
+const collator = new Intl.Collator();
 
 // Tags that use IDs as values as opposed to the tag value
 const ID_TAGS = new Set<string>(['albumversion', 'mood']);
@@ -784,14 +785,16 @@ export const NavidromeController: InternalControllerEndpoint = {
                 name: data[0],
                 options: data[1]
                     .sort((a, b) => {
-                        return collator.compare(
+                        return numericSortCollator.compare(
                             a.name.toLocaleLowerCase(),
                             b.name.toLocaleLowerCase(),
                         );
                     })
                     .map((option) => ({ id: option.id, name: option.name })),
             }))
-            .sort((a, b) => a.name.toLocaleLowerCase().localeCompare(b.name.toLocaleLowerCase()));
+            .sort((a, b) =>
+                collator.compare(a.name.toLocaleLowerCase(), b.name.toLocaleLowerCase()),
+            );
 
         const excludedAlbumTags = Array.from(EXCLUDED_ALBUM_TAGS.values());
         const excludedSongTags = Array.from(EXCLUDED_SONG_TAGS.values());

--- a/src/renderer/features/artists/components/album-artist-detail-content.tsx
+++ b/src/renderer/features/artists/components/album-artist-detail-content.tsx
@@ -88,6 +88,8 @@ import {
 } from '/@/shared/types/domain-types';
 import { ItemListKey, ListDisplayType, Play } from '/@/shared/types/types';
 
+const collator = new Intl.Collator();
+
 interface AlbumArtistActionButtonsProps {
     artistDiscographyLink: string;
     artistSongsLink: string;
@@ -1251,12 +1253,12 @@ const ArtistAlbums = ({ albumsQuery }: ArtistAlbumsProps) => {
                     const secondaryKeyB = getSecondaryTypePriorityKey(b.releaseType);
 
                     if (secondaryKeyA && secondaryKeyB) {
-                        return secondaryKeyA.localeCompare(secondaryKeyB);
+                        return collator.compare(secondaryKeyA, secondaryKeyB);
                     }
                 }
 
                 // Fallback to alphabetical for non-combined types or if weighted comparison isn't applicable
-                return a.releaseType.localeCompare(b.releaseType);
+                return collator.compare(a.releaseType, b.releaseType);
             });
     }, [albumsByReleaseType, artistReleaseTypeItems, t]);
 


### PR DESCRIPTION
After opening https://github.com/jeffvli/feishin/pull/1637, I tried to run a `git bisect` to see when and the UI seemed slower since ~1.3.0. Bisect lead me to [this commit that added natural sorting](https://github.com/jeffvli/feishin/commit/45df497ee6d9efa3419ff09808c6250f09053981). Unfortunately, using `localeCompare` on a lot of items in an array isn't free because the JS engine re-creates a new instance of `Intl.Collator` for every item.

This PR fixes that by setting up a re-usable instance of `Intl.Collator()` which yields a [~84% speed improvement](https://jsperf.app/fekera/1/preview) (when sorting 1,000 items).