### PR TITLE
feat: customizable item layout on fullscreen player

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -541,9 +541,7 @@
             "related": "related",
             "upNext": "up next",
             "visualizer": "visualizer",
-            "noLyrics": "no lyrics found",
-            "year": "year",
-            "container": "container"
+            "noLyrics": "no lyrics found"
         },
         "genreList": {
             "showAlbums": "show $t(entity.genre, {\"count\": 1}) $t(entity.album, {\"count\": 2})",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -541,7 +541,9 @@
             "related": "related",
             "upNext": "up next",
             "visualizer": "visualizer",
-            "noLyrics": "no lyrics found"
+            "noLyrics": "no lyrics found",
+            "year": "year",
+            "container": "container"
         },
         "genreList": {
             "showAlbums": "show $t(entity.genre, {\"count\": 1}) $t(entity.album, {\"count\": 2})",
@@ -1007,6 +1009,8 @@
         "sidebarCollapsedNavigation": "sidebar (collapsed) navigation",
         "sidebarConfiguration_description": "select the items and order in which they appear in the sidebar",
         "sidebarConfiguration": "sidebar configuration",
+        "playerItemConfiguration_description": "configure what items are shown, and in what order, on the fullscreen player",
+        "playerItemConfiguration": "player item configuration",
         "sidebarPlaylistList_description": "show or hide the playlist list in the sidebar",
         "sidebarPlaylistList": "sidebar playlist list",
         "sidebarPlaylistSorting_description": "allows manual playlist sorting in the sidebar using drag and drop instead of the default server order",

--- a/src/renderer/features/player/components/full-screen-player-image.tsx
+++ b/src/renderer/features/player/components/full-screen-player-image.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import { t } from 'i18next';
 import { AnimatePresence, HTMLMotionProps, motion, Variants } from 'motion/react';
 import { Fragment, useEffect, useRef } from 'react';
 import { generatePath, Link } from 'react-router';
@@ -174,9 +175,17 @@ export const FullScreenPlayerImage = () => {
     const builtDataItems = {
         bit_depth: currentSong?.bitDepth && <Badge>{currentSong?.bitDepth} bit</Badge>,
         bit_rate: currentSong?.bitRate && <Badge>{currentSong?.bitRate} kbps</Badge>,
-        bpm: currentSong?.bpm && <Badge>{currentSong?.bpm} bpm</Badge>,
+        bpm: currentSong?.bpm && (
+            <Badge>
+                {currentSong?.bpm} {t('common.bpm')}
+            </Badge>
+        ),
         codec: currentSong?.container && <Badge>{currentSong?.container}</Badge>,
-        disc_number: currentSong?.discNumber && <Badge>Disc {currentSong?.discNumber}</Badge>,
+        disc_number: currentSong?.discNumber && (
+            <Badge>
+                {t('common.disc')} {currentSong?.discNumber}
+            </Badge>
+        ),
         genres:
             currentSong?.genres &&
             currentSong?.genres
@@ -188,7 +197,11 @@ export const FullScreenPlayerImage = () => {
         ),
         release_year: currentSong?.releaseYear && <Badge>{currentSong?.releaseYear}</Badge>,
         sample_rate: currentSong?.sampleRate && <Badge>{currentSong?.sampleRate / 1000} kHz</Badge>,
-        track_number: currentSong?.trackNumber && <Badge>Track {currentSong?.trackNumber}</Badge>,
+        track_number: currentSong?.trackNumber && (
+            <Badge>
+                {t('common.trackNumber')} {currentSong?.trackNumber}
+            </Badge>
+        ),
     };
 
     return (

--- a/src/renderer/features/player/components/full-screen-player-image.tsx
+++ b/src/renderer/features/player/components/full-screen-player-image.tsx
@@ -172,11 +172,23 @@ export const FullScreenPlayerImage = () => {
     ]);
 
     const builtDataItems = {
+        bit_depth: currentSong?.bitDepth && <Badge>{currentSong?.bitDepth} bit</Badge>,
+        bit_rate: currentSong?.bitRate && <Badge>{currentSong?.bitRate} kbps</Badge>,
+        bpm: currentSong?.bpm && <Badge>{currentSong?.bpm} bpm</Badge>,
         codec: currentSong?.container && <Badge>{currentSong?.container}</Badge>,
+        disc_number: currentSong?.discNumber && <Badge>Disc {currentSong?.discNumber}</Badge>,
+        genres:
+            currentSong?.genres &&
+            currentSong?.genres
+                .slice(0, 2)
+                .map((genre) => <Badge key={genre.id}>{genre.name}</Badge>),
+        release_date: currentSong?.releaseDate && <Badge>{currentSong?.releaseDate}</Badge>,
         release_type: currentSong?.tags?.releasetype && (
             <Badge>{currentSong?.tags?.releasetype[0]}</Badge>
         ),
-        year: currentSong?.releaseYear && <Badge>{currentSong?.releaseYear}</Badge>,
+        release_year: currentSong?.releaseYear && <Badge>{currentSong?.releaseYear}</Badge>,
+        sample_rate: currentSong?.sampleRate && <Badge>{currentSong?.sampleRate / 1000} kHz</Badge>,
+        track_number: currentSong?.trackNumber && <Badge>Track {currentSong?.trackNumber}</Badge>,
     };
 
     return (

--- a/src/renderer/features/player/components/full-screen-player-image.tsx
+++ b/src/renderer/features/player/components/full-screen-player-image.tsx
@@ -101,7 +101,7 @@ export const FullScreenPlayerImage = () => {
 
     const currentSong = usePlayerSong();
     const { nextSong } = usePlayerData();
-    const { blurExplicitImages } = useGeneralSettings();
+    const { blurExplicitImages, playerItems } = useGeneralSettings();
 
     const isPlayingRadio = isRadioActive && isRadioPlaying;
 
@@ -170,6 +170,14 @@ export const FullScreenPlayerImage = () => {
         currentSong?.explicitStatus,
         nextSong?.explicitStatus,
     ]);
+
+    const builtDataItems = {
+        codec: currentSong?.container && <Badge>{currentSong?.container}</Badge>,
+        release_type: currentSong?.tags?.releasetype && (
+            <Badge>{currentSong?.tags?.releasetype[0]}</Badge>
+        ),
+        year: currentSong?.releaseYear && <Badge>{currentSong?.releaseYear}</Badge>,
+    };
 
     return (
         <Flex
@@ -283,10 +291,7 @@ export const FullScreenPlayerImage = () => {
                 </Text>
                 {!isPlayingRadio && (
                     <Group justify="center" mt="sm">
-                        {currentSong?.tags.releasetype && (
-                            <Badge>{currentSong?.tags.releasetype[0]}</Badge>
-                        )}
-                        {currentSong?.releaseYear && <Badge>{currentSong?.releaseYear}</Badge>}
+                        {playerItems.map((i) => !i.disabled && builtDataItems[i.id])}
                     </Group>
                 )}
             </Stack>

--- a/src/renderer/features/player/components/full-screen-player-image.tsx
+++ b/src/renderer/features/player/components/full-screen-player-image.tsx
@@ -283,12 +283,10 @@ export const FullScreenPlayerImage = () => {
                 </Text>
                 {!isPlayingRadio && (
                     <Group justify="center" mt="sm">
-                        {currentSong?.container && (
-                            <Badge variant="transparent">{currentSong?.container}</Badge>
+                        {currentSong?.tags.releasetype && (
+                            <Badge>{currentSong?.tags.releasetype[0]}</Badge>
                         )}
-                        {currentSong?.releaseYear && (
-                            <Badge variant="transparent">{currentSong?.releaseYear}</Badge>
-                        )}
+                        {currentSong?.releaseYear && <Badge>{currentSong?.releaseYear}</Badge>}
                     </Group>
                 )}
             </Stack>

--- a/src/renderer/features/player/components/full-screen-player.tsx
+++ b/src/renderer/features/player/components/full-screen-player.tsx
@@ -555,7 +555,6 @@ const Controls = () => {
                             />
                         </Option.Control>
                     </Option>
-                    <Divider my="sm" />
                 </Popover.Dropdown>
             </Popover>
             <ListConfigMenu

--- a/src/renderer/features/settings/components/general/application-settings.tsx
+++ b/src/renderer/features/settings/components/general/application-settings.tsx
@@ -11,6 +11,7 @@ import {
     ArtistReleaseTypeSettings,
     ArtistSettings,
 } from '/@/renderer/features/settings/components/general/artist-settings';
+import { FullscreenPlayerSettings } from '/@/renderer/features/settings/components/general/fullscreen-player-settings';
 import { HomeSettings } from '/@/renderer/features/settings/components/general/home-settings';
 import { PathSettings } from '/@/renderer/features/settings/components/general/path-settings';
 import {
@@ -697,6 +698,7 @@ export const ApplicationSettings = memo(() => {
                     <HomeSettings />
                     <ArtistSettings />
                     <ArtistReleaseTypeSettings />
+                    <FullscreenPlayerSettings />
                     <PathSettings />
                 </>
             }

--- a/src/renderer/features/settings/components/general/fullscreen-player-settings.tsx
+++ b/src/renderer/features/settings/components/general/fullscreen-player-settings.tsx
@@ -9,9 +9,17 @@ import {
 } from '/@/renderer/store';
 
 const PLAYER_ITEMS: Array<[PlayerItem, string]> = [
+    [PlayerItem.BIT_DEPTH, 'common.bitDepth'],
+    [PlayerItem.BIT_RATE, 'common.bitrate'],
+    [PlayerItem.BPM, 'common.bpm'],
     [PlayerItem.CODEC, 'common.codec'],
+    [PlayerItem.DISC_NUMBER, 'table.config.label.discNumber'],
+    [PlayerItem.GENRES, 'entity.genre_other'],
+    [PlayerItem.RELEASE_DATE, 'filter.releaseDate'],
     [PlayerItem.RELEASE_TYPE, 'common.releaseType'],
-    [PlayerItem.YEAR, 'common.year'],
+    [PlayerItem.RELEASE_YEAR, 'filter.releaseYear'],
+    [PlayerItem.SAMPLE_RATE, 'common.sampleRate'],
+    [PlayerItem.TRACK_NUMBER, 'table.config.label.trackNumber'],
 ];
 
 export const FullscreenPlayerSettings = memo(() => {

--- a/src/renderer/features/settings/components/general/fullscreen-player-settings.tsx
+++ b/src/renderer/features/settings/components/general/fullscreen-player-settings.tsx
@@ -1,0 +1,30 @@
+import { memo } from 'react';
+
+import { DraggableItems } from '/@/renderer/features/settings/components/general/draggable-items';
+import {
+    PlayerItem,
+    SortableItem,
+    useGeneralSettings,
+    useSettingsStoreActions,
+} from '/@/renderer/store';
+
+const PLAYER_ITEMS: Array<[PlayerItem, string]> = [
+    [PlayerItem.CODEC, 'common.codec'],
+    [PlayerItem.RELEASE_TYPE, 'common.releaseType'],
+    [PlayerItem.YEAR, 'common.year'],
+];
+
+export const FullscreenPlayerSettings = memo(() => {
+    const { playerItems } = useGeneralSettings();
+    const { setPlayerItems } = useSettingsStoreActions();
+
+    return (
+        <DraggableItems
+            description="setting.playerItemConfiguration"
+            itemLabels={PLAYER_ITEMS}
+            items={playerItems as SortableItem<PlayerItem>[]}
+            setItems={setPlayerItems}
+            title="setting.playerItemConfiguration"
+        />
+    );
+});

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -74,6 +74,8 @@ const HomeItemSchema = z.enum([
     'recentlyReleased',
 ]);
 
+const PlayerItemSchema = z.enum(['codec', 'year', 'release_type']);
+
 const ArtistItemSchema = z.enum([
     'biography',
     'compilations',
@@ -461,6 +463,7 @@ export const GeneralSettingsSchema = z.object({
     playButtonBehavior: z.nativeEnum(Play),
     playerbarOpenDrawer: z.boolean(),
     playerbarSlider: PlayerbarSliderSchema,
+    playerItems: z.array(SortableItemSchema(PlayerItemSchema)),
     playlistTarget: PlaylistTargetSchema,
     resume: z.boolean(),
     showLyricsInSidebar: z.boolean(),
@@ -779,6 +782,12 @@ export enum PlayerbarSliderType {
     WAVEFORM = 'waveform',
 }
 
+export enum PlayerItem {
+    CODEC = 'codec',
+    RELEASE_TYPE = 'release_type',
+    YEAR = 'year',
+}
+
 export enum PlaylistTarget {
     ALBUM = 'album',
     TRACK = 'track',
@@ -838,6 +847,7 @@ export interface SettingsSlice extends z.infer<typeof SettingsStateSchema> {
         setHomeItems: (item: SortableItem<HomeItem>[]) => void;
         setList: (type: ItemListKey, data: DeepPartial<ItemListSettings>) => void;
         setPlaybackFilters: (filters: PlayerFilter[]) => void;
+        setPlayerItems: (items: SortableItem<PlayerItem>[]) => void;
         setPlaylistBehavior: (target: PlaylistTarget) => void;
         setSettings: (data: DeepPartial<SettingsState>) => void;
         setSidebarItems: (items: SidebarItemType[]) => void;
@@ -861,6 +871,21 @@ export type SortableItem<T extends string> = {
 export type TranscodingConfig = z.infer<typeof TranscodingConfigSchema>;
 
 export type VersionedSettings = SettingsState & { version: number };
+
+export const playerItems: SortableItem<PlayerItem>[] = [
+    {
+        disabled: false,
+        id: PlayerItem.RELEASE_TYPE,
+    },
+    {
+        disabled: false,
+        id: PlayerItem.YEAR,
+    },
+    {
+        disabled: true,
+        id: PlayerItem.CODEC,
+    },
+];
 
 export const sidebarItems: SidebarItemType[] = [
     {
@@ -1050,6 +1075,7 @@ const initialState: SettingsState = {
             barWidth: 2,
             type: PlayerbarSliderType.SLIDER,
         },
+        playerItems,
         playlistTarget: PlaylistTarget.TRACK,
         resume: true,
         showLyricsInSidebar: true,
@@ -1897,6 +1923,11 @@ export const useSettingsStore = createWithEqualityFn<SettingsSlice>()(
                                 state.playback.filters = filters;
                             });
                         },
+                        setPlayerItems: (items: SortableItem<PlayerItem>[]) => {
+                            set((state) => {
+                                state.general.playerItems = items;
+                            });
+                        },
                         setPlaylistBehavior: (target: PlaylistTarget) => {
                             set((state) => {
                                 state.general.playlistTarget = target;
@@ -2371,6 +2402,8 @@ export const useSidebarPlaylistListFilterRegex = () =>
 
 export const useSidebarItems = () =>
     useSettingsStore((state) => state.general.sidebarItems, shallow);
+
+export const usePlayerItems = () => useSettingsStore((state) => state.general.playerItems, shallow);
 
 export const useSidebarCollapsedNavigation = () =>
     useSettingsStore((state) => state.general.sidebarCollapsedNavigation, shallow);

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -906,7 +906,7 @@ export const playerItems: SortableItem<PlayerItem>[] = [
         id: PlayerItem.BPM,
     },
     {
-        disabled: true,
+        disabled: false,
         id: PlayerItem.CODEC,
     },
     {
@@ -922,7 +922,7 @@ export const playerItems: SortableItem<PlayerItem>[] = [
         id: PlayerItem.RELEASE_DATE,
     },
     {
-        disabled: false,
+        disabled: true,
         id: PlayerItem.RELEASE_TYPE,
     },
     {

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -74,7 +74,19 @@ const HomeItemSchema = z.enum([
     'recentlyReleased',
 ]);
 
-const PlayerItemSchema = z.enum(['codec', 'year', 'release_type']);
+const PlayerItemSchema = z.enum([
+    'bit_depth',
+    'bit_rate',
+    'bpm',
+    'disc_number',
+    'sample_rate',
+    'track_number',
+    'codec',
+    'release_year',
+    'release_type',
+    'release_date',
+    'genres',
+]);
 
 const ArtistItemSchema = z.enum([
     'biography',
@@ -783,9 +795,17 @@ export enum PlayerbarSliderType {
 }
 
 export enum PlayerItem {
+    BIT_DEPTH = 'bit_depth',
+    BIT_RATE = 'bit_rate',
+    BPM = 'bpm',
     CODEC = 'codec',
+    DISC_NUMBER = 'disc_number',
+    GENRES = 'genres',
+    RELEASE_DATE = 'release_date',
     RELEASE_TYPE = 'release_type',
-    YEAR = 'year',
+    RELEASE_YEAR = 'release_year',
+    SAMPLE_RATE = 'sample_rate',
+    TRACK_NUMBER = 'track_number',
 }
 
 export enum PlaylistTarget {
@@ -874,16 +894,48 @@ export type VersionedSettings = SettingsState & { version: number };
 
 export const playerItems: SortableItem<PlayerItem>[] = [
     {
+        disabled: true,
+        id: PlayerItem.BIT_DEPTH,
+    },
+    {
+        disabled: true,
+        id: PlayerItem.BIT_RATE,
+    },
+    {
+        disabled: true,
+        id: PlayerItem.BPM,
+    },
+    {
+        disabled: true,
+        id: PlayerItem.CODEC,
+    },
+    {
+        disabled: true,
+        id: PlayerItem.DISC_NUMBER,
+    },
+    {
+        disabled: true,
+        id: PlayerItem.GENRES,
+    },
+    {
+        disabled: true,
+        id: PlayerItem.RELEASE_DATE,
+    },
+    {
         disabled: false,
         id: PlayerItem.RELEASE_TYPE,
     },
     {
         disabled: false,
-        id: PlayerItem.YEAR,
+        id: PlayerItem.RELEASE_YEAR,
     },
     {
         disabled: true,
-        id: PlayerItem.CODEC,
+        id: PlayerItem.SAMPLE_RATE,
+    },
+    {
+        disabled: true,
+        id: PlayerItem.TRACK_NUMBER,
     },
 ];
 


### PR DESCRIPTION
This PR changes the fullscreen player display to allow customizing what items are displayed underneath the artist display, and in what order. Right now it supports toggling between release year, codec (container), and release type.

Additionally, I've readded the default badge styling to improve contrast against the background, since I personally think it looks extremely weird without some sort of a border at the minimum.

Screenshots:

<img width="391" height="188" alt="image" src="https://github.com/user-attachments/assets/9fa13bbc-c566-4183-853b-540811b65d2d" />'
<br>
<img width="662" height="190" alt="image" src="https://github.com/user-attachments/assets/28aae899-8bc3-4f31-b25b-164761a8df66" />
<br>
<img width="641" height="163" alt="image" src="https://github.com/user-attachments/assets/4b8777b3-4fb5-4030-ab0a-aaf09faa09b0" />

<br>
The implementation remains the same, if there's no data for a given item then the badge will be omitted.