### PR TITLE
fix: use media session by default on mac and hide setting to disable

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,6 @@ Download the [latest desktop client](https://github.com/jeffvli/feishin/releases
 
 If you're using a device running macOS 12 (Monterey) or higher, [check here](https://github.com/jeffvli/feishin/issues/104#issuecomment-1553914730) for instructions on how to remove the app from quarantine.
 
-For media keys to work, you will be prompted to allow Feishin to be a Trusted Accessibility Client. After allowing, you will need to restart Feishin for the privacy settings to take effect.
-
 #### Linux Notes
 
 We provide a small install script to download the latest `.AppImage`, make it executable, and also download the icons required by Desktop Environments. Finally, it generates a `.desktop` file to add Feishin to your Application Launcher.

--- a/src/main/features/core/player/media-keys.ts
+++ b/src/main/features/core/player/media-keys.ts
@@ -1,30 +1,11 @@
-import { BrowserWindow, globalShortcut, systemPreferences } from 'electron';
+import { BrowserWindow, globalShortcut } from 'electron';
 
-import { isLinux, isMacOS } from '../../../utils';
+import { isLinux } from '../../../utils';
 import { store } from '../settings';
 
 import { PlayerType } from '/@/shared/types/types';
 
 export const enableMediaKeys = (window: BrowserWindow | null) => {
-    if (isMacOS()) {
-        const shouldPrompt = store.get('should_prompt_accessibility', true) as boolean;
-        const shownWarning = store.get('shown_accessibility_warning', false) as boolean;
-        const trusted = systemPreferences.isTrustedAccessibilityClient(shouldPrompt);
-
-        if (shouldPrompt) {
-            store.set('should_prompt_accessibility', false);
-        }
-
-        if (!trusted && !shownWarning) {
-            window?.webContents.send('toast-from-main', {
-                message:
-                    'Feishin is not a trusted accessibility client. Media keys will not work until this setting is changed',
-                type: 'warning',
-            });
-            store.set('shown_accessibility_warning', true);
-        }
-    }
-
     const enableMediaSession = store.get('mediaSession', false) as boolean;
     const playbackType = store.get('playbackType', PlayerType.WEB) as PlayerType;
 

--- a/src/main/features/core/settings/index.ts
+++ b/src/main/features/core/settings/index.ts
@@ -4,10 +4,10 @@ import { app, dialog, ipcMain, nativeTheme, OpenDialogOptions, safeStorage } fro
 import Store from 'electron-store';
 import path from 'path';
 
-const getFrame = () => {
-    const isWindows = process.platform === 'win32';
-    const isMacOS = process.platform === 'darwin';
+const isWindows = process.platform === 'win32';
+const isMacOS = process.platform === 'darwin';
 
+const getFrame = () => {
     if (isWindows) {
         return 'windows';
     }
@@ -36,10 +36,8 @@ export const store = new Store<any>({
         enableNeteaseTranslation: false,
         global_media_hotkeys: true,
         lyrics: ['NetEase', 'lrclib.net'],
-        mediaSession: false,
+        mediaSession: isMacOS,
         playbackType: 'web',
-        should_prompt_accessibility: true,
-        shown_accessibility_warning: false,
         window_enable_tray: true,
         window_exit_to_tray: false,
         window_minimize_to_tray: false,

--- a/src/renderer/features/settings/components/hotkeys/media-session-settings.tsx
+++ b/src/renderer/features/settings/components/hotkeys/media-session-settings.tsx
@@ -12,6 +12,7 @@ import { Switch } from '/@/shared/components/switch/switch';
 import { PlayerType } from '/@/shared/types/types';
 
 const isLinux = isElectron() ? window.api.utils.isLinux() : false;
+const isWindows = isElectron() ? window.api.utils.isWindows() : false;
 const isDesktop = isElectron();
 const localSettings = isElectron() ? window.api.localSettings : null;
 
@@ -56,7 +57,7 @@ export const MediaSessionSettings = memo(() => {
                 context: 'description',
                 postProcess: 'sentenceCase',
             }),
-            isHidden: isLinux || !isDesktop,
+            isHidden: !isWindows,
             note: t('common.restartRequired', { postProcess: 'sentenceCase' }),
             title: t('setting.mediaSession', { postProcess: 'sentenceCase' }),
         },

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -1603,7 +1603,7 @@ const initialState: SettingsState = {
         audioDeviceId: undefined,
         audioFadeOnStatusChange: true,
         filters: [],
-        mediaSession: false,
+        mediaSession: utils?.isMacOS() ?? false,
         mpvAudioDeviceId: undefined,
         mpvExtraParameters: [],
         mpvProperties: {


### PR DESCRIPTION
Following up the discussion in discord, there is no reason for mac to have media session (Now playing) disabled. This change enables it by default and hides setting to disable.