### PR TITLE
Fix macOS dark theme window

### DIFF
--- a/src/renderer/features/settings/components/general/theme-settings.tsx
+++ b/src/renderer/features/settings/components/general/theme-settings.tsx
@@ -109,9 +109,7 @@ export const ThemeSettings = memo(() => {
                             localSettings.themeSet(
                                 e.currentTarget.checked
                                     ? 'system'
-                                    : settings.theme === AppTheme.DEFAULT_DARK
-                                      ? 'dark'
-                                      : 'light',
+                                    : (getAppTheme(settings.theme).mode ?? 'dark'),
                             );
                         }
                     }}
@@ -138,7 +136,7 @@ export const ThemeSettings = memo(() => {
                             },
                         });
 
-                        const colorScheme = theme === AppTheme.DEFAULT_DARK ? 'dark' : 'light';
+                        const colorScheme = getAppTheme(theme).mode ?? 'dark';
 
                         setColorScheme(colorScheme);
 


### PR DESCRIPTION
Previously, only DEFAULT_DARK was checked to determine the native window theme (dark/light title bar on macOS). Any other dark theme would incorrectly get a light title bar. Now uses `getAppTheme(theme).mode` to read the actual mode from each theme's configuration.


Before:
<img width="1468" height="429" alt="image" src="https://github.com/user-attachments/assets/39e21b51-7c6b-47f3-a0eb-534ef05b7e60" />

After:
<img width="1470" height="423" alt="image" src="https://github.com/user-attachments/assets/77d65554-df1b-49d3-8d1e-6f9fea8ac91b" />