### PR TITLE
use electron-builder's static AppImage runtime

### DIFF
--- a/electron-builder-alpha.yml
+++ b/electron-builder-alpha.yml
@@ -60,6 +60,9 @@ linux:
     icon: assets/icons/icon.png
     artifactName: ${productName}-${os}-${arch}.${ext}
 
+toolsets:
+    appimage: "1.0.2"
+
 npmRebuild: false
 
 publish:

--- a/electron-builder-beta.yml
+++ b/electron-builder-beta.yml
@@ -59,6 +59,9 @@ linux:
     icon: assets/icons/icon.png
     artifactName: ${productName}-${os}-${arch}.${ext}
 
+toolsets:
+    appimage: "1.0.2"
+
 npmRebuild: false
 publish:
     provider: github

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -59,6 +59,9 @@ linux:
     icon: assets/icons/icon.png
     artifactName: ${productName}-${os}-${arch}.${ext}
 
+toolsets:
+    appimage: "1.0.2"
+
 npmRebuild: false
 afterAllArtifactBuild: scripts/after-all-artifact-build.mjs
 publish:


### PR DESCRIPTION
electron-builder added compatibility with the AppImage Type2 runtime (i.e. FUSE-less runtime). However, this is - for now anyway - an opt-in feature, which this commit enables.

---

Addresses issues like #1603 where Feishin cannot be launched due to missing FUSE2 libraries on the host. This report was on CachyOS, however Fedora's Atomic desktops are also [moving towards removing those](https://discussion.fedoraproject.org/t/f44-change-proposal-atomic-desktops-drop-fuse-2-libraries-selfcontained/179410/19).

Tested a build on my fork:
https://github.com/mihawk90/feishin/actions/runs/22884735205/job/66394840074

Downloaded the artefact and confirmed Feishin still runs, and also checked the `--appimage-version` to confirm the new runtime:
```
❯ ./Feishin-linux-x86_64.AppImage --appimage-version
AppImage runtime version: https://github.com/AppImage/type2-runtime/commit/dd6cebe
```

---

The toolset version corresponds to [electron-builder-binaries releases](https://github.com/electron-userland/electron-builder-binaries/releases?q=appimage&expanded=true).

**This does not yet add an update check for the runtime.**
However, the new runtime will supposedly be default in electron-builder 27:
https://github.com/electron-userland/electron-builder/issues/9632#issuecomment-4028265299

I'm not sure if Dependabot can pull them, and if not the only way is a custom script. But since their releases contain all kinds of binaries under different release names and tags, querying `latest` isn't an option and I'm not sure how to approach searching releases for a title or tag.