### PR TITLE
fix: stale SERVER_URL when changing env var in Docker

### DIFF
--- a/ng.conf.template
+++ b/ng.conf.template
@@ -20,9 +20,11 @@ server {
 
   location ${PUBLIC_PATH}settings.js {
     alias /etc/nginx/conf.d/settings.js;
+    add_header Cache-Control "no-store";
   }
 
   location ${PUBLIC_PATH}/settings.js {
     alias /etc/nginx/conf.d/settings.js;
+    add_header Cache-Control "no-store";
   }
 }

--- a/src/renderer/router/app-outlet.tsx
+++ b/src/renderer/router/app-outlet.tsx
@@ -1,20 +1,37 @@
 import { useMemo } from 'react';
 import { Navigate, Outlet } from 'react-router';
 
+import { isServerLock } from '/@/renderer/features/action-required/utils/window-properties';
 import { AppRoute } from '/@/renderer/router/routes';
-import { useCurrentServer } from '/@/renderer/store';
+import { useAuthStoreActions, useCurrentServer } from '/@/renderer/store';
+
+const normalizeUrl = (url: string) => url.replace(/\/$/, '');
 
 export const AppOutlet = () => {
     const currentServer = useCurrentServer();
+    const { deleteServer, setCurrentServer } = useAuthStoreActions();
 
     const isActionsRequired = useMemo(() => {
+        // When SERVER_LOCK is enabled and the configured URL has changed,
+        // clear the stale session so the user re-authenticates against the new server.
+        if (isServerLock() && currentServer && window.SERVER_URL) {
+            const configuredUrl = normalizeUrl(window.SERVER_URL);
+            const persistedUrl = normalizeUrl(currentServer.url);
+
+            if (configuredUrl !== persistedUrl) {
+                deleteServer(currentServer.id);
+                setCurrentServer(null);
+                return true;
+            }
+        }
+
         const isServerRequired = !currentServer;
 
         const actions = [isServerRequired];
         const isActionRequired = actions.some((c) => c);
 
         return isActionRequired;
-    }, [currentServer]);
+    }, [currentServer, deleteServer, setCurrentServer]);
 
     if (isActionsRequired) {
         return <Navigate replace to={AppRoute.ACTION_REQUIRED} />;


### PR DESCRIPTION
## Summary

When using `SERVER_LOCK=true` with a static `SERVER_URL` in Docker, changing the env var and recreating the container does not take effect — the web app keeps using the old server URL. The only workaround is changing the FQDN where the service is exposed.

Two independent bugs cause this:

- **`settings.js` is served without `Cache-Control` headers.** Reverse proxies and CDNs (notably Cloudflare, which caches `.js` files by default) cache the old `settings.js` indefinitely. Even a different browser or private mode gets the stale response because the caching happens upstream, not in the browser. Changing the FQDN works because it's a different cache key.

- **localStorage persists the old server URL.** When a user is already authenticated, the Zustand auth store in localStorage holds the old URL. `AppOutlet` checks if `currentServer` exists and redirects straight to HOME without ever comparing the persisted URL against the current `window.SERVER_URL`. So even when `settings.js` is correctly updated, same-browser sessions keep using the old server.

## Changes

- **`ng.conf.template`**: Add `Cache-Control: no-store` to both `settings.js` location blocks, preventing any intermediate cache from serving stale config.
- **`app-outlet.tsx`**: When `SERVER_LOCK=true`, detect if the persisted server URL differs from `window.SERVER_URL`. If so, delete the stale server entry and force re-authentication against the new server.

