### PR TITLE
Fix: ratings display on player bar and mobile player

### DIFF
--- a/src/renderer/features/player/components/mobile-fullscreen-player.tsx
+++ b/src/renderer/features/player/components/mobile-fullscreen-player.tsx
@@ -31,6 +31,7 @@ import {
     useCurrentServer,
     useFullScreenPlayerStore,
     useFullScreenPlayerStoreActions,
+    useGeneralSettings,
     usePlayerData,
     usePlayerSong,
     useSetFullScreenPlayerStore,
@@ -377,6 +378,7 @@ export const MobileFullscreenPlayer = () => {
     const { currentSong: currentSongData } = usePlayerData();
     const server = useCurrentServer();
     const setFavorite = useSetFavorite();
+    const { showRatings: showRatingsSetting } = useGeneralSettings();
     const setRating = useSetRating();
 
     const [isPageHovered, setIsPageHovered] = useState(false);
@@ -435,6 +437,7 @@ export const MobileFullscreenPlayer = () => {
     const isLyricsState = activeTab === 'lyrics';
     const isSongDefined = Boolean(currentSong?.id);
     const showRating =
+        showRatingsSetting &&
         isSongDefined &&
         (server?.type === ServerType.NAVIDROME || server?.type === ServerType.SUBSONIC);
 

--- a/src/renderer/features/player/components/right-controls.tsx
+++ b/src/renderer/features/player/components/right-controls.tsx
@@ -14,6 +14,7 @@ import {
     useAutoDJSettings,
     useCurrentServer,
     useFullScreenPlayerStore,
+    useGeneralSettings,
     useHotkeySettings,
     usePlayerData,
     usePlayerMuted,
@@ -63,10 +64,11 @@ const calculateVolumeDown = (volume: number, volumeWheelStep: number) => {
 };
 
 export const RightControls = () => {
+    const { showRatings } = useGeneralSettings();
     return (
         <Flex align="flex-end" direction="column" h="100%" px="1rem" py="0.5rem">
             <Group h="calc(100% / 3)">
-                <RatingButton />
+                {showRatings && <RatingButton />}
                 <AutoDJButton />
             </Group>
             <Group align="center" gap="xs" wrap="nowrap">


### PR DESCRIPTION
This PR is to fix the ratings being displayed on both the player bar and the full screen mobile player when disabled on the user settings. Adresses #1644 introduced by #1426

I decided to add the conditional to `RightControls` to avoid `RatingButton` unnecessarily running the code inside it, but if there's another preferable approach such as calling `useGeneralSettings` on `Playerbar` instead and passing the boolean as props, I can adjust it.