### PR TITLE
chore: make useCurretnServer nullable, prever useCurrentServerId where possible

### DIFF
--- a/src/renderer/features/albums/components/album-detail-content.tsx
+++ b/src/renderer/features/albums/components/album-detail-content.tsx
@@ -32,7 +32,7 @@ import {
 import { ListSortOrderToggleButtonControlled } from '/@/renderer/features/shared/components/list-sort-order-toggle-button';
 import { FILTER_KEYS, searchLibraryItems } from '/@/renderer/features/shared/utils';
 import { AppRoute } from '/@/renderer/router/routes';
-import { useCurrentServer, usePlayerSong } from '/@/renderer/store';
+import { useCurrentServerId, usePlayerSong } from '/@/renderer/store';
 import { useExternalLinks, useSettingsStore } from '/@/renderer/store/settings.store';
 import { sentenceCase, titleCase } from '/@/renderer/utils';
 import { replaceURLWithHTMLLinks } from '/@/renderer/utils/linkify';
@@ -365,9 +365,9 @@ const AlbumMetadataExternalLinks = ({
 
 export const AlbumDetailContent = () => {
     const { albumId } = useParams() as { albumId: string };
-    const server = useCurrentServer();
+    const serverId = useCurrentServerId();
     const detailQuery = useSuspenseQuery(
-        albumQueries.detail({ query: { id: albumId }, serverId: server.id }),
+        albumQueries.detail({ query: { id: albumId }, serverId: serverId }),
     );
 
     const { externalLinks, lastFM, musicBrainz } = useExternalLinks();

--- a/src/renderer/features/albums/components/album-detail-header.tsx
+++ b/src/renderer/features/albums/components/album-detail-header.tsx
@@ -18,7 +18,7 @@ import { useSetFavorite } from '/@/renderer/features/shared/hooks/use-set-favori
 import { useSetRating } from '/@/renderer/features/shared/hooks/use-set-rating';
 import { songsQueries } from '/@/renderer/features/songs/api/songs-api';
 import { AppRoute } from '/@/renderer/router/routes';
-import { useCurrentServer, useShowRatings } from '/@/renderer/store';
+import { useCurrentServerId, useShowRatings } from '/@/renderer/store';
 import { useArtistRadioCount, usePlayButtonBehavior } from '/@/renderer/store/settings.store';
 import { formatDateAbsoluteUTC, formatDurationString } from '/@/renderer/utils';
 import { normalizeReleaseTypes } from '/@/renderer/utils/normalize-release-types';
@@ -32,12 +32,12 @@ import { Play } from '/@/shared/types/types';
 export const AlbumDetailHeader = forwardRef<HTMLDivElement>((_props, ref) => {
     const { albumId } = useParams() as { albumId: string };
     const { t } = useTranslation();
-    const server = useCurrentServer();
+    const serverId = useCurrentServerId();
     const showRatings = useShowRatings();
     const queryClient = useQueryClient();
     const albumRadioCount = useArtistRadioCount();
     const detailQuery = useQuery(
-        albumQueries.detail({ query: { id: albumId }, serverId: server?.id }),
+        albumQueries.detail({ query: { id: albumId }, serverId: serverId }),
     );
 
     const showRating =
@@ -84,8 +84,8 @@ export const AlbumDetailHeader = forwardRef<HTMLDivElement>((_props, ref) => {
         : undefined;
 
     const handlePlay = (type?: Play) => {
-        if (!server?.id || !albumId) return;
-        addToQueueByFetch(server.id, [albumId], LibraryItem.ALBUM, type || playButtonBehavior);
+        if (!serverId || !albumId) return;
+        addToQueueByFetch(serverId, [albumId], LibraryItem.ALBUM, type || playButtonBehavior);
     };
 
     const handleMoreOptions = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -97,7 +97,7 @@ export const AlbumDetailHeader = forwardRef<HTMLDivElement>((_props, ref) => {
     };
 
     const handleAlbumRadio = async () => {
-        if (!server?.id || !albumId) return;
+        if (!serverId || !albumId) return;
 
         try {
             const albumRadioSongs = await queryClient.fetchQuery({
@@ -106,7 +106,7 @@ export const AlbumDetailHeader = forwardRef<HTMLDivElement>((_props, ref) => {
                         albumId: albumId,
                         count: albumRadioCount,
                     },
-                    serverId: server.id,
+                    serverId: serverId,
                 }),
                 queryKey: queryKeys.player.fetch({ albumId: albumId }),
             });

--- a/src/renderer/features/albums/components/album-list-content.tsx
+++ b/src/renderer/features/albums/components/album-list-content.tsx
@@ -5,7 +5,7 @@ import { useAlbumListFilters } from '/@/renderer/features/albums/hooks/use-album
 import { ListFilters, ListFiltersTitle } from '/@/renderer/features/shared/components/list-filters';
 import { ListWithSidebarContainer } from '/@/renderer/features/shared/components/list-with-sidebar-container';
 import { SaveAsCollectionButton } from '/@/renderer/features/shared/components/save-as-collection-button';
-import { ItemListSettings, useCurrentServer, useListSettings } from '/@/renderer/store';
+import { ItemListSettings, useCurrentServerId, useListSettings } from '/@/renderer/store';
 import { ScrollArea } from '/@/shared/components/scroll-area/scroll-area';
 import { Spinner } from '/@/shared/components/spinner/spinner';
 import { Stack } from '/@/shared/components/stack/stack';
@@ -109,7 +109,7 @@ export const AlbumListView = ({
     detail?: ItemListSettings['detail'];
     overrideQuery?: OverrideAlbumListQuery;
 }) => {
-    const server = useCurrentServer();
+    const serverId = useCurrentServerId();
     const { pageKey } = useListContext();
 
     const { query } = useAlbumListFilters(pageKey as ItemListKey);
@@ -127,6 +127,10 @@ export const AlbumListView = ({
         };
     }, [query, overrideQuery]);
 
+    if (!serverId) {
+        return null;
+    }
+
     switch (display) {
         case ListDisplayType.GRID: {
             switch (pagination) {
@@ -137,7 +141,7 @@ export const AlbumListView = ({
                             itemsPerPage={itemsPerPage}
                             itemsPerRow={grid.itemsPerRowEnabled ? grid.itemsPerRow : undefined}
                             query={mergedQuery}
-                            serverId={server.id}
+                            serverId={serverId}
                             size={grid.size}
                         />
                     );
@@ -149,7 +153,7 @@ export const AlbumListView = ({
                             itemsPerPage={itemsPerPage}
                             itemsPerRow={grid.itemsPerRowEnabled ? grid.itemsPerRow : undefined}
                             query={mergedQuery}
-                            serverId={server.id}
+                            serverId={serverId}
                             size={grid.size}
                         />
                     );
@@ -172,7 +176,7 @@ export const AlbumListView = ({
                             enableVerticalBorders={table.enableVerticalBorders}
                             itemsPerPage={itemsPerPage}
                             query={mergedQuery}
-                            serverId={server.id}
+                            serverId={serverId}
                             size={table.size}
                         />
                     );
@@ -189,7 +193,7 @@ export const AlbumListView = ({
                             enableVerticalBorders={table.enableVerticalBorders}
                             itemsPerPage={itemsPerPage}
                             query={mergedQuery}
-                            serverId={server.id}
+                            serverId={serverId}
                             size={table.size}
                         />
                     );
@@ -206,7 +210,7 @@ export const AlbumListView = ({
                             enableHeader={detail?.enableHeader}
                             itemsPerPage={itemsPerPage}
                             query={mergedQuery}
-                            serverId={server.id}
+                            serverId={serverId}
                         />
                     );
                 }
@@ -216,7 +220,7 @@ export const AlbumListView = ({
                             enableHeader={detail?.enableHeader}
                             itemsPerPage={itemsPerPage}
                             query={mergedQuery}
-                            serverId={server.id}
+                            serverId={serverId}
                         />
                     );
                 }

--- a/src/renderer/features/albums/components/navidrome-album-filters.tsx
+++ b/src/renderer/features/albums/components/navidrome-album-filters.tsx
@@ -11,7 +11,7 @@ import {
     GenreMultiSelectRow,
 } from '/@/renderer/features/shared/components/multi-select-rows';
 import { TagFilters } from '/@/renderer/features/shared/components/tag-filter';
-import { useCurrentServer } from '/@/renderer/store';
+import { useCurrentServerId } from '/@/renderer/store';
 import { useAppStore, useAppStoreActions } from '/@/renderer/store/app.store';
 import { Divider } from '/@/shared/components/divider/divider';
 import { Group } from '/@/shared/components/group/group';
@@ -39,8 +39,7 @@ export const NavidromeAlbumFilters = ({
     disableGenreFilter,
 }: NavidromeAlbumFiltersProps) => {
     const { t } = useTranslation();
-    const server = useCurrentServer();
-    const serverId = server.id;
+    const serverId = useCurrentServerId();
 
     const artistSelectMode = useAppStore((state) => state.artistSelectMode);
     const genreSelectMode = useAppStore((state) => state.genreSelectMode);

--- a/src/renderer/features/albums/routes/album-detail-route.tsx
+++ b/src/renderer/features/albums/routes/album-detail-route.tsx
@@ -16,7 +16,7 @@ import { LibraryContainer } from '/@/renderer/features/shared/components/library
 import { LibraryHeaderBar } from '/@/renderer/features/shared/components/library-header-bar';
 import { PageErrorBoundary } from '/@/renderer/features/shared/components/page-error-boundary';
 import { useFastAverageColor } from '/@/renderer/hooks';
-import { useAlbumBackground, useCurrentServer } from '/@/renderer/store';
+import { useAlbumBackground, useCurrentServerId } from '/@/renderer/store';
 import { Spinner } from '/@/shared/components/spinner/spinner';
 import { LibraryItem } from '/@/shared/types/domain-types';
 
@@ -26,12 +26,12 @@ const AlbumDetailRoute = () => {
     const { albumBackground, albumBackgroundBlur } = useAlbumBackground();
 
     const { albumId } = useParams() as { albumId: string };
-    const server = useCurrentServer();
+    const serverId = useCurrentServerId();
 
     const location = useLocation();
 
     const detailQuery = useQuery({
-        ...albumQueries.detail({ query: { id: albumId }, serverId: server?.id }),
+        ...albumQueries.detail({ query: { id: albumId }, serverId: serverId }),
         placeholderData: location.state?.item,
     });
 

--- a/src/renderer/features/artists/components/album-artist-detail-content.tsx
+++ b/src/renderer/features/artists/components/album-artist-detail-content.tsx
@@ -982,8 +982,10 @@ export const AlbumArtistDetailContent = ({
     const showGenres = detailQuery.data?.genres ? detailQuery.data.genres.length !== 0 : false;
     const mbzId = detailQuery.data?.mbz;
 
+    const serverId = server?.id;
+
     const handleArtistRadio = useCallback(async () => {
-        if (!server?.id || !routeId) return;
+        if (!serverId || !routeId) return;
 
         try {
             const artistRadioSongs = await queryClient.fetchQuery({
@@ -992,7 +994,7 @@ export const AlbumArtistDetailContent = ({
                         artistId: routeId,
                         count: artistRadioCount,
                     },
-                    serverId: server.id,
+                    serverId: serverId,
                 }),
                 queryKey: queryKeys.player.fetch({ artistId: routeId }),
             });
@@ -1002,7 +1004,7 @@ export const AlbumArtistDetailContent = ({
         } catch (error) {
             console.error('Failed to load artist radio:', error);
         }
-    }, [addToQueueByData, artistRadioCount, queryClient, routeId, server.id]);
+    }, [addToQueueByData, artistRadioCount, queryClient, routeId, serverId]);
 
     // Calculate order for genres and external links (show before other sections)
     // Use a very low order number to ensure they appear first

--- a/src/renderer/features/artists/components/album-artist-detail-header.tsx
+++ b/src/renderer/features/artists/components/album-artist-detail-header.tsx
@@ -16,7 +16,7 @@ import {
 import { useSetFavorite } from '/@/renderer/features/shared/hooks/use-set-favorite';
 import { useSetRating } from '/@/renderer/features/shared/hooks/use-set-rating';
 import { AppRoute } from '/@/renderer/router/routes';
-import { useCurrentServer, useShowRatings } from '/@/renderer/store';
+import { useCurrentServerId, useShowRatings } from '/@/renderer/store';
 import { usePlayButtonBehavior } from '/@/renderer/store/settings.store';
 import { formatDurationString } from '/@/renderer/utils';
 import { SEPARATOR_STRING } from '/@/shared/api/utils';
@@ -32,13 +32,13 @@ export const AlbumArtistDetailHeader = forwardRef((_props, ref: Ref<HTMLDivEleme
         artistId?: string;
     };
     const routeId = (artistId || albumArtistId) as string;
-    const server = useCurrentServer();
+    const serverId = useCurrentServerId();
     const showRatings = useShowRatings();
     const { t } = useTranslation();
     const detailQuery = useSuspenseQuery(
         artistsQueries.albumArtistDetail({
             query: { id: routeId },
-            serverId: server?.id,
+            serverId: serverId,
         }),
     );
 
@@ -75,15 +75,15 @@ export const AlbumArtistDetailHeader = forwardRef((_props, ref: Ref<HTMLDivEleme
 
     const handlePlay = useCallback(
         (type?: Play) => {
-            if (!server?.id || !routeId) return;
+            if (!serverId || !routeId) return;
             addToQueueByFetch(
-                server.id,
+                serverId,
                 [routeId],
                 LibraryItem.ALBUM_ARTIST,
                 type || playButtonBehavior,
             );
         },
-        [addToQueueByFetch, playButtonBehavior, routeId, server.id],
+        [addToQueueByFetch, playButtonBehavior, routeId, serverId],
     );
 
     const handleFavorite = useCallback(() => {

--- a/src/renderer/features/artists/components/album-artist-list-content.tsx
+++ b/src/renderer/features/artists/components/album-artist-list-content.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense, useMemo } from 'react';
 
 import { useAlbumArtistListFilters } from '/@/renderer/features/artists/hooks/use-album-artist-list-filters';
-import { ItemListSettings, useCurrentServer, useListSettings } from '/@/renderer/store';
+import { ItemListSettings, useCurrentServerId, useListSettings } from '/@/renderer/store';
 import { Spinner } from '/@/shared/components/spinner/spinner';
 import { AlbumArtistListQuery } from '/@/shared/types/domain-types';
 import { ItemListKey, ListDisplayType, ListPaginationType } from '/@/shared/types/types';
@@ -66,7 +66,7 @@ export const AlbumArtistListView = ({
     pagination,
     table,
 }: ItemListSettings & { overrideQuery?: OverrideAlbumArtistListQuery }) => {
-    const server = useCurrentServer();
+    const serverId = useCurrentServerId();
 
     const { query } = useAlbumArtistListFilters();
 
@@ -83,6 +83,8 @@ export const AlbumArtistListView = ({
         };
     }, [query, overrideQuery]);
 
+    if (!serverId) return null;
+
     switch (display) {
         case ListDisplayType.GRID: {
             switch (pagination) {
@@ -93,7 +95,7 @@ export const AlbumArtistListView = ({
                             itemsPerPage={itemsPerPage}
                             itemsPerRow={grid.itemsPerRowEnabled ? grid.itemsPerRow : undefined}
                             query={mergedQuery}
-                            serverId={server.id}
+                            serverId={serverId}
                             size={grid.size}
                         />
                     );
@@ -105,7 +107,7 @@ export const AlbumArtistListView = ({
                             itemsPerPage={itemsPerPage}
                             itemsPerRow={grid.itemsPerRowEnabled ? grid.itemsPerRow : undefined}
                             query={mergedQuery}
-                            serverId={server.id}
+                            serverId={serverId}
                             size={grid.size}
                         />
                     );
@@ -128,7 +130,7 @@ export const AlbumArtistListView = ({
                             enableVerticalBorders={table.enableVerticalBorders}
                             itemsPerPage={itemsPerPage}
                             query={mergedQuery}
-                            serverId={server.id}
+                            serverId={serverId}
                             size={table.size}
                         />
                     );
@@ -145,7 +147,7 @@ export const AlbumArtistListView = ({
                             enableVerticalBorders={table.enableVerticalBorders}
                             itemsPerPage={itemsPerPage}
                             query={mergedQuery}
-                            serverId={server.id}
+                            serverId={serverId}
                             size={table.size}
                         />
                     );

--- a/src/renderer/features/artists/components/artist-list-content.tsx
+++ b/src/renderer/features/artists/components/artist-list-content.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense, useMemo } from 'react';
 
 import { useArtistListFilters } from '/@/renderer/features/artists/hooks/use-artist-list-filters';
-import { ItemListSettings, useCurrentServer, useListSettings } from '/@/renderer/store';
+import { ItemListSettings, useCurrentServerId, useListSettings } from '/@/renderer/store';
 import { Spinner } from '/@/shared/components/spinner/spinner';
 import { ArtistListQuery } from '/@/shared/types/domain-types';
 import { ItemListKey, ListDisplayType, ListPaginationType } from '/@/shared/types/types';
@@ -58,7 +58,7 @@ export const ArtistListView = ({
     pagination,
     table,
 }: ItemListSettings & { overrideQuery?: OverrideArtistListQuery }) => {
-    const server = useCurrentServer();
+    const serverId = useCurrentServerId();
 
     const { query } = useArtistListFilters();
 
@@ -85,7 +85,7 @@ export const ArtistListView = ({
                             itemsPerPage={itemsPerPage}
                             itemsPerRow={grid.itemsPerRowEnabled ? grid.itemsPerRow : undefined}
                             query={mergedQuery}
-                            serverId={server.id}
+                            serverId={serverId}
                             size={grid.size}
                         />
                     );
@@ -97,7 +97,7 @@ export const ArtistListView = ({
                             itemsPerPage={itemsPerPage}
                             itemsPerRow={grid.itemsPerRowEnabled ? grid.itemsPerRow : undefined}
                             query={mergedQuery}
-                            serverId={server.id}
+                            serverId={serverId}
                             size={grid.size}
                         />
                     );
@@ -120,7 +120,7 @@ export const ArtistListView = ({
                             enableVerticalBorders={table.enableVerticalBorders}
                             itemsPerPage={itemsPerPage}
                             query={mergedQuery}
-                            serverId={server.id}
+                            serverId={serverId}
                             size={table.size}
                         />
                     );
@@ -137,7 +137,7 @@ export const ArtistListView = ({
                             enableVerticalBorders={table.enableVerticalBorders}
                             itemsPerPage={itemsPerPage}
                             query={mergedQuery}
-                            serverId={server.id}
+                            serverId={serverId}
                             size={table.size}
                         />
                     );

--- a/src/renderer/features/artists/components/artist-list-header-filters.tsx
+++ b/src/renderer/features/artists/components/artist-list-header-filters.tsx
@@ -9,7 +9,7 @@ import { ListSelectFilter } from '/@/renderer/features/shared/components/list-se
 import { ListSortByDropdown } from '/@/renderer/features/shared/components/list-sort-by-dropdown';
 import { ListSortOrderToggleButton } from '/@/renderer/features/shared/components/list-sort-order-toggle-button';
 import { FILTER_KEYS } from '/@/renderer/features/shared/utils';
-import { useCurrentServer } from '/@/renderer/store';
+import { useCurrentServerId } from '/@/renderer/store';
 import { Divider } from '/@/shared/components/divider/divider';
 import { Flex } from '/@/shared/components/flex/flex';
 import { Group } from '/@/shared/components/group/group';
@@ -17,9 +17,9 @@ import { ArtistListSort, LibraryItem, SortOrder } from '/@/shared/types/domain-t
 import { ItemListKey } from '/@/shared/types/types';
 
 export const ArtistListHeaderFilters = () => {
-    const server = useCurrentServer();
+    const serverId = useCurrentServerId();
 
-    const rolesQuery = useQuery(sharedQueries.roles({ query: {}, serverId: server.id }));
+    const rolesQuery = useQuery(sharedQueries.roles({ query: {}, serverId }));
 
     return (
         <Flex justify="space-between">

--- a/src/renderer/features/artists/routes/album-artist-detail-favorite-songs-list-route.tsx
+++ b/src/renderer/features/artists/routes/album-artist-detail-favorite-songs-list-route.tsx
@@ -14,7 +14,7 @@ import { usePlayer } from '/@/renderer/features/player/context/player-context';
 import { AnimatedPage } from '/@/renderer/features/shared/components/animated-page';
 import { PageErrorBoundary } from '/@/renderer/features/shared/components/page-error-boundary';
 import { usePlayerSong } from '/@/renderer/store';
-import { useCurrentServer } from '/@/renderer/store/auth.store';
+import { useCurrentServerId } from '/@/renderer/store/auth.store';
 import { useSettingsStore } from '/@/renderer/store/settings.store';
 import { LibraryItem, Song } from '/@/shared/types/domain-types';
 import { ItemListKey, Play } from '/@/shared/types/types';
@@ -25,13 +25,13 @@ const AlbumArtistDetailFavoriteSongsListRoute = () => {
         artistId?: string;
     };
     const routeId = (artistId || albumArtistId) as string;
-    const server = useCurrentServer();
+    const serverId = useCurrentServerId();
     const pageKey = LibraryItem.SONG;
 
     const detailQuery = useQuery(
         artistsQueries.albumArtistDetail({
             query: { id: routeId },
-            serverId: server?.id,
+            serverId: serverId,
         }),
     );
 
@@ -39,7 +39,7 @@ const AlbumArtistDetailFavoriteSongsListRoute = () => {
         artistsQueries.favoriteSongs({
             options: { enabled: !!detailQuery?.data?.name },
             query: { artistId: routeId },
-            serverId: server?.id,
+            serverId: serverId,
         }),
     );
 

--- a/src/renderer/features/artists/routes/album-artist-detail-route.tsx
+++ b/src/renderer/features/artists/routes/album-artist-detail-route.tsx
@@ -17,14 +17,13 @@ import { LibraryContainer } from '/@/renderer/features/shared/components/library
 import { LibraryHeaderBar } from '/@/renderer/features/shared/components/library-header-bar';
 import { PageErrorBoundary } from '/@/renderer/features/shared/components/page-error-boundary';
 import { useFastAverageColor } from '/@/renderer/hooks';
-import { useArtistBackground, useCurrentServer, useCurrentServerId } from '/@/renderer/store';
+import { useArtistBackground, useCurrentServerId } from '/@/renderer/store';
 import { Spinner } from '/@/shared/components/spinner/spinner';
 import { AlbumListSort, LibraryItem, SortOrder } from '/@/shared/types/domain-types';
 
 const AlbumArtistDetailRouteContent = () => {
     const scrollAreaRef = useRef<HTMLDivElement>(null);
     const headerRef = useRef<HTMLDivElement>(null);
-    const server = useCurrentServer();
     const serverId = useCurrentServerId();
     const { artistBackground, artistBackgroundBlur } = useArtistBackground();
 
@@ -37,7 +36,7 @@ const AlbumArtistDetailRouteContent = () => {
 
     const [detailQuery, albumsQuery] = useSuspenseQueries({
         queries: [
-            artistsQueries.albumArtistDetail({ query: { id: routeId }, serverId: server?.id }),
+            artistsQueries.albumArtistDetail({ query: { id: routeId }, serverId }),
             albumQueries.list({
                 query: {
                     artistIds: [routeId],

--- a/src/renderer/features/artists/routes/album-artist-detail-top-songs-list-route.tsx
+++ b/src/renderer/features/artists/routes/album-artist-detail-top-songs-list-route.tsx
@@ -14,7 +14,7 @@ import { usePlayer } from '/@/renderer/features/player/context/player-context';
 import { AnimatedPage } from '/@/renderer/features/shared/components/animated-page';
 import { PageErrorBoundary } from '/@/renderer/features/shared/components/page-error-boundary';
 import { usePlayerSong } from '/@/renderer/store';
-import { useCurrentServer } from '/@/renderer/store/auth.store';
+import { useCurrentServerId } from '/@/renderer/store/auth.store';
 import { useSettingsStore } from '/@/renderer/store/settings.store';
 import { useLocalStorage } from '/@/shared/hooks/use-local-storage';
 import { LibraryItem, Song } from '/@/shared/types/domain-types';
@@ -26,7 +26,7 @@ const AlbumArtistDetailTopSongsListRoute = () => {
         artistId?: string;
     };
     const routeId = (artistId || albumArtistId) as string;
-    const server = useCurrentServer();
+    const serverId = useCurrentServerId();
     const pageKey = LibraryItem.SONG;
 
     const [topSongsQueryType] = useLocalStorage<'community' | 'personal'>({
@@ -37,7 +37,7 @@ const AlbumArtistDetailTopSongsListRoute = () => {
     const detailQuery = useQuery(
         artistsQueries.albumArtistDetail({
             query: { id: routeId },
-            serverId: server?.id,
+            serverId,
         }),
     );
 
@@ -49,7 +49,7 @@ const AlbumArtistDetailTopSongsListRoute = () => {
                 artistId: routeId,
                 type: topSongsQueryType,
             },
-            serverId: server?.id,
+            serverId,
         }),
     );
 

--- a/src/renderer/features/context-menu/actions/add-to-playlist-action.tsx
+++ b/src/renderer/features/context-menu/actions/add-to-playlist-action.tsx
@@ -16,7 +16,7 @@ import {
 import { playlistsQueries } from '/@/renderer/features/playlists/api/playlists-api';
 import { useRecentPlaylists } from '/@/renderer/features/playlists/hooks/use-recent-playlists';
 import { useAddToPlaylist } from '/@/renderer/features/playlists/mutations/add-to-playlist-mutation';
-import { useCurrentServer, useCurrentServerId } from '/@/renderer/store';
+import { useCurrentServerId } from '/@/renderer/store';
 import { Checkbox } from '/@/shared/components/checkbox/checkbox';
 import { ContextMenu } from '/@/shared/components/context-menu/context-menu';
 import { Icon } from '/@/shared/components/icon/icon';
@@ -34,7 +34,6 @@ interface AddToPlaylistActionProps {
 
 export const AddToPlaylistAction = ({ items, itemType }: AddToPlaylistActionProps) => {
     const { t } = useTranslation();
-    const server = useCurrentServer();
     const serverId = useCurrentServerId();
     const queryClient = useQueryClient();
     const [searchTerm, setSearchTerm] = useState('');
@@ -52,7 +51,7 @@ export const AddToPlaylistAction = ({ items, itemType }: AddToPlaylistActionProp
                 sortOrder: SortOrder.ASC,
                 startIndex: 0,
             },
-            serverId: server?.id,
+            serverId,
         }),
     );
 
@@ -147,12 +146,12 @@ export const AddToPlaylistAction = ({ items, itemType }: AddToPlaylistActionProp
 
     const getSongsByFolderLocal = useCallback(
         async (folderId: string) => {
-            if (!server) return null;
+            if (!serverId) return null;
 
             const songsResponse = await getSongsByFolder({
                 id: [folderId],
                 queryClient,
-                serverId: server.id,
+                serverId,
             });
 
             return {
@@ -161,7 +160,7 @@ export const AddToPlaylistAction = ({ items, itemType }: AddToPlaylistActionProp
                 totalRecordCount: songsResponse.items.length,
             };
         },
-        [queryClient, server],
+        [queryClient, serverId],
     );
 
     const handleAddToPlaylist = useCallback(

--- a/src/renderer/features/context-menu/actions/download-action.tsx
+++ b/src/renderer/features/context-menu/actions/download-action.tsx
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { api } from '/@/renderer/api';
-import { useCurrentServer } from '/@/renderer/store';
+import { useCurrentServerId } from '/@/renderer/store';
 import { ContextMenu } from '/@/shared/components/context-menu/context-menu';
 
 interface DownloadActionProps {
@@ -14,13 +14,13 @@ const utils = isElectron() ? window.api.utils : null;
 
 export const DownloadAction = ({ ids }: DownloadActionProps) => {
     const { t } = useTranslation();
-    const server = useCurrentServer();
+    const serverId = useCurrentServerId();
 
     const onSelect = useCallback(async () => {
         try {
             for (const id of ids) {
                 const downloadUrl = api.controller.getDownloadUrl({
-                    apiClientProps: { serverId: server.id },
+                    apiClientProps: { serverId },
                     query: { id },
                 });
 
@@ -33,7 +33,7 @@ export const DownloadAction = ({ ids }: DownloadActionProps) => {
         } catch (error) {
             console.error('Failed to download items:', error);
         }
-    }, [ids, server]);
+    }, [ids, serverId]);
 
     return (
         <ContextMenu.Item disabled={ids.length > 1} leftIcon="download" onSelect={onSelect}>

--- a/src/renderer/features/genres/components/genre-list-content.tsx
+++ b/src/renderer/features/genres/components/genre-list-content.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense, useMemo } from 'react';
 
 import { useGenreListFilters } from '/@/renderer/features/genres/hooks/use-genre-list-filters';
-import { ItemListSettings, useCurrentServer, useListSettings } from '/@/renderer/store';
+import { ItemListSettings, useCurrentServerId, useListSettings } from '/@/renderer/store';
 import { Spinner } from '/@/shared/components/spinner/spinner';
 import { GenreListQuery } from '/@/shared/types/domain-types';
 import { ItemListKey, ListDisplayType, ListPaginationType } from '/@/shared/types/types';
@@ -54,7 +54,7 @@ export const GenreListView = ({
     pagination,
     table,
 }: ItemListSettings & { overrideQuery?: Omit<GenreListQuery, 'limit' | 'startIndex'> }) => {
-    const server = useCurrentServer();
+    const serverId = useCurrentServerId();
 
     const { query } = useGenreListFilters();
 
@@ -81,7 +81,7 @@ export const GenreListView = ({
                             itemsPerPage={itemsPerPage}
                             itemsPerRow={grid.itemsPerRowEnabled ? grid.itemsPerRow : undefined}
                             query={mergedQuery}
-                            serverId={server.id}
+                            serverId={serverId}
                             size={grid.size}
                         />
                     );
@@ -93,7 +93,7 @@ export const GenreListView = ({
                             itemsPerPage={itemsPerPage}
                             itemsPerRow={grid.itemsPerRowEnabled ? grid.itemsPerRow : undefined}
                             query={mergedQuery}
-                            serverId={server.id}
+                            serverId={serverId}
                             size={grid.size}
                         />
                     );
@@ -116,7 +116,7 @@ export const GenreListView = ({
                             enableVerticalBorders={table.enableVerticalBorders}
                             itemsPerPage={itemsPerPage}
                             query={mergedQuery}
-                            serverId={server.id}
+                            serverId={serverId}
                             size={table.size}
                         />
                     );
@@ -133,7 +133,7 @@ export const GenreListView = ({
                             enableVerticalBorders={table.enableVerticalBorders}
                             itemsPerPage={itemsPerPage}
                             query={mergedQuery}
-                            serverId={server.id}
+                            serverId={serverId}
                             size={table.size}
                         />
                     );

--- a/src/renderer/features/home/components/featured-genres.tsx
+++ b/src/renderer/features/home/components/featured-genres.tsx
@@ -13,7 +13,7 @@ import { useIsPlayerFetching, usePlayer } from '/@/renderer/features/player/cont
 import { PlayButton } from '/@/renderer/features/shared/components/play-button';
 import { useContainerQuery } from '/@/renderer/hooks';
 import { AppRoute } from '/@/renderer/router/routes';
-import { useCurrentServer, useCurrentServerId } from '/@/renderer/store';
+import { useCurrentServerId } from '/@/renderer/store';
 import { Button } from '/@/shared/components/button/button';
 import { Group } from '/@/shared/components/group/group';
 import { TextTitle } from '/@/shared/components/text-title/text-title';
@@ -58,7 +58,7 @@ function getGenresToShow(breakpoints: {
 
 export const FeaturedGenres = () => {
     const { t } = useTranslation();
-    const server = useCurrentServer();
+    const serverId = useCurrentServerId();
     const { ref, ...cq } = useContainerQuery({
         lg: 900,
         md: 600,
@@ -73,9 +73,9 @@ export const FeaturedGenres = () => {
                 sortOrder: SortOrder.ASC,
                 startIndex: 0,
             },
-            serverId: server?.id,
+            serverId,
         }),
-        queryKey: [server.id, 'home', 'featured-genres'],
+        queryKey: [serverId, 'home', 'featured-genres'],
     });
 
     const randomGenres = useMemo(() => {

--- a/src/renderer/features/player/components/shuffle-all-modal.tsx
+++ b/src/renderer/features/player/components/shuffle-all-modal.tsx
@@ -71,6 +71,7 @@ export const ShuffleAllContextModal = () => {
     const { enableMaxYear, enableMinYear, genre, limit, maxYear, minYear, musicFolderId, played } =
         useShuffleAllStore();
     const { setStore } = useShuffleAllStoreActions();
+    const serverId = server?.id || '';
 
     const { isFetching, refetch } = useQuery({
         ...randomFetchQuery({
@@ -82,7 +83,7 @@ export const ShuffleAllContextModal = () => {
                 musicFolderId: musicFolderId || undefined,
                 played,
             },
-            serverId: server.id,
+            serverId,
         }),
         enabled: false,
         gcTime: 0,
@@ -215,7 +216,7 @@ const GenreSelect = () => {
                 value,
             };
         });
-    }, [genres, server.type]);
+    }, [genres, server?.type]);
 
     return (
         <Select

--- a/src/renderer/features/playlists/components/client-side-song-filters.tsx
+++ b/src/renderer/features/playlists/components/client-side-song-filters.tsx
@@ -14,7 +14,7 @@ import {
     GenreMultiSelectRow,
 } from '/@/renderer/features/shared/components/multi-select-rows';
 import { FILTER_KEYS } from '/@/renderer/features/shared/utils';
-import { useCurrentServer } from '/@/renderer/store';
+import { useCurrentServerId } from '/@/renderer/store';
 import { useAppStore, useAppStoreActions } from '/@/renderer/store/app.store';
 import { Divider } from '/@/shared/components/divider/divider';
 import { Group } from '/@/shared/components/group/group';
@@ -214,7 +214,7 @@ const MultiSelectFilterLabel = ({
 export const ClientSideSongFilters = () => {
     const { t } = useTranslation();
     const { playlistId } = useParams() as { playlistId: string };
-    const server = useCurrentServer();
+    const serverId = useCurrentServerId();
     const {
         query,
         setAlbumArtistIds,
@@ -232,7 +232,7 @@ export const ClientSideSongFilters = () => {
     const playlistSongsQuery = useSuspenseQuery(
         playlistsQueries.songList({
             query: { id: playlistId },
-            serverId: server?.id,
+            serverId,
         }),
     );
 

--- a/src/renderer/features/playlists/components/playlist-detail-song-list-content.tsx
+++ b/src/renderer/features/playlists/components/playlist-detail-song-list-content.tsx
@@ -9,7 +9,7 @@ import { eventEmitter } from '/@/renderer/events/event-emitter';
 import { playlistsQueries } from '/@/renderer/features/playlists/api/playlists-api';
 import { PlaylistDetailAlbumView } from '/@/renderer/features/playlists/components/playlist-detail-album-view';
 import { usePlaylistTrackList } from '/@/renderer/features/playlists/hooks/use-playlist-track-list';
-import { useCurrentServer, useListSettings } from '/@/renderer/store';
+import { useCurrentServerId, useListSettings } from '/@/renderer/store';
 import { Spinner } from '/@/shared/components/spinner/spinner';
 import {
     LibraryItem,
@@ -50,7 +50,7 @@ const PlaylistDetailSongListGrid = lazy(() =>
 
 export const PlaylistDetailSongListContent = () => {
     const { playlistId } = useParams() as { playlistId: string };
-    const server = useCurrentServer();
+    const serverId = useCurrentServerId();
     const queryClient = useQueryClient();
 
     const playlistSongsQuery = useSuspenseQuery(
@@ -58,7 +58,7 @@ export const PlaylistDetailSongListContent = () => {
             query: {
                 id: playlistId,
             },
-            serverId: server?.id,
+            serverId,
         }),
     );
 
@@ -75,7 +75,7 @@ export const PlaylistDetailSongListContent = () => {
                 query: {
                     id: playlistId,
                 },
-                serverId: server?.id,
+                serverId,
             }).queryKey;
 
             await queryClient.invalidateQueries({ queryKey });
@@ -87,7 +87,7 @@ export const PlaylistDetailSongListContent = () => {
         return () => {
             eventEmitter.off('ITEM_LIST_REFRESH', handleRefresh);
         };
-    }, [playlistId, queryClient, server?.id]);
+    }, [playlistId, queryClient, serverId]);
 
     return (
         <Suspense fallback={<Spinner container />}>
@@ -104,7 +104,7 @@ interface PlaylistDetailSongListViewProps {
 }
 
 export const PlaylistDetailSongListView = ({ data, items }: PlaylistDetailSongListViewProps) => {
-    const server = useCurrentServer();
+    const serverId = useCurrentServerId();
     const { display, itemsPerPage, pagination, table } = useListSettings(ItemListKey.PLAYLIST_SONG);
     const { currentPage, onChange: onPageChange } = useItemListPagination();
     const isPaginated = pagination === ListPaginationType.PAGINATED;
@@ -117,13 +117,15 @@ export const PlaylistDetailSongListView = ({ data, items }: PlaylistDetailSongLi
           }
         : undefined;
 
+    if (!serverId) return null;
+
     switch (display) {
         case ListDisplayType.GRID: {
             return (
                 <PlaylistDetailSongListGrid
                     data={data}
                     items={items}
-                    serverId={server.id}
+                    serverId={serverId}
                     {...paginationProps}
                 />
             );
@@ -140,7 +142,7 @@ export const PlaylistDetailSongListView = ({ data, items }: PlaylistDetailSongLi
                     enableRowHoverHighlight={table.enableRowHoverHighlight}
                     enableVerticalBorders={table.enableVerticalBorders}
                     items={items}
-                    serverId={server.id}
+                    serverId={serverId}
                     size={table.size}
                     {...paginationProps}
                 />
@@ -153,7 +155,7 @@ export const PlaylistDetailSongListView = ({ data, items }: PlaylistDetailSongLi
 
 export const PlaylistDetailSongListEdit = ({ data }: { data: PlaylistSongListResponse }) => {
     const { playlistId } = useParams() as { playlistId: string };
-    const server = useCurrentServer();
+    const serverId = useCurrentServerId();
     const { display, table } = useListSettings(ItemListKey.PLAYLIST_SONG);
 
     const [localData, setLocalData] = useState<PlaylistSongListResponse>(data);
@@ -272,7 +274,7 @@ export const PlaylistDetailSongListEdit = ({ data }: { data: PlaylistSongListRes
                     enableRowHoverHighlight={table.enableRowHoverHighlight}
                     enableVerticalBorders={table.enableVerticalBorders}
                     ref={tableRef}
-                    serverId={server.id}
+                    serverId={serverId}
                     size={table.size}
                 />
             );

--- a/src/renderer/features/playlists/components/playlist-detail-song-list-header.tsx
+++ b/src/renderer/features/playlists/components/playlist-detail-song-list-header.tsx
@@ -16,7 +16,7 @@ import {
 import { LibraryHeaderBar } from '/@/renderer/features/shared/components/library-header-bar';
 import { ListSearchInput } from '/@/renderer/features/shared/components/list-search-input';
 import { AppRoute } from '/@/renderer/router/routes';
-import { useCurrentServer } from '/@/renderer/store';
+import { useCurrentServerId } from '/@/renderer/store';
 import { formatDurationString } from '/@/renderer/utils';
 import { Stack } from '/@/shared/components/stack/stack';
 import { useLocalStorage } from '/@/shared/hooks/use-local-storage';
@@ -36,11 +36,11 @@ export const PlaylistDetailSongListHeader = ({
     const { t } = useTranslation();
     const { playlistId } = useParams() as { playlistId: string };
     const { itemCount, listData } = useListContext();
-    const server = useCurrentServer();
+    const serverId = useCurrentServerId();
     const location = useLocation();
 
     const detailQuery = useQuery({
-        ...playlistsQueries.detail({ query: { id: playlistId }, serverId: server?.id }),
+        ...playlistsQueries.detail({ query: { id: playlistId }, serverId }),
         placeholderData: location.state?.item,
     });
 

--- a/src/renderer/features/playlists/components/playlist-list-content.tsx
+++ b/src/renderer/features/playlists/components/playlist-list-content.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense, useMemo } from 'react';
 
 import { usePlaylistListFilters } from '/@/renderer/features/playlists/hooks/use-playlist-list-filters';
-import { ItemListSettings, useCurrentServer, useListSettings } from '/@/renderer/store';
+import { ItemListSettings, useCurrentServerId, useListSettings } from '/@/renderer/store';
 import { Spinner } from '/@/shared/components/spinner/spinner';
 import { PlaylistListQuery } from '/@/shared/types/domain-types';
 import { ItemListKey, ListDisplayType, ListPaginationType } from '/@/shared/types/types';
@@ -64,7 +64,7 @@ export const PlaylistListView = ({
     pagination,
     table,
 }: ItemListSettings & { overrideQuery?: Omit<PlaylistListQuery, 'limit' | 'startIndex'> }) => {
-    const server = useCurrentServer();
+    const serverId = useCurrentServerId();
 
     const { query } = usePlaylistListFilters();
 
@@ -91,7 +91,7 @@ export const PlaylistListView = ({
                             itemsPerPage={itemsPerPage}
                             itemsPerRow={grid.itemsPerRowEnabled ? grid.itemsPerRow : undefined}
                             query={mergedQuery}
-                            serverId={server.id}
+                            serverId={serverId}
                             size={grid.size}
                         />
                     );
@@ -103,7 +103,7 @@ export const PlaylistListView = ({
                             itemsPerPage={itemsPerPage}
                             itemsPerRow={grid.itemsPerRowEnabled ? grid.itemsPerRow : undefined}
                             query={mergedQuery}
-                            serverId={server.id}
+                            serverId={serverId}
                             size={grid.size}
                         />
                     );
@@ -126,7 +126,7 @@ export const PlaylistListView = ({
                             enableVerticalBorders={table.enableVerticalBorders}
                             itemsPerPage={itemsPerPage}
                             query={mergedQuery}
-                            serverId={server.id}
+                            serverId={serverId}
                             size={table.size}
                         />
                     );
@@ -143,7 +143,7 @@ export const PlaylistListView = ({
                             enableVerticalBorders={table.enableVerticalBorders}
                             itemsPerPage={itemsPerPage}
                             query={mergedQuery}
-                            serverId={server.id}
+                            serverId={serverId}
                             size={table.size}
                         />
                     );

--- a/src/renderer/features/playlists/components/playlist-list-header-filters.tsx
+++ b/src/renderer/features/playlists/components/playlist-list-header-filters.tsx
@@ -22,7 +22,9 @@ export const PlaylistListHeaderFilters = () => {
     const server = useCurrentServer();
 
     const handleCreatePlaylistModal = (e: MouseEvent<HTMLButtonElement>) => {
-        openCreatePlaylistModal(server, e);
+        if (server) {
+            openCreatePlaylistModal(server, e);
+        }
     };
 
     return (

--- a/src/renderer/features/playlists/components/playlist-query-builder.tsx
+++ b/src/renderer/features/playlists/components/playlist-query-builder.tsx
@@ -17,7 +17,7 @@ import { useTranslation } from 'react-i18next';
 import { QueryBuilder } from '/@/renderer/components/query-builder';
 import { playlistsQueries } from '/@/renderer/features/playlists/api/playlists-api';
 import { convertNDQueryToQueryGroup } from '/@/renderer/features/playlists/utils';
-import { useCurrentServer } from '/@/renderer/store';
+import { useCurrentServerId } from '/@/renderer/store';
 import { useQueryBuilderSettings } from '/@/renderer/store/settings.store';
 import {
     NDSongQueryBooleanOperators,
@@ -168,7 +168,7 @@ export const PlaylistQueryBuilder = forwardRef(
         ref: Ref<PlaylistQueryBuilderRef>,
     ) => {
         const { t } = useTranslation();
-        const server = useCurrentServer();
+        const serverId = useCurrentServerId();
         const queryBuilderSettings = useQueryBuilderSettings();
 
         // Memoize initial filters to avoid recalculation
@@ -189,7 +189,7 @@ export const PlaylistQueryBuilder = forwardRef(
         const { data: playlists } = useQuery(
             playlistsQueries.list({
                 query: { sortBy: PlaylistListSort.NAME, sortOrder: SortOrder.ASC, startIndex: 0 },
-                serverId: server?.id,
+                serverId,
             }),
         );
 

--- a/src/renderer/features/playlists/routes/playlist-detail-song-list-route.tsx
+++ b/src/renderer/features/playlists/routes/playlist-detail-song-list-route.tsx
@@ -77,7 +77,7 @@ const PlaylistDetailSongListRoute = () => {
     const server = useCurrentServer();
 
     const detailQuery = useQuery({
-        ...playlistsQueries.detail({ query: { id: playlistId }, serverId: server?.id }),
+        ...playlistsQueries.detail({ query: { id: playlistId }, serverId: server?.id || '' }),
         placeholderData: location.state?.item,
     });
     const createPlaylistMutation = useCreatePlaylist({});

--- a/src/renderer/features/search/components/command-palette.tsx
+++ b/src/renderer/features/search/components/command-palette.tsx
@@ -11,7 +11,7 @@ import { HomeCommands } from '/@/renderer/features/search/components/home-comman
 import { LibraryCommandItem } from '/@/renderer/features/search/components/library-command-item';
 import { ServerCommands } from '/@/renderer/features/search/components/server-commands';
 import { AppRoute } from '/@/renderer/router/routes';
-import { useCurrentServer } from '/@/renderer/store';
+import { useCurrentServerId } from '/@/renderer/store';
 import { ActionIcon } from '/@/shared/components/action-icon/action-icon';
 import { Box } from '/@/shared/components/box/box';
 import { Button } from '/@/shared/components/button/button';
@@ -31,7 +31,7 @@ interface CommandPaletteProps {
 
 export const CommandPalette = ({ modalProps }: CommandPaletteProps) => {
     const navigate = useNavigate();
-    const server = useCurrentServer();
+    const serverId = useCurrentServerId();
     const [value, setValue] = useState('');
     const [query, setQuery] = useState('');
     const [debouncedQuery] = useDebouncedValue(query, 400);
@@ -61,7 +61,7 @@ export const CommandPalette = ({ modalProps }: CommandPaletteProps) => {
                 songLimit: 4,
                 songStartIndex: 0,
             },
-            serverId: server?.id,
+            serverId,
         }),
     );
 

--- a/src/renderer/features/search/components/home-commands.tsx
+++ b/src/renderer/features/search/components/home-commands.tsx
@@ -30,7 +30,9 @@ export const HomeCommands = ({
 
     const handleCreatePlaylistModal = useCallback(() => {
         handleClose();
-        openCreatePlaylistModal(server);
+        if (server) {
+            openCreatePlaylistModal(server);
+        }
     }, [handleClose, server]);
 
     const handleSearch = () => {

--- a/src/renderer/features/search/components/library-command-item.tsx
+++ b/src/renderer/features/search/components/library-command-item.tsx
@@ -9,7 +9,7 @@ import {
     PlayTooltip,
 } from '/@/renderer/features/shared/components/play-button-group';
 import { usePlayButtonClick } from '/@/renderer/features/shared/hooks/use-play-button-click';
-import { useCurrentServer } from '/@/renderer/store';
+import { useCurrentServerId } from '/@/renderer/store';
 import { ActionIcon, ActionIconGroup } from '/@/shared/components/action-icon/action-icon';
 import { Flex } from '/@/shared/components/flex/flex';
 import { Text } from '/@/shared/components/text/text';
@@ -42,20 +42,20 @@ export const LibraryCommandItem = ({
     title,
 }: LibraryCommandItemProps) => {
     const { addToQueueByData, addToQueueByFetch } = usePlayer();
-    const server = useCurrentServer();
+    const serverId = useCurrentServerId();
 
     const handlePlay = useCallback(
         (playType: Play) => {
-            if (!server.id) return;
+            if (!serverId) return;
 
             // Use addToQueueByData for songs when we have the song data
             if (itemType === LibraryItem.SONG && song) {
                 addToQueueByData([song], playType);
             } else {
-                addToQueueByFetch(server.id, [id], itemType, playType);
+                addToQueueByFetch(serverId, [id], itemType, playType);
             }
         },
-        [addToQueueByData, addToQueueByFetch, id, itemType, server.id, song],
+        [addToQueueByData, addToQueueByFetch, id, itemType, serverId, song],
     );
 
     const handlePlayNext = usePlayButtonClick({

--- a/src/renderer/features/shared/components/list-filters.tsx
+++ b/src/renderer/features/shared/components/list-filters.tsx
@@ -43,10 +43,6 @@ export const ListFiltersModal = ({ isActive, itemType }: ListFiltersProps) => {
     const server = useCurrentServer();
     const { isSidebarOpen, pageKey, setIsSidebarOpen } = useListContext();
 
-    const serverType = server.type;
-
-    const FilterComponent = FILTERS[serverType][itemType];
-
     const [isOpen, handlers] = useDisclosure(false);
 
     const albumListFilters = useAlbumListFilters(pageKey as ItemListKey);
@@ -66,6 +62,10 @@ export const ListFiltersModal = ({ isActive, itemType }: ListFiltersProps) => {
     const disableArtistFilter = pageKey === ItemListKey.ALBUM_ARTIST_ALBUM;
     const disableGenreFilter =
         pageKey === ItemListKey.GENRE_ALBUM || pageKey === ItemListKey.GENRE_SONG;
+
+    if (!server?.type) return null;
+
+    const FilterComponent = FILTERS[server.type][itemType];
 
     return (
         <>
@@ -118,13 +118,14 @@ export const ListFiltersModal = ({ isActive, itemType }: ListFiltersProps) => {
 
 export const ListFilters = ({ itemType }: ListFiltersProps) => {
     const server = useCurrentServer();
-    const serverType = server.type;
-    const FilterComponent = FILTERS[serverType][itemType];
     const { pageKey } = useListContext();
 
     const disableArtistFilter = pageKey === ItemListKey.ALBUM_ARTIST_ALBUM;
     const disableGenreFilter =
         pageKey === ItemListKey.GENRE_ALBUM || pageKey === ItemListKey.GENRE_SONG;
+
+    if (!server?.type) return null;
+    const FilterComponent = FILTERS[server.type][itemType];
 
     return (
         <ComponentErrorBoundary>

--- a/src/renderer/features/shared/components/list-music-folder-dropdown.tsx
+++ b/src/renderer/features/shared/components/list-music-folder-dropdown.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { sharedQueries } from '/@/renderer/features/shared/api/shared-api';
 import { FolderButton } from '/@/renderer/features/shared/components/folder-button';
 import { useMusicFolderIdFilter } from '/@/renderer/features/shared/hooks/use-music-folder-id-filter';
-import { useCurrentServer } from '/@/renderer/store';
+import { useCurrentServerId } from '/@/renderer/store';
 import { DropdownMenu } from '/@/shared/components/dropdown-menu/dropdown-menu';
 import { ItemListKey } from '/@/shared/types/types';
 
@@ -12,10 +12,8 @@ interface ListMusicFolderDropdownProps {
 }
 
 export const ListMusicFolderDropdown = ({ listKey }: ListMusicFolderDropdownProps) => {
-    const server = useCurrentServer();
-    const { data: musicFolders } = useQuery(
-        sharedQueries.musicFolders({ query: null, serverId: server.id }),
-    );
+    const serverId = useCurrentServerId();
+    const { data: musicFolders } = useQuery(sharedQueries.musicFolders({ query: null, serverId }));
 
     const { musicFolderId, setMusicFolderId } = useMusicFolderIdFilter('', listKey);
 

--- a/src/renderer/features/shared/components/list-sort-by-dropdown.tsx
+++ b/src/renderer/features/shared/components/list-sort-by-dropdown.tsx
@@ -41,6 +41,8 @@ export const ListSortByDropdown = ({
 
     const { setSortBy, sortBy } = useSortByFilter(defaultSortByValue, listKey);
 
+    if (!server?.type) return null;
+
     const sortByLabel =
         (itemType && FILTERS[itemType][server.type].find((f) => f.value === sortBy)?.name) || '—';
 
@@ -94,6 +96,8 @@ export const ListSortByDropdownControlled = ({
     target,
 }: ListSortByDropdownControlledProps) => {
     const server = useCurrentServer();
+
+    if (!server?.type) return null;
 
     const availableFilters = filters || (itemType && FILTERS[itemType]?.[server.type]) || [];
 

--- a/src/renderer/features/shared/hooks/use-music-folder-id-filter.ts
+++ b/src/renderer/features/shared/hooks/use-music-folder-id-filter.ts
@@ -3,13 +3,13 @@ import { useSearchParams } from 'react-router';
 
 import { useListFilterPersistence } from '/@/renderer/features/shared/hooks/use-list-filter-persistence';
 import { FILTER_KEYS } from '/@/renderer/features/shared/utils';
-import { useCurrentServer } from '/@/renderer/store';
+import { useCurrentServerId } from '/@/renderer/store';
 import { parseStringParam, setSearchParam } from '/@/renderer/utils/query-params';
 import { ItemListKey } from '/@/shared/types/types';
 
 export const useMusicFolderIdFilter = (defaultValue: null | string, listKey: ItemListKey) => {
-    const server = useCurrentServer();
-    const { getFilter, setFilter } = useListFilterPersistence(server.id, listKey);
+    const serverId = useCurrentServerId();
+    const { getFilter, setFilter } = useListFilterPersistence(serverId, listKey);
     const [searchParams, setSearchParams] = useSearchParams();
 
     const persisted = getFilter(FILTER_KEYS.SHARED.MUSIC_FOLDER_ID);

--- a/src/renderer/features/shared/hooks/use-select-filter.ts
+++ b/src/renderer/features/shared/hooks/use-select-filter.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { useSearchParams } from 'react-router';
 
 import { useListFilterPersistence } from '/@/renderer/features/shared/hooks/use-list-filter-persistence';
-import { useCurrentServer } from '/@/renderer/store';
+import { useCurrentServerId } from '/@/renderer/store';
 import { parseStringParam, setSearchParam } from '/@/renderer/utils/query-params';
 import { ItemListKey } from '/@/shared/types/types';
 
@@ -11,8 +11,8 @@ export const useSelectFilter = (
     defaultValue: null | string,
     listKey: ItemListKey,
 ) => {
-    const server = useCurrentServer();
-    const { getFilter, setFilter } = useListFilterPersistence(server.id, listKey);
+    const serverId = useCurrentServerId();
+    const { getFilter, setFilter } = useListFilterPersistence(serverId, listKey);
     const [searchParams, setSearchParams] = useSearchParams();
 
     const persisted = getFilter(filterKey);

--- a/src/renderer/features/shared/hooks/use-sort-by-filter.ts
+++ b/src/renderer/features/shared/hooks/use-sort-by-filter.ts
@@ -3,13 +3,13 @@ import { useSearchParams } from 'react-router';
 
 import { useListFilterPersistence } from '/@/renderer/features/shared/hooks/use-list-filter-persistence';
 import { FILTER_KEYS } from '/@/renderer/features/shared/utils';
-import { useCurrentServer } from '/@/renderer/store';
+import { useCurrentServerId } from '/@/renderer/store';
 import { parseStringParam, setSearchParam } from '/@/renderer/utils/query-params';
 import { ItemListKey } from '/@/shared/types/types';
 
 export const useSortByFilter = <TSortBy>(defaultValue: null | string, listKey: ItemListKey) => {
-    const server = useCurrentServer();
-    const { getFilter, setFilter } = useListFilterPersistence(server.id, listKey);
+    const serverId = useCurrentServerId();
+    const { getFilter, setFilter } = useListFilterPersistence(serverId, listKey);
     const [searchParams, setSearchParams] = useSearchParams();
 
     const persisted = getFilter(FILTER_KEYS.SHARED.SORT_BY);

--- a/src/renderer/features/shared/hooks/use-sort-order-filter.ts
+++ b/src/renderer/features/shared/hooks/use-sort-order-filter.ts
@@ -3,14 +3,14 @@ import { useSearchParams } from 'react-router';
 
 import { useListFilterPersistence } from '/@/renderer/features/shared/hooks/use-list-filter-persistence';
 import { FILTER_KEYS } from '/@/renderer/features/shared/utils';
-import { useCurrentServer } from '/@/renderer/store';
+import { useCurrentServerId } from '/@/renderer/store';
 import { parseStringParam, setSearchParam } from '/@/renderer/utils/query-params';
 import { SortOrder } from '/@/shared/types/domain-types';
 import { ItemListKey } from '/@/shared/types/types';
 
 export const useSortOrderFilter = (defaultValue: null | string, listKey: ItemListKey) => {
-    const server = useCurrentServer();
-    const { getFilter, setFilter } = useListFilterPersistence(server.id, listKey);
+    const serverId = useCurrentServerId();
+    const { getFilter, setFilter } = useListFilterPersistence(serverId, listKey);
     const [searchParams, setSearchParams] = useSearchParams();
 
     const persisted = getFilter(FILTER_KEYS.SHARED.SORT_ORDER);

--- a/src/renderer/features/sidebar/components/server-selector-items.tsx
+++ b/src/renderer/features/sidebar/components/server-selector-items.tsx
@@ -41,7 +41,7 @@ export const ServerSelectorItems = () => {
     const queryClient = useQueryClient();
 
     const handleToggleMusicFolder = (musicFolderId: string) => {
-        if (supportsMultiSelect) {
+        if (supportsMultiSelect && currentServer) {
             const currentIds = currentServer.musicFolderId || [];
             const isSelected = currentIds.includes(musicFolderId);
 
@@ -53,7 +53,7 @@ export const ServerSelectorItems = () => {
                 // Add to selection
                 setMusicFolderId([...currentIds, musicFolderId]);
             }
-        } else {
+        } else if (currentServer) {
             const currentId = Array.isArray(currentServer.musicFolderId)
                 ? currentServer.musicFolderId[0]
                 : currentServer.musicFolderId;

--- a/src/renderer/features/sidebar/components/sidebar-playlist-list.tsx
+++ b/src/renderer/features/sidebar/components/sidebar-playlist-list.tsx
@@ -357,6 +357,9 @@ export const SidebarPlaylistList = () => {
     const player = usePlayer();
     const { t } = useTranslation();
     const server = useCurrentServer();
+    const serverId = server?.id || '';
+    const serverType = server?.type;
+    const serverUsername = server?.username;
     const sidebarPlaylistSorting = useSidebarPlaylistSorting();
     const filterRegex = useSidebarPlaylistListFilterRegex();
 
@@ -367,15 +370,15 @@ export const SidebarPlaylistList = () => {
                 sortOrder: SortOrder.ASC,
                 startIndex: 0,
             },
-            serverId: server?.id,
+            serverId,
         }),
     );
 
     const handlePlayPlaylist = useCallback(
         (id: string, playType: Play) => {
-            player.addToQueueByFetch(server.id, [id], LibraryItem.PLAYLIST, playType);
+            player.addToQueueByFetch(serverId, [id], LibraryItem.PLAYLIST, playType);
         },
-        [player, server.id],
+        [player, serverId],
     );
 
     const handleContextMenu = useCallback(
@@ -392,13 +395,13 @@ export const SidebarPlaylistList = () => {
 
     const [playlistOrder, setPlaylistOrder] = useLocalStorage<string[]>({
         defaultValue: [],
-        key: getPlaylistOrderKey(server.id, 'owned'),
+        key: getPlaylistOrderKey(serverId, 'owned'),
     });
 
     const playlistItems = useMemo(() => {
         const base = { handlePlay: handlePlayPlaylist };
 
-        if (!server?.type || !server?.username || !playlistsQuery.data?.items) {
+        if (!serverType || !serverUsername || !playlistsQuery.data?.items) {
             return { ...base, items: playlistsQuery.data?.items };
         }
 
@@ -414,7 +417,7 @@ export const SidebarPlaylistList = () => {
         const ownedPlaylistItems: Array<Playlist> = [];
 
         for (const playlist of playlistsQuery.data?.items ?? []) {
-            if (!playlist.owner || playlist.owner === server.username) {
+            if (!playlist.owner || playlist.owner === serverUsername) {
                 // Filter out playlists that match the regex
                 if (regex && regex.test(playlist.name)) {
                     continue;
@@ -440,8 +443,8 @@ export const SidebarPlaylistList = () => {
     }, [
         handlePlayPlaylist,
         playlistsQuery.data?.items,
-        server.type,
-        server.username,
+        serverType,
+        serverUsername,
         sidebarPlaylistSorting,
         playlistOrder,
         filterRegex,
@@ -482,7 +485,9 @@ export const SidebarPlaylistList = () => {
     };
 
     const handleCreatePlaylistModal = (e: MouseEvent<HTMLButtonElement>) => {
-        openCreatePlaylistModal(server, e);
+        if (server) {
+            openCreatePlaylistModal(server, e);
+        }
     };
 
     return (
@@ -550,6 +555,9 @@ export const SidebarSharedPlaylistList = () => {
     const server = useCurrentServer();
     const sidebarPlaylistSorting = useSidebarPlaylistSorting();
     const filterRegex = useSidebarPlaylistListFilterRegex();
+    const serverId = server?.id || '';
+    const serverType = server?.type;
+    const serverUsername = server?.username;
 
     const playlistsQuery = useQuery(
         playlistsQueries.list({
@@ -558,16 +566,16 @@ export const SidebarSharedPlaylistList = () => {
                 sortOrder: SortOrder.ASC,
                 startIndex: 0,
             },
-            serverId: server?.id,
+            serverId: serverId,
         }),
     );
 
     const handlePlayPlaylist = useCallback(
         (id: string, playType: Play) => {
-            if (!server?.id) return;
-            player.addToQueueByFetch(server.id, [id], LibraryItem.PLAYLIST, playType);
+            if (!serverId) return;
+            player.addToQueueByFetch(serverId, [id], LibraryItem.PLAYLIST, playType);
         },
-        [player, server.id],
+        [player, serverId],
     );
 
     const handleContextMenu = useCallback(
@@ -587,13 +595,13 @@ export const SidebarSharedPlaylistList = () => {
 
     const [playlistOrder, setPlaylistOrder] = useLocalStorage<string[]>({
         defaultValue: [],
-        key: getPlaylistOrderKey(server.id, 'shared'),
+        key: getPlaylistOrderKey(serverId, 'shared'),
     });
 
     const playlistItems = useMemo(() => {
         const base = { handlePlay: handlePlayPlaylist };
 
-        if (!server?.type || !server?.username || !playlistsQuery.data?.items) {
+        if (!serverType || !serverUsername || !playlistsQuery.data?.items) {
             return { ...base, items: playlistsQuery.data?.items };
         }
 
@@ -609,7 +617,7 @@ export const SidebarSharedPlaylistList = () => {
         const sharedPlaylistItems: Array<Playlist> = [];
 
         for (const playlist of playlistsQuery.data?.items ?? []) {
-            if (playlist.owner && playlist.owner !== server.username) {
+            if (playlist.owner && playlist.owner !== serverUsername) {
                 // Filter out playlists that match the regex
                 if (regex && regex.test(playlist.name)) {
                     continue;
@@ -635,8 +643,8 @@ export const SidebarSharedPlaylistList = () => {
     }, [
         handlePlayPlaylist,
         playlistsQuery.data?.items,
-        server.type,
-        server.username,
+        serverType,
+        serverUsername,
         sidebarPlaylistSorting,
         playlistOrder,
         filterRegex,

--- a/src/renderer/features/songs/components/jellyfin-song-filters.tsx
+++ b/src/renderer/features/songs/components/jellyfin-song-filters.tsx
@@ -11,7 +11,7 @@ import {
 } from '/@/renderer/features/shared/components/multi-select-rows';
 import { TagFilters } from '/@/renderer/features/shared/components/tag-filter';
 import { useSongListFilters } from '/@/renderer/features/songs/hooks/use-song-list-filters';
-import { useCurrentServer } from '/@/renderer/store';
+import { useCurrentServerId } from '/@/renderer/store';
 import { useAppStore, useAppStoreActions } from '/@/renderer/store/app.store';
 import { Divider } from '/@/shared/components/divider/divider';
 import { Group } from '/@/shared/components/group/group';
@@ -38,8 +38,7 @@ export const JellyfinSongFilters = ({
     disableArtistFilter,
     disableGenreFilter,
 }: JellyfinSongFiltersProps) => {
-    const server = useCurrentServer();
-    const serverId = server.id;
+    const serverId = useCurrentServerId();
     const { t } = useTranslation();
     const { query, setArtistIds, setCustom, setFavorite, setMaxYear, setMinYear } =
         useSongListFilters();

--- a/src/renderer/features/songs/components/navidrome-song-filters.tsx
+++ b/src/renderer/features/songs/components/navidrome-song-filters.tsx
@@ -41,7 +41,7 @@ export const NavidromeSongFilters = ({
 }: NavidromeSongFiltersProps) => {
     const { t } = useTranslation();
     const server = useCurrentServer();
-    const serverId = server.id;
+    const serverId = server?.id || '';
     const {
         query,
         setArtistIds,

--- a/src/renderer/features/songs/components/song-list-content.tsx
+++ b/src/renderer/features/songs/components/song-list-content.tsx
@@ -5,7 +5,7 @@ import { ListFilters, ListFiltersTitle } from '/@/renderer/features/shared/compo
 import { ListWithSidebarContainer } from '/@/renderer/features/shared/components/list-with-sidebar-container';
 import { SaveAsCollectionButton } from '/@/renderer/features/shared/components/save-as-collection-button';
 import { useSongListFilters } from '/@/renderer/features/songs/hooks/use-song-list-filters';
-import { ItemListSettings, useCurrentServer, useListSettings } from '/@/renderer/store';
+import { ItemListSettings, useCurrentServerId, useListSettings } from '/@/renderer/store';
 import { ScrollArea } from '/@/shared/components/scroll-area/scroll-area';
 import { Spinner } from '/@/shared/components/spinner/spinner';
 import { Stack } from '/@/shared/components/stack/stack';
@@ -87,7 +87,7 @@ export const SongListView = ({
     pagination,
     table,
 }: ItemListSettings & { overrideQuery?: OverrideSongListQuery }) => {
-    const server = useCurrentServer();
+    const serverId = useCurrentServerId();
     const { pageKey } = useListContext();
 
     const { query } = useSongListFilters(pageKey as ItemListKey);
@@ -105,6 +105,8 @@ export const SongListView = ({
         };
     }, [query, overrideQuery]);
 
+    if (!serverId) return null;
+
     switch (display) {
         case ListDisplayType.GRID: {
             switch (pagination) {
@@ -115,7 +117,7 @@ export const SongListView = ({
                             itemsPerPage={itemsPerPage}
                             itemsPerRow={grid.itemsPerRowEnabled ? grid.itemsPerRow : undefined}
                             query={mergedQuery}
-                            serverId={server.id}
+                            serverId={serverId}
                             size={grid.size}
                         />
                     );
@@ -126,7 +128,7 @@ export const SongListView = ({
                             itemsPerPage={itemsPerPage}
                             itemsPerRow={grid.itemsPerRowEnabled ? grid.itemsPerRow : undefined}
                             query={mergedQuery}
-                            serverId={server.id}
+                            serverId={serverId}
                             size={grid.size}
                         />
                     );
@@ -148,7 +150,7 @@ export const SongListView = ({
                             enableVerticalBorders={table.enableVerticalBorders}
                             itemsPerPage={itemsPerPage}
                             query={mergedQuery}
-                            serverId={server.id}
+                            serverId={serverId}
                             size={table.size}
                         />
                     );
@@ -164,7 +166,7 @@ export const SongListView = ({
                             enableVerticalBorders={table.enableVerticalBorders}
                             itemsPerPage={itemsPerPage}
                             query={mergedQuery}
-                            serverId={server.id}
+                            serverId={serverId}
                             size={table.size}
                         />
                     );

--- a/src/renderer/store/auth.store.ts
+++ b/src/renderer/store/auth.store.ts
@@ -111,7 +111,7 @@ export const useCurrentServerId = (): string =>
         return currentServer.id;
     }, shallow);
 
-export const useCurrentServer = () =>
+export const useCurrentServer = (): null | ServerListItem =>
     useAuthStore((state) => {
         if (!state.currentServer) {
             return null;
@@ -133,7 +133,7 @@ export const useCurrentServer = () =>
             username: state.currentServer?.username,
             version: state.currentServer?.version,
         };
-    }, shallow) as ServerListItem;
+    }, shallow);
 
 export const useIsAdmin = () =>
     useAuthStore((state) => {


### PR DESCRIPTION
`useCurrentServer()` was incorrectly typed as always returning a `ServerListItem`.
This PR changes it such that it returns null when not set, and then uses `useCurrentServerId()` where posible.

Of note, most of the core logic isn't changed, so many of the places will use an empty string if the server isn't present.