### PR TITLE
Fix image resolution setting value checking

### DIFF
--- a/src/renderer/features/settings/components/general/art-resolution-settings.tsx
+++ b/src/renderer/features/settings/components/general/art-resolution-settings.tsx
@@ -78,9 +78,7 @@ export const ImageResolutionSettings = memo(() => {
                                         max={2000}
                                         min={0}
                                         onChange={(e) => {
-                                            if (!e) return;
-
-                                            if (typeof e === 'string') return;
+                                            if (typeof e !== 'number') return;
 
                                             setSettings({
                                                 general: {


### PR DESCRIPTION
Currently, if a user sets 0 as the value for preferred image resolution, the setting is not applied because of a falsy-value check, while 0 in JS is false too. To fix this problem, replace the falsy check with a simple check for a number, because the NumberInput component can pass either a number or a string to onChange and we want to accept any number.