### PR TITLE
Remote URL hardcoding compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY --chown=nginx:nginx --from=builder /app/out/web /usr/share/nginx/html
 COPY ./settings.js.template /etc/nginx/templates/settings.js.template
 COPY ng.conf.template /etc/nginx/templates/default.conf.template
 
-ENV SERVER_LOCK=false SERVER_NAME="" SERVER_TYPE="" SERVER_URL=""
+ENV SERVER_LOCK=false SERVER_NAME="" SERVER_TYPE="" SERVER_URL="" REMOTE_URL=""
 ENV LEGACY_AUTHENTICATION="" ANALYTICS_DISABLED="" PUBLIC_PATH="/"
 
 EXPOSE 9180

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ services:
             - SERVER_LOCK=true # When true AND name/type/url are set, only username/password can be toggled
             - SERVER_TYPE=jellyfin # the allowed types are: jellyfin, navidrome, subsonic. These values are case insensitive
             - SERVER_URL= # http://address:port or https://address:port
+            = REMOTE_URL= # http://address or https://address
             - LEGACY_AUTHENTICATION=false # When SERVER_LOCK is true, sets the legacy (plaintext) authentication flag for Subsonic/OpenSubsonic servers
             - ANALYTICS_DISABLED=true # Set to true to disable Umami analytics tracking
         ports:
@@ -134,9 +135,11 @@ services:
 
 4. _Optional_ - To hard code the server url, pass the following environment variables: `SERVER_NAME`, `SERVER_TYPE` (one of `jellyfin` or `navidrome` or `subsonic`), `SERVER_URL`. To prevent users from changing these settings, pass `SERVER_LOCK=true`. This can only be set if all three of the previous values are set. When `SERVER_LOCK=true`, you can also set `LEGACY_AUTHENTICATION=true` or `LEGACY_AUTHENTICATION=false` to configure the legacy authentication flag for the server (only applicable for Subsonic/OpenSubsonic servers).
 
-5. _Optional_ - To disable Umami analytics tracking in the Docker/web version, set the environment variable `ANALYTICS_DISABLED=true`. When enabled, the analytics script will not be loaded and all tracking will be disabled.
+5. _Optional_ - If your server uses a separate public-facing URL than what integrating applications use internally to communicate with your server, such as a separate Navidrome `ShareURL`, set `REMOTE_URL` to said public-facing URL.
 
-6. _Optional_ - App settings (theme, language, sidebar options, etc.) can be overridden with environment variables on first run. The variables use the `FS_` prefix (e.g. `FS_GENERAL_THEME=defaultDark`, `FS_GENERAL_LANGUAGE=de`). See [the settings environment variable documentation](docs/ENV_SETTINGS.md) for the full list.
+6. _Optional_ - To disable Umami analytics tracking in the Docker/web version, set the environment variable `ANALYTICS_DISABLED=true`. When enabled, the analytics script will not be loaded and all tracking will be disabled.
+
+7. _Optional_ - App settings (theme, language, sidebar options, etc.) can be overridden with environment variables on first run. The variables use the `FS_` prefix (e.g. `FS_GENERAL_THEME=defaultDark`, `FS_GENERAL_LANGUAGE=de`). See [the settings environment variable documentation](docs/ENV_SETTINGS.md) for the full list.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ services:
 4. _Optional_ - To hard code the server url, pass the following environment variables: `SERVER_NAME`, `SERVER_TYPE` (one of `jellyfin` or `navidrome` or `subsonic`), `SERVER_URL`. To prevent users from changing these settings, pass `SERVER_LOCK=true`. This can only be set if all three of the previous values are set. When `SERVER_LOCK=true`, you can also set `LEGACY_AUTHENTICATION=true` or `LEGACY_AUTHENTICATION=false` to configure the legacy authentication flag for the server (only applicable for Subsonic/OpenSubsonic servers).
 
 5. _Optional_ - If your server uses a separate public-facing URL than what integrating applications use internally to communicate with your server, such as a separate Navidrome `ShareURL`, set `REMOTE_URL` to said public-facing URL.
-
+ 
 6. _Optional_ - To disable Umami analytics tracking in the Docker/web version, set the environment variable `ANALYTICS_DISABLED=true`. When enabled, the analytics script will not be loaded and all tracking will be disabled.
 
 7. _Optional_ - App settings (theme, language, sidebar options, etc.) can be overridden with environment variables on first run. The variables use the `FS_` prefix (e.g. `FS_GENERAL_THEME=defaultDark`, `FS_GENERAL_LANGUAGE=de`). See [the settings environment variable documentation](docs/ENV_SETTINGS.md) for the full list.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,7 @@ services:
             - SERVER_LOCK=false # When true AND name/type/url are set, only username/password can be toggled
             - SERVER_TYPE=jellyfin # the allowed types are: jellyfin, navidrome, subsonic. These values are case insensitive
             - SERVER_URL=http://localhost:8096 # http://address:port or https://address:port
+            # - REMOTE_URL=http://share.localhost # Used for compatibility with external functionality, such as custom sharing URLs on Navidrome
             - LEGACY_AUTHENTICATION=false # When SERVER_LOCK is true, sets the legacyauth flag for server authentication (true or false)
             - ANALYTICS_DISABLED=false # Set to true to disable Umami analytics tracking
         ports:

--- a/settings.js.template
+++ b/settings.js.template
@@ -1,6 +1,7 @@
 "use strict";
 
 window.SERVER_URL = "${SERVER_URL}";
+window.REMOTE_URL = "${REMOTE_URL}";
 window.SERVER_NAME = "${SERVER_NAME}";
 window.SERVER_TYPE = "${SERVER_TYPE}";
 window.SERVER_LOCK = "${SERVER_LOCK}";

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -12,5 +12,6 @@ declare global {
         SERVER_NAME?: string;
         SERVER_TYPE?: ServerType;
         SERVER_URL?: string;
+        REMOTE_URL?: string;
     }
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -8,10 +8,10 @@ declare global {
         electron: ElectronAPI;
         LEGACY_AUTHENTICATION?: boolean;
         queryLocalFonts?: () => Promise<Font[]>;
+        REMOTE_URL?: string;
         SERVER_LOCK?: boolean;
         SERVER_NAME?: string;
         SERVER_TYPE?: ServerType;
         SERVER_URL?: string;
-        REMOTE_URL?: string;
     }
 }

--- a/src/preload/local-settings.ts
+++ b/src/preload/local-settings.ts
@@ -79,6 +79,7 @@ const env = {
     SERVER_NAME: process.env.SERVER_NAME ?? '',
     SERVER_TYPE,
     SERVER_URL: process.env.SERVER_URL ?? 'http://',
+    REMOTE_URL: process.env.REMOTE_URL ?? '',
     START_MAXIMIZED: undefined as boolean | undefined,
 };
 

--- a/src/preload/local-settings.ts
+++ b/src/preload/local-settings.ts
@@ -74,12 +74,12 @@ const env = {
         SERVER_TYPE !== null
             ? process.env.LEGACY_AUTHENTICATION?.toLocaleLowerCase() === 'true'
             : false,
+    REMOTE_URL: process.env.REMOTE_URL ?? '',
     SERVER_LOCK:
         SERVER_TYPE !== null ? process.env.SERVER_LOCK?.toLocaleLowerCase() === 'true' : false,
     SERVER_NAME: process.env.SERVER_NAME ?? '',
     SERVER_TYPE,
     SERVER_URL: process.env.SERVER_URL ?? 'http://',
-    REMOTE_URL: process.env.REMOTE_URL ?? '',
     START_MAXIMIZED: undefined as boolean | undefined,
 };
 

--- a/src/renderer/features/login/routes/login-route.tsx
+++ b/src/renderer/features/login/routes/login-route.tsx
@@ -93,7 +93,7 @@ const LoginRoute = () => {
             isvalid: remoteUrl !== '',
             key: 'REMOTE_URL',
             value: remoteUrl,
-        }
+        },
     ];
 
     const form = useForm({
@@ -166,9 +166,9 @@ const LoginRoute = () => {
                 id: nanoid(),
                 isAdmin: data.isAdmin,
                 name: serverName,
+                remoteUrl: normalizedRemoteURL,
                 type: serverType as ServerType,
                 url: normalizedUrl,
-                remoteUrl: normalizedRemoteURL,
                 userId: data.userId,
                 username: data.username,
             };

--- a/src/renderer/features/login/routes/login-route.tsx
+++ b/src/renderer/features/login/routes/login-route.tsx
@@ -90,7 +90,7 @@ const LoginRoute = () => {
             value: serverUrl,
         },
         {
-            isvalid: remoteUrl !== '',
+            isValid: remoteUrl !== '',
             key: 'REMOTE_URL',
             value: remoteUrl,
         },

--- a/src/renderer/features/login/routes/login-route.tsx
+++ b/src/renderer/features/login/routes/login-route.tsx
@@ -65,6 +65,7 @@ const LoginRoute = () => {
     const serverType = window.SERVER_TYPE ? toServerType(window.SERVER_TYPE) : null;
     const serverName = window.SERVER_NAME || '';
     const serverUrl = window.SERVER_URL || '';
+    const remoteUrl = window.REMOTE_URL || '';
     const legacyAuth = serverLock && isLegacyAuth();
 
     const config = [
@@ -88,6 +89,11 @@ const LoginRoute = () => {
             key: 'SERVER_URL',
             value: serverUrl,
         },
+        {
+            isvalid: remoteUrl !== '',
+            key: 'REMOTE_URL',
+            value: remoteUrl,
+        }
     ];
 
     const form = useForm({
@@ -150,6 +156,7 @@ const LoginRoute = () => {
             }
 
             const normalizedUrl = normalizeUrl(serverUrl);
+            const normalizedRemoteURL = normalizeUrl(remoteUrl);
             const existingServer =
                 serverLock &&
                 Object.values(serverList).find((s) => normalizeUrl(s.url) === normalizedUrl);
@@ -161,6 +168,7 @@ const LoginRoute = () => {
                 name: serverName,
                 type: serverType as ServerType,
                 url: normalizedUrl,
+                remoteUrl: normalizedRemoteURL,
                 userId: data.userId,
                 username: data.username,
             };

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -74,6 +74,7 @@ declare global {
         FS_PLAYBACK_TRANSCODE_ENABLED?: string;
         FS_PLAYBACK_WEB_AUDIO?: string;
         LEGACY_AUTHENTICATION?: boolean | string;
+        REMOTE_URL?: string;
         SERVER_LOCK?: boolean | string;
         SERVER_NAME?: string;
         SERVER_TYPE?: string;


### PR DESCRIPTION
This PR should add functionality to hardcode the public/remote URL, as there is some external functionality which may need it (for example, custom sharing URLs in a hosted Navidrome setup). 

Creating this as a draft since I don't have access to proper testing tools. I would appreciate any testing and feedback that can be provided, I use a prettier custom ShareURL for navidrome shares and I really want to get that functionality up and running on Feishin on my homeserver <3