### PR TITLE
fix(mpv): only check player time when there is an item in the track

### DIFF
--- a/src/renderer/features/player/audio-player/mpv-player.tsx
+++ b/src/renderer/features/player/audio-player/mpv-player.tsx
@@ -23,7 +23,7 @@ const mpvPlayer = isElectron() ? window.api.mpvPlayer : null;
 
 export function MpvPlayer() {
     const playerRef = useRef<MpvPlayerEngineHandle>(null);
-    const { status } = usePlayerData();
+    const { currentSong, status } = usePlayerData();
     const { mediaAutoNext, setTimestamp } = usePlayerActions();
     const { speed } = usePlayerProperties();
     const isMuted = usePlayerMuted();
@@ -147,8 +147,10 @@ export function MpvPlayer() {
         };
     }, []);
 
+    const hasCurrentSong = !!currentSong?.id;
+
     useEffect(() => {
-        if (localPlayerStatus !== PlayerStatus.PLAYING) {
+        if (localPlayerStatus !== PlayerStatus.PLAYING || !hasCurrentSong) {
             return;
         }
 
@@ -168,7 +170,7 @@ export function MpvPlayer() {
         }, 500);
 
         return () => clearInterval(interval);
-    }, [localPlayerStatus, setTimestamp]);
+    }, [hasCurrentSong, localPlayerStatus, setTimestamp]);
 
     return (
         <MpvPlayerEngine


### PR DESCRIPTION
If using MPV player and the queue is empty, there will be constant errors when trying to fetch the time.
Only fetch the time from MPV when the current song exists.

Note: when going from an empty queue to playing a song, there is one extraneous `player-get-time` call that is fired. Maybe this is a timing/delay issue?