### PR TITLE
Update instant mix to use the new items endpoint instead of songs

### DIFF
--- a/src/renderer/api/jellyfin/jellyfin-api.ts
+++ b/src/renderer/api/jellyfin/jellyfin-api.ts
@@ -137,7 +137,7 @@ export const contract = c.router({
     },
     getInstantMix: {
         method: 'GET',
-        path: 'songs/:itemId/InstantMix',
+        path: 'items/:itemId/InstantMix',
         query: jfType._parameters.similarSongs,
         responses: {
             200: jfType._response.songList,


### PR DESCRIPTION
The `items` endpoint can generate an instant playlist from any media item, including albums, artists, genres, playlists, or individual tracks, when provided with an ID.
(See: https://api.jellyfin.org/#tag/InstantMix/operation/GetInstantMixFromItem )

Using this endpoint offers two advantages:

1. It enables broader “Radio” functionality. While it would need to be implemented in the client, the endpoint already supports instant mixes for albums, genres, and playlists in addition to songs and artists.

2. It ensures compatibility with audiomuse-ai. For users without the audiomuse plugin, nothing changes, since Jellyfin internally translates the `items` endpoint to the existing endpoints such as `/song`. When audiomuse is installed, the overridden endpoint is used, which resolves:
   https://github.com/jeffvli/feishin/issues/1425
   https://github.com/NeptuneHub/audiomuse-ai-plugin/issues/14
