### PR TITLE
fix(scrobble): send now-playing updates on repeat-one loops for Navidrome

### DIFF
--- a/web.vite.config.ts
+++ b/web.vite.config.ts
@@ -41,7 +41,7 @@ export default defineConfig({
             '@atlaskit/pragmatic-drag-and-drop',
             '@atlaskit/pragmatic-drag-and-drop-auto-scroll',
             '@atlaskit/pragmatic-drag-and-drop-hitbox',
-            '@tanstack_react-query-persist-client',
+            '@tanstack/react-query-persist-client',
             'idb-keyval',
         ],
     },


### PR DESCRIPTION
- Add `handleScrobbleFromRepeat` callback to reset scrobble state and send 'start' event when player repeats a song, ensuring accurate scrobbling in repeat mode.
- Fix typo in `web.vite.config.ts` by correcting '@tanstack_react-query-persist-client' to '@tanstack/react-query-persist-client' for proper package reference.

Fix https://github.com/jeffvli/feishin/issues/1659