### PR TITLE
Populate bit depth from Jellyfin

### DIFF
--- a/src/shared/api/jellyfin/jellyfin-normalize.ts
+++ b/src/shared/api/jellyfin/jellyfin-normalize.ts
@@ -139,6 +139,7 @@ const normalizeSong = (
     pathReplace?: string,
     pathReplaceWith?: string,
 ): Song => {
+    let bitDepth: null | number = null;
     let bitRate = 0;
     let channels: null | number = null;
     let container: null | string = null;
@@ -156,6 +157,7 @@ const normalizeSong = (
         if ((source.MediaStreams?.length || 0) > 0) {
             for (const stream of source.MediaStreams) {
                 if (stream.Type === 'Audio') {
+                    bitDepth = stream.BitDepth || null;
                     bitRate =
                         stream.BitRate !== undefined
                             ? Number(Math.trunc(stream.BitRate / 1000))
@@ -191,7 +193,7 @@ const normalizeSong = (
         albumId: item.AlbumId || `dummy/${item.Id}`,
         artistName: item?.ArtistItems?.map((entry) => entry.Name).join(', ') || '',
         artists,
-        bitDepth: null,
+        bitDepth,
         bitRate,
         bpm: null,
         channels,


### PR DESCRIPTION
First contribution here. Tried to follow the existing pattern in the code.

Context: bit depth from Jellyfin was [originally set to `null`](https://github.com/jeffvli/feishin/commit/4b4df28641417381b06a0589cf88978f815df725#diff-00d6c399c77705d29f8ba7688d49e2e54c9ab6801f88017aa7c3e35b67d6bcf9R228) because [Jellyfin didn't expose it](https://github.com/jeffvli/feishin/issues/799#issuecomment-3067073419). This may have been true at that time, but since then, Jellyfin appears to have added it, because this works for me.


### Before

Showing the "BIT DEPTH" table column results in empty values:

<img width="350" height="336" alt="CleanShot 2026-02-03 at 23 10 30" src="https://github.com/user-attachments/assets/76b8648a-09ec-438e-a905-a87a867f3fc6" />

### After

"BIT DEPTH" is properly populated:

<img width="338" height="339" alt="CleanShot 2026-02-03 at 23 08 36" src="https://github.com/user-attachments/assets/10d3831d-95af-48aa-bb2e-85e62a372be7" />

Another example:

<img width="366" height="204" alt="CleanShot 2026-02-03 at 23 23 00" src="https://github.com/user-attachments/assets/c4e3e0fc-e1bc-4a5e-9fe5-3f60e6d23d48" />


This also appropriately populates the "Bit depth" field in the "Get info" dialog on a track.

Shoutout to my fellow audio nerds who care about seeing this information ;) 

Thanks for a nice player, jeffvli! And thanks for originally implementing this feature, kgarner7!