### PR TITLE
fix: remove duplicate CommandPalette in mobile layout

### DIFF
--- a/src/renderer/layouts/mobile-layout/mobile-layout.tsx
+++ b/src/renderer/layouts/mobile-layout/mobile-layout.tsx
@@ -8,11 +8,10 @@ import styles from './mobile-layout.module.css';
 import { ContextMenuController } from '/@/renderer/features/context-menu/context-menu-controller';
 import { FullScreenVisualizer } from '/@/renderer/features/player/components/full-screen-visualizer';
 import { MobileFullscreenPlayer } from '/@/renderer/features/player/components/mobile-fullscreen-player';
-import { CommandPalette } from '/@/renderer/features/search/components/command-palette';
 import { MobileSidebar } from '/@/renderer/features/sidebar/components/mobile-sidebar';
 import { PlayerBar } from '/@/renderer/layouts/default-layout/player-bar';
 import { useFullScreenPlayerStore } from '/@/renderer/store';
-import { useCommandPalette, useWindowSettings } from '/@/renderer/store';
+import { useWindowSettings } from '/@/renderer/store';
 import { ActionIcon } from '/@/shared/components/action-icon/action-icon';
 import { Drawer } from '/@/shared/components/drawer/drawer';
 import { useDisclosure } from '/@/shared/hooks/use-disclosure';
@@ -29,7 +28,6 @@ interface MobileLayoutProps {
 }
 
 export const MobileLayout = ({ shell }: MobileLayoutProps) => {
-    const { opened, ...handlers } = useCommandPalette();
     const [sidebarOpened, { close: closeSidebar, open: openSidebar }] = useDisclosure(false);
     const {
         expanded: isFullScreenPlayerExpanded,
@@ -93,7 +91,6 @@ export const MobileLayout = ({ shell }: MobileLayoutProps) => {
                     </div>
                 )}
             </AnimatePresence>
-            <CommandPalette modalProps={{ handlers, opened }} />
             <ContextMenuController.Root />
         </>
     );


### PR DESCRIPTION
## Summary

Fixes #1666

The `CommandPalette` component was being rendered twice when in mobile view:
1. In `ResponsiveLayout` via `LayoutHotkeys` component (which provides CommandPalette for all layouts)
2. In `MobileLayout` directly

This caused two overlapping command menus to open when pressing Ctrl+K in mobile view, with keyboard input going to the background menu instead of the visible foreground one.

## Solution

Remove the duplicate `CommandPalette` from `MobileLayout` since `LayoutHotkeys` (in `ResponsiveLayout`) already provides it for all layouts - both desktop and mobile.

Note: `DefaultLayout` never had its own `CommandPalette` and relied on `LayoutHotkeys`, so this brings `MobileLayout` in line with that pattern.

## Testing

1. Resize Feishin window to mobile layout
2. Press Ctrl+K
3. Verify only one command palette opens
4. Verify typing goes into the visible menu