### PR TITLE
fix: actually show Jellyfin recently played songs carousel

### DIFF
--- a/src/renderer/features/home/routes/home-route.tsx
+++ b/src/renderer/features/home/routes/home-route.tsx
@@ -82,16 +82,7 @@ const HomeRoute = () => {
         },
     };
 
-    const sortedItems = homeItems.filter((item) => {
-        if (item.disabled) {
-            return false;
-        }
-        if (isJellyfin && item.id === HomeItem.RECENTLY_PLAYED) {
-            return false;
-        }
-
-        return true;
-    });
+    const sortedItems = homeItems.filter((item) => !item.disabled);
 
     const sortedCarousel = sortedItems
         .filter((item) => item.id !== HomeItem.GENRES)


### PR DESCRIPTION
Follow-up to #1494

Support for showing a Jellyfin recently-played songs carousel was added in a8604dd150c421ba32a7237015b1b1d0af744c33 (thanks!), but the carousel wouldn't show up when enabled, due to this filter.

### Testing

Ran the app locally, and confirmed I could see the "Recently played" carousel as expected.