### PR TITLE
Listen on IPv6 by default in docker image

### DIFF
--- a/ng.conf.template
+++ b/ng.conf.template
@@ -1,5 +1,6 @@
 server {
   listen 9180;
+  listen [::]:9180;
   sendfile on;
   default_type application/octet-stream;
 


### PR DESCRIPTION
Very trivial change, I'm trying to run the docker image in an IPv6-only environment which doesn't work without this.