### PR TITLE
Move settings panel to native menu bar

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -95,6 +95,9 @@ let tray: null | Tray = null;
 let exitFromTray = false;
 let forceQuit = false;
 let powerSaveBlockerId: null | number = null;
+let menuBuilder: MenuBuilder | null = null;
+let isPrivateMode = false;
+let isCollapsedSidebar = false;
 
 if (process.env.NODE_ENV === 'production') {
     import('source-map-support').then((sourceMapSupport) => {
@@ -454,12 +457,23 @@ async function createWindow(first = true): Promise<void> {
         });
     }
 
-    const menuBuilder = new MenuBuilder(mainWindow);
-    menuBuilder.buildMenu();
+    menuBuilder = new MenuBuilder(mainWindow);
+    menuBuilder.buildMenu(isPrivateMode, isCollapsedSidebar);
 
-    if (process.platform !== 'darwin') {
-        Menu.setApplicationMenu(null);
-    }
+    // Listen for private mode updates from renderer
+    ipcMain.on('update-private-mode', (_event, privateMode: boolean) => {
+        isPrivateMode = privateMode;
+        if (menuBuilder) {
+            menuBuilder.buildMenu(isPrivateMode, isCollapsedSidebar);
+        }
+    });
+
+    ipcMain.on('update-sidebar-collapsed', (_event, collapsedSidebar: boolean) => {
+        isCollapsedSidebar = collapsedSidebar;
+        if (menuBuilder) {
+            menuBuilder.buildMenu(isPrivateMode, isCollapsedSidebar);
+        }
+    });
 
     // Open URLs in the user's browser
     mainWindow.webContents.setWindowOpenHandler((edata) => {

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,5 +1,7 @@
 import { app, BrowserWindow, Menu, MenuItemConstructorOptions, shell } from 'electron';
 
+import packageJson from '../../package.json';
+
 interface DarwinMenuItemConstructorOptions extends MenuItemConstructorOptions {
     selector?: string;
     submenu?: DarwinMenuItemConstructorOptions[] | Menu;
@@ -12,13 +14,39 @@ export default class MenuBuilder {
         this.mainWindow = mainWindow;
     }
 
-    buildDarwinTemplate(): MenuItemConstructorOptions[] {
+    buildDarwinTemplate(
+        privateMode: boolean,
+        collapsedSidebar: boolean,
+    ): MenuItemConstructorOptions[] {
         const subMenuAbout: DarwinMenuItemConstructorOptions = {
             label: 'Electron',
             submenu: [
                 {
                     label: 'About Feishin',
                     selector: 'orderFrontStandardAboutPanel:',
+                },
+                { type: 'separator' },
+                {
+                    accelerator: 'Command+,',
+                    click: () => {
+                        this.mainWindow.webContents.send('renderer-open-settings');
+                    },
+                    label: 'Settings',
+                },
+                { type: 'separator' },
+                {
+                    click: () => {
+                        this.mainWindow.webContents.send('renderer-open-manage-servers');
+                    },
+                    label: 'Manage servers',
+                },
+                {
+                    checked: privateMode,
+                    click: () => {
+                        this.mainWindow.webContents.send('renderer-toggle-private-mode');
+                    },
+                    label: 'Private session',
+                    type: 'checkbox',
                 },
                 { type: 'separator' },
                 { label: 'Services', submenu: [] },
@@ -63,6 +91,22 @@ export default class MenuBuilder {
         const subMenuViewDev: MenuItemConstructorOptions = {
             label: 'View',
             submenu: [
+                {
+                    accelerator: 'Command+K',
+                    click: () => {
+                        this.mainWindow.webContents.send('renderer-open-command-palette');
+                    },
+                    label: 'Command Palette…',
+                },
+                {
+                    checked: collapsedSidebar,
+                    click: () => {
+                        this.mainWindow.webContents.send('renderer-toggle-sidebar');
+                    },
+                    label: 'Collapse sidebar',
+                    type: 'checkbox',
+                },
+                { type: 'separator' },
                 {
                     accelerator: 'Command+R',
                     click: () => {
@@ -140,6 +184,12 @@ export default class MenuBuilder {
                     },
                     label: 'Search Issues',
                 },
+                {
+                    click: () => {
+                        this.mainWindow.webContents.send('renderer-open-release-notes');
+                    },
+                    label: 'Version ' + packageJson.version,
+                },
             ],
         };
 
@@ -151,8 +201,11 @@ export default class MenuBuilder {
         return [subMenuAbout, subMenuEdit, subMenuView, subMenuWindow, subMenuHelp];
     }
 
-    buildDefaultTemplate() {
-        const templateDefault = [
+    buildDefaultTemplate(
+        privateMode: boolean = false,
+        collapsedSidebar: boolean = false,
+    ): MenuItemConstructorOptions[] {
+        const templateDefault: MenuItemConstructorOptions[] = [
             {
                 label: '&File',
                 submenu: [
@@ -160,6 +213,22 @@ export default class MenuBuilder {
                         accelerator: 'Ctrl+O',
                         label: '&Open',
                     },
+                    {
+                        accelerator: 'Ctrl+,',
+                        click: () => {
+                            this.mainWindow.webContents.send('renderer-open-settings');
+                        },
+                        label: '&Settings...',
+                    },
+                    {
+                        checked: privateMode,
+                        click: () => {
+                            this.mainWindow.webContents.send('renderer-toggle-private-mode');
+                        },
+                        label: 'Private &session',
+                        type: 'checkbox',
+                    },
+                    { type: 'separator' },
                     {
                         accelerator: 'Ctrl+W',
                         click: () => {
@@ -174,6 +243,14 @@ export default class MenuBuilder {
                 submenu:
                     process.env.NODE_ENV === 'development' || process.env.DEBUG_PROD === 'true'
                         ? [
+                              {
+                                  checked: collapsedSidebar,
+                                  click: () => {
+                                      this.mainWindow.webContents.send('renderer-toggle-sidebar');
+                                  },
+                                  label: 'Collapse &Sidebar',
+                                  type: 'checkbox',
+                              },
                               {
                                   accelerator: 'Ctrl+R',
                                   click: () => {
@@ -199,6 +276,14 @@ export default class MenuBuilder {
                               },
                           ]
                         : [
+                              {
+                                  checked: collapsedSidebar,
+                                  click: () => {
+                                      this.mainWindow.webContents.send('renderer-toggle-sidebar');
+                                  },
+                                  label: 'Collapse &Sidebar',
+                                  type: 'checkbox',
+                              },
                               {
                                   accelerator: 'F11',
                                   click: () => {
@@ -246,15 +331,15 @@ export default class MenuBuilder {
         return templateDefault;
     }
 
-    buildMenu(): Menu {
+    buildMenu(privateMode: boolean = false, collapsedSidebar: boolean = false): Menu {
         if (process.env.NODE_ENV === 'development' || process.env.DEBUG_PROD === 'true') {
             this.setupDevelopmentEnvironment();
         }
 
         const template =
             process.platform === 'darwin'
-                ? this.buildDarwinTemplate()
-                : this.buildDefaultTemplate();
+                ? this.buildDarwinTemplate(privateMode, collapsedSidebar)
+                : this.buildDefaultTemplate(privateMode, collapsedSidebar);
 
         const menu = Menu.buildFromTemplate(template);
         Menu.setApplicationMenu(menu);

--- a/src/preload/utils.ts
+++ b/src/preload/utils.ts
@@ -57,6 +57,30 @@ const forceGarbageCollection = (): boolean => {
     }
 };
 
+const rendererOpenSettings = (cb: (event: IpcRendererEvent) => void) => {
+    ipcRenderer.on('renderer-open-settings', cb);
+};
+
+const rendererOpenCommandPalette = (cb: (event: IpcRendererEvent) => void) => {
+    ipcRenderer.on('renderer-open-command-palette', cb);
+};
+
+const rendererOpenManageServers = (cb: (event: IpcRendererEvent) => void) => {
+    ipcRenderer.on('renderer-open-manage-servers', cb);
+};
+
+const rendererTogglePrivateMode = (cb: (event: IpcRendererEvent) => void) => {
+    ipcRenderer.on('renderer-toggle-private-mode', cb);
+};
+
+const rendererToggleSidebar = (cb: (event: IpcRendererEvent) => void) => {
+    ipcRenderer.on('renderer-toggle-sidebar', cb);
+};
+
+const rendererOpenReleaseNotes = (cb: (event: IpcRendererEvent) => void) => {
+    ipcRenderer.on('renderer-open-release-notes', cb);
+};
+
 export const utils = {
     disableAutoUpdates,
     download,
@@ -69,6 +93,12 @@ export const utils = {
     openApplicationDirectory,
     openItem,
     playerErrorListener,
+    rendererOpenCommandPalette,
+    rendererOpenManageServers,
+    rendererOpenReleaseNotes,
+    rendererOpenSettings,
+    rendererTogglePrivateMode,
+    rendererToggleSidebar,
 };
 
 export type Utils = typeof utils;

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable perfectionist/sort-imports */
 import { MantineProvider } from '@mantine/core';
+import { openModal } from '@mantine/modals';
 import { Notifications } from '@mantine/notifications';
 import 'overlayscrollbars/overlayscrollbars.css';
 import '/styles/overlayscrollbars.css';
@@ -8,12 +9,24 @@ import '@mantine/dates/styles.css';
 import '@mantine/notifications/styles.css';
 import isElectron from 'is-electron';
 import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import packageJson from '../../package.json';
 
 import i18n from '/@/i18n/i18n';
+import { openSettingsModal } from '/@/renderer/features/settings/utils/open-settings-modal';
+import { ServerList } from '/@/renderer/features/servers/components/server-list';
 import { WebAudioContext } from '/@/renderer/features/player/context/webaudio-context';
 import { useSyncSettingsToMain } from '/@/renderer/hooks/use-sync-settings-to-main';
 import { AppRouter } from '/@/renderer/router/app-router';
-import { useCssSettings, useHotkeySettings, useLanguage } from '/@/renderer/store';
+import {
+    useAppStore,
+    useAppStoreActions,
+    useCommandPalette,
+    useCssSettings,
+    useHotkeySettings,
+    useLanguage,
+} from '/@/renderer/store';
 import { useAppTheme } from '/@/renderer/themes/use-app-theme';
 import { sanitizeCss } from '/@/renderer/utils/sanitize';
 import { WebAudio } from '/@/shared/types/types';
@@ -32,10 +45,16 @@ const ipc = isElectron() ? window.api.ipc : null;
 export const App = () => {
     const { mode, theme } = useAppTheme();
     const language = useLanguage();
+    const { t } = useTranslation();
 
     const { content, enabled } = useCssSettings();
     const { bindings } = useHotkeySettings();
     const cssRef = useRef<HTMLStyleElement | null>(null);
+
+    const privateMode = useAppStore((state) => state.privateMode);
+    const sidebar = useAppStore((state) => state.sidebar);
+    const { setPrivateMode, setSideBar } = useAppStoreActions();
+    const { open: openCommandPalette } = useCommandPalette();
 
     useSyncSettingsToMain();
 
@@ -76,6 +95,109 @@ export const App = () => {
             i18n.changeLanguage(language);
         }
     }, [language]);
+
+    useEffect(() => {
+        if (isElectron()) {
+            window.api.utils.rendererOpenSettings(() => {
+                openSettingsModal();
+            });
+
+            return () => {
+                ipc?.removeAllListeners('renderer-open-settings');
+            };
+        }
+        return undefined;
+    }, []);
+
+    useEffect(() => {
+        if (isElectron()) {
+            window.api.utils.rendererOpenCommandPalette(() => {
+                openCommandPalette();
+            });
+
+            return () => {
+                ipc?.removeAllListeners('renderer-open-command-palette');
+            };
+        }
+        return () => {};
+    }, [openCommandPalette]);
+
+    useEffect(() => {
+        if (isElectron()) {
+            window.api.utils.rendererOpenManageServers(() => {
+                openModal({
+                    children: <ServerList />,
+                    title: t('page.manageServers.title', { postProcess: 'titleCase' }),
+                });
+            });
+
+            return () => {
+                ipc?.removeAllListeners('renderer-open-manage-servers');
+            };
+        }
+        return () => {};
+    }, [t]);
+
+    useEffect(() => {
+        if (isElectron()) {
+            window.api.utils.rendererTogglePrivateMode(() => {
+                const newPrivateMode = !privateMode;
+                setPrivateMode(newPrivateMode);
+            });
+
+            return () => {
+                ipc?.removeAllListeners('renderer-toggle-private-mode');
+            };
+        }
+        return () => {};
+    }, [privateMode, setPrivateMode, t]);
+
+    useEffect(() => {
+        if (isElectron()) {
+            window.api.utils.rendererToggleSidebar(() => {
+                const newCollapseSidebar = !sidebar.collapsed;
+                setSideBar({ collapsed: newCollapseSidebar });
+            });
+
+            return () => {
+                ipc?.removeAllListeners('renderer-toggle-sidebar');
+            };
+        }
+        return () => {};
+    }, [sidebar, setSideBar, t]);
+
+    useEffect(() => {
+        if (isElectron()) {
+            ipc?.send('update-sidebar-collapsed', sidebar.collapsed);
+        }
+    }, [sidebar]);
+
+    useEffect(() => {
+        if (isElectron()) {
+            ipc?.send('update-private-mode', privateMode);
+        }
+    }, [privateMode]);
+
+    useEffect(() => {
+        if (isElectron()) {
+            window.api.utils.rendererOpenReleaseNotes(() => {
+                import('./release-notes-modal').then((module) => {
+                    module.openReleaseNotesModal(
+                        t('common.newVersion', {
+                            postProcess: 'sentenceCase',
+                            version: packageJson.version,
+                        }) as string,
+                    );
+                });
+            });
+
+            return () => {
+                ipc?.removeAllListeners('renderer-open-release-notes');
+            };
+        }
+
+        return () => {};
+    }, [t]);
 
     const notificationStyles = useMemo(
         () => ({

--- a/src/renderer/features/sidebar/components/action-bar.tsx
+++ b/src/renderer/features/sidebar/components/action-bar.tsx
@@ -1,3 +1,4 @@
+import isElectron from 'is-electron';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 
@@ -39,16 +40,18 @@ export const ActionBar = () => {
                 </Grid.Col>
                 <Grid.Col span={5}>
                     <Group gap="sm" grow wrap="nowrap">
-                        <DropdownMenu position="bottom-start">
-                            <DropdownMenu.Target>
-                                <Button p="0">
-                                    <Icon icon="menu" size="lg" />
-                                </Button>
-                            </DropdownMenu.Target>
-                            <DropdownMenu.Dropdown>
-                                <AppMenu />
-                            </DropdownMenu.Dropdown>
-                        </DropdownMenu>
+                        {!isElectron() && (
+                            <DropdownMenu position="bottom-start">
+                                <DropdownMenu.Target>
+                                    <Button p="0">
+                                        <Icon icon="menu" size="lg" />
+                                    </Button>
+                                </DropdownMenu.Target>
+                                <DropdownMenu.Dropdown>
+                                    <AppMenu />
+                                </DropdownMenu.Dropdown>
+                            </DropdownMenu>
+                        )}
                         <NavigateButtons />
                     </Group>
                 </Grid.Col>

--- a/src/renderer/features/sidebar/components/collapsed-sidebar.tsx
+++ b/src/renderer/features/sidebar/components/collapsed-sidebar.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import isElectron from 'is-electron';
 import { motion } from 'motion/react';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -99,23 +100,25 @@ export const CollapsedSidebar = () => {
                         </CollapsedSidebarButton>
                     </Group>
                 )}
-                <DropdownMenu position="right-start">
-                    <DropdownMenu.Target>
-                        <CollapsedSidebarItem
-                            activeIcon={null}
-                            component={Flex}
-                            icon={<Icon fill="muted" icon="menu" size="3xl" />}
-                            label={t('common.menu', { postProcess: 'titleCase' })}
-                            style={{
-                                cursor: 'pointer',
-                                padding: 'var(--theme-spacing-md) 0',
-                            }}
-                        />
-                    </DropdownMenu.Target>
-                    <DropdownMenu.Dropdown>
-                        <AppMenu />
-                    </DropdownMenu.Dropdown>
-                </DropdownMenu>
+                {!isElectron() && (
+                    <DropdownMenu position="right-start">
+                        <DropdownMenu.Target>
+                            <CollapsedSidebarItem
+                                activeIcon={null}
+                                component={Flex}
+                                icon={<Icon fill="muted" icon="menu" size="3xl" />}
+                                label={t('common.menu', { postProcess: 'titleCase' })}
+                                style={{
+                                    cursor: 'pointer',
+                                    padding: 'var(--theme-spacing-md) 0',
+                                }}
+                            />
+                        </DropdownMenu.Target>
+                        <DropdownMenu.Dropdown>
+                            <AppMenu />
+                        </DropdownMenu.Dropdown>
+                    </DropdownMenu>
+                )}
                 {sidebarItemsWithRoute.map((item) =>
                     item.id === 'Collections' ? (
                         collections && collections.length > 0 ? (


### PR DESCRIPTION
Works off https://github.com/jeffvli/feishin/pull/1655 to move all settings to the native menu bar.

- Moved settings, manage servers and private mode to main app menu:

<img width="362" height="342" alt="imagen" src="https://github.com/user-attachments/assets/12cc71a9-1950-4553-ba83-ec00d20826a9" />

<p>

- It also integrates checkbox state, so for example, if you toggle private mode the menu bar gets checked
<img width="382" height="352" alt="imagen" src="https://github.com/user-attachments/assets/daf2d412-968b-4719-8f67-79d4d81da20e" />

<p>

- Moved command palette icon and collapse sidebar to "View" menu option:
<img width="459" height="231" alt="imagen" src="https://github.com/user-attachments/assets/00ee63a8-5671-449b-a11b-092eca496847" />

<p>

- The same thing happens when collapse sidebar is activated:

<img width="437" height="223" alt="imagen" src="https://github.com/user-attachments/assets/0d62bb60-53dc-481a-b532-d7d1a06c2637" />

<p>

- Moved version to "Help" menu option:
<img width="564" height="235" alt="imagen" src="https://github.com/user-attachments/assets/372c0346-a1b7-483a-967d-0bc9234e127e" />

<p>

- This means that we can hide the settings icon from sidebar, both on normal and collapsed states:
<img width="651" height="543" alt="imagen" src="https://github.com/user-attachments/assets/334fbc07-8e13-49a8-a656-d69aaaea1cc3" />

<img width="216" height="784" alt="imagen" src="https://github.com/user-attachments/assets/98388419-29bb-443d-a0c3-32aaa225d3d6" />
