### PR TITLE
change "Fields" query parameter to array

### DIFF
--- a/scripts/after-all-artifact-build.mjs
+++ b/scripts/after-all-artifact-build.mjs
@@ -15,8 +15,7 @@ const __dirname = path.dirname(__filename);
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export default async function afterAllArtifactBuild(buildResult) {
     // Check if this build includes Linux as a target
-    const isLinux = buildResult.platformToTargets
-        .keys()
+    const isLinux = Array.from(buildResult.platformToTargets.keys())
         .some((platform) => platform.name === 'linux');
 
     if (isLinux) {

--- a/scripts/after-all-artifact-build.mjs
+++ b/scripts/after-all-artifact-build.mjs
@@ -15,8 +15,9 @@ const __dirname = path.dirname(__filename);
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export default async function afterAllArtifactBuild(buildResult) {
     // Check if this build includes Linux as a target
-    const isLinux = Array.from(buildResult.platformToTargets.keys())
-        .some((platform) => platform.name === 'linux');
+    const isLinux = Array.from(buildResult.platformToTargets.keys()).some(
+        (platform) => platform.name === 'linux',
+    );
 
     if (isLinux) {
         const updateScriptPath = path.join(__dirname, 'update-app-stream.mjs');

--- a/src/renderer/api/jellyfin/jellyfin-controller.ts
+++ b/src/renderer/api/jellyfin/jellyfin-controller.ts
@@ -54,15 +54,38 @@ const VERSION_INFO: VersionInfo = [
 ];
 
 const JF_FIELDS = {
-    ALBUM_ARTIST_DETAIL: 'Genres, Overview, SortName, ProviderIds',
-    ALBUM_ARTIST_LIST: 'Genres, DateCreated, ExternalUrls, Overview, SortName, ProviderIds',
-    ALBUM_DETAIL: 'Genres, DateCreated, ChildCount, People, Tags, ProviderIds',
-    ALBUM_LIST: 'People, Tags, Studios, SortName, UserData, ProviderIds, ChildCount',
-    FOLDER: 'Genres, DateCreated, MediaSources, UserData, ParentId',
-    GENRE: 'ItemCounts',
-    PLAYLIST_DETAIL: 'Genres, DateCreated, MediaSources, ChildCount, ParentId, SortName',
-    PLAYLIST_LIST: 'ChildCount, Genres, DateCreated, ParentId, Overview',
-    SONG: 'Genres, DateCreated, MediaSources, ParentId, People, Tags, SortName, UserData, ProviderIds',
+    ALBUM_ARTIST_DETAIL: ['Genres', 'Overview', 'SortName', 'ProviderIds'],
+    ALBUM_ARTIST_LIST: [
+        'Genres',
+        'DateCreated',
+        'ExternalUrls',
+        'Overview',
+        'SortName',
+        'ProviderIds',
+    ],
+    ALBUM_DETAIL: ['Genres', 'DateCreated', 'ChildCount', 'People', 'Tags', 'ProviderIds'],
+    ALBUM_LIST: ['People', 'Tags', 'Studios', 'SortName', 'ProviderIds', 'ChildCount'],
+    FOLDER: ['Genres', 'DateCreated', 'MediaSources', 'ParentId'],
+    GENRE: ['ItemCounts'],
+    PLAYLIST_DETAIL: [
+        'Genres',
+        'DateCreated',
+        'MediaSources',
+        'ChildCount',
+        'ParentId',
+        'SortName',
+    ],
+    PLAYLIST_LIST: ['ChildCount', 'Genres', 'DateCreated', 'ParentId', 'Overview'],
+    SONG: [
+        'Genres',
+        'DateCreated',
+        'MediaSources',
+        'ParentId',
+        'People',
+        'Tags',
+        'SortName',
+        'ProviderIds',
+    ],
 } as const;
 
 export const JellyfinController: InternalControllerEndpoint = {

--- a/src/shared/api/jellyfin/jellyfin-types.ts
+++ b/src/shared/api/jellyfin/jellyfin-types.ts
@@ -107,7 +107,7 @@ const baseParameters = z.object({
     ExcludeArtistIds: z.string().optional(),
     ExcludeItemIds: z.string().optional(),
     ExcludeItemTypes: z.string().optional(),
-    Fields: z.string().optional(),
+    Fields: z.array(z.string()).readonly().optional(),
     FolderId: z.string().optional(),
     ImageTypeLimit: z.number().optional(),
     IncludeArtists: z.boolean().optional(),
@@ -757,7 +757,7 @@ const serverInfo = z.object({
 });
 
 const similarSongsParameters = z.object({
-    Fields: z.string().optional(),
+    Fields: z.array(z.string()).readonly().optional(),
     Limit: z.number().optional(),
     UserId: z.string().optional(),
 });
@@ -806,7 +806,7 @@ const folderList = pagination.extend({
 });
 
 const folderParameters = z.object({
-    Fields: z.string().optional(),
+    Fields: z.array(z.string()).readonly().optional(),
     ParentId: z.string().optional(),
     SortBy: z.string().optional(),
     SortOrder: z.enum(sortOrderValues).optional(),


### PR DESCRIPTION
This fixes #1729.

**Changes**
- Converted Fields parameter from comma-separated strings to arrays to match Jellyfin API specification
- Removed invalid UserData field value and replaced with EnableUserData: true query parameter
Updated type definitions to accept readonly string arrays

**Issue**
Jellyfin API was returning 400 errors when starting radio or fetching items because Fields were sent as comma-separated strings instead of arrays

Fields are now properly serialized as repeated query parameters (e.g., [?Fields=Genres&Fields=DateCreated] using the existing qs.stringify and user data is requested via the correct EnableUserData parameter.