### PR TITLE
fix(Settings): mpv path selector displays wrong default

### DIFF
--- a/src/renderer/features/settings/components/playback/mpv-settings.tsx
+++ b/src/renderer/features/settings/components/playback/mpv-settings.tsx
@@ -36,9 +36,7 @@ export const MpvSettings = memo(() => {
     // const { pause } = usePlayerControls();
     // const { clearQueue } = useQueueControls();
 
-    const [mpvPath, setMpvPath] = useState(
-        (localSettings?.get('mpv_path') as string | undefined) || '',
-    );
+    const [mpvPath, setMpvPath] = useState('');
 
     const handleSetMpvPath = async (clear?: boolean) => {
         if (clear) {
@@ -62,8 +60,8 @@ export const MpvSettings = memo(() => {
     useEffect(() => {
         const getMpvPath = async () => {
             if (!localSettings) return setMpvPath('');
-            const mpvPath = (await localSettings.get('mpv_path')) as string;
-            return setMpvPath(mpvPath);
+            const mpvPath = (await localSettings.get('mpv_path')) as string | undefined;
+            return setMpvPath(mpvPath || '');
         };
 
         getMpvPath();


### PR DESCRIPTION
The MPV path setting has a broken default value even though a separate `useEffect` hook is supposed to properly load the setting value later.

<img width="869" height="75" alt="image" src="https://github.com/user-attachments/assets/0a52da11-a440-43cd-ad9a-819189ec83a5" />
