### PR TITLE
feat: macOS Now Playing / Control Center integration

### DIFF
--- a/src/main/features/core/player/index.ts
+++ b/src/main/features/core/player/index.ts
@@ -9,6 +9,7 @@ import process from 'process';
 import { getMainWindow, sendToastToRenderer } from '../../../index';
 import { createLog, isWindows } from '../../../utils';
 import { store } from '../settings';
+import { updateNowPlaying } from './now-playing';
 
 import { PlayerData } from '/@/shared/types/domain-types';
 
@@ -447,6 +448,7 @@ ipcMain.handle('player-get-time', async (): Promise<number | undefined> => {
 // Updates the current player metadata (song data)
 ipcMain.on('player-update-metadata', (_event, data: PlayerData) => {
     currentPlayerData = data;
+    updateNowPlaying(data);
 });
 
 // Returns the current player metadata (song data)

--- a/src/main/features/core/player/now-playing.ts
+++ b/src/main/features/core/player/now-playing.ts
@@ -1,0 +1,77 @@
+import { net } from 'electron';
+
+import { getMainWindow } from '../../../index';
+import { isMacOS } from '../../../utils';
+import { PlayerData } from '/@/shared/types/domain-types';
+
+// macOS Now Playing / Control Center integration.
+//
+// The HTML5 MediaSession API (which Electron forwards to the
+// macOS Now Playing info-center) lives in the renderer process.
+// This file acts as coordinator: whenever the track or playback
+// state changes it sends an IPC message to the renderer which
+// then updates its MediaSession object.  Electron on macOS
+// automatically mirrors that into the Control Center widget and
+// Touch Bar.
+
+let lastImageUrl: null | string = null;
+let lastImageData: null | string = null;
+
+async function fetchImageAsDataUrl(url: string): Promise<null | string> {
+    if (lastImageUrl === url && lastImageData) {
+        return lastImageData;
+    }
+
+    return new Promise((resolve) => {
+        const request = net.request(url);
+        const chunks: Buffer[] = [];
+
+        request.on('response', (response) => {
+            const contentType = (response.headers['content-type'] as string) || 'image/jpeg';
+
+            response.on('data', (chunk) => {
+                chunks.push(chunk as Buffer);
+            });
+
+            response.on('end', () => {
+                const buffer = Buffer.concat(chunks);
+                const dataUrl = `data:${contentType};base64,${buffer.toString('base64')}`;
+                lastImageUrl = url;
+                lastImageData = dataUrl;
+                resolve(dataUrl);
+            });
+
+            response.on('error', () => resolve(null));
+        });
+
+        request.on('error', () => resolve(null));
+        request.end();
+    });
+}
+
+export async function updateNowPlaying(data: PlayerData): Promise<void> {
+    if (!isMacOS()) return;
+
+    const window = getMainWindow();
+    if (!window) return;
+
+    const song = data.currentSong;
+    if (!song) {
+        window.webContents.send('update-media-session', null);
+        return;
+    }
+
+    let artworkDataUrl: null | string = null;
+    if (song.imageUrl) {
+        artworkDataUrl = await fetchImageAsDataUrl(song.imageUrl).catch(() => null);
+    }
+
+    window.webContents.send('update-media-session', {
+        album: song.album ?? '',
+        artist: song.artistName ?? '',
+        artworkDataUrl,
+        duration: song.duration ?? 0,
+        playbackState: data.status,
+        title: song.name,
+    });
+}

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -99,6 +99,51 @@ export const App = () => {
         return undefined;
     }, []);
 
+    // macOS Now Playing / Control Center integration via HTML5 MediaSession API.
+    // The main process fetches artwork and sends metadata here; Electron mirrors
+    // it automatically into the OS-level Now Playing info-center.
+    useEffect(() => {
+        if (!isElectron() || !('mediaSession' in navigator)) return undefined;
+
+        const handler = (
+            _event: unknown,
+            payload: null | {
+                album: string;
+                artist: string;
+                artworkDataUrl: null | string;
+                duration: number;
+                playbackState: string;
+                title: string;
+            },
+        ) => {
+            if (!payload) {
+                navigator.mediaSession.metadata = null;
+                navigator.mediaSession.playbackState = 'none';
+                return;
+            }
+
+            const artwork: MediaImage[] = [];
+            if (payload.artworkDataUrl) {
+                artwork.push({ src: payload.artworkDataUrl });
+            }
+
+            navigator.mediaSession.metadata = new MediaMetadata({
+                album: payload.album,
+                artist: payload.artist,
+                artwork,
+                title: payload.title,
+            });
+
+            navigator.mediaSession.playbackState =
+                payload.playbackState === 'playing' ? 'playing' : 'paused';
+        };
+
+        ipc?.on('update-media-session', handler);
+        return () => {
+            ipc?.removeAllListeners('update-media-session');
+        };
+    }, []);
+
     const notificationStyles = useMemo(
         () => ({
             root: {

--- a/src/renderer/features/player/audio-player/hooks/use-main-player-listener.tsx
+++ b/src/renderer/features/player/audio-player/hooks/use-main-player-listener.tsx
@@ -84,6 +84,27 @@ export const useMainPlayerListener = () => {
             }
         });
 
+        // macOS Now Playing / Control Center media key handlers.
+        // These allow the OS-level transport controls (Control Center, headphones,
+        // keyboard media keys when MediaSession is active) to control playback.
+        if ('mediaSession' in navigator) {
+            navigator.mediaSession.setActionHandler('play', () => {
+                if (!isRadioActive) mediaPlay();
+            });
+            navigator.mediaSession.setActionHandler('pause', () => {
+                if (!isRadioActive) mediaPause();
+            });
+            navigator.mediaSession.setActionHandler('stop', () => {
+                if (!isRadioActive) mediaStop();
+            });
+            navigator.mediaSession.setActionHandler('nexttrack', () => {
+                if (!isRadioActive) mediaNext();
+            });
+            navigator.mediaSession.setActionHandler('previoustrack', () => {
+                if (!isRadioActive) mediaPrevious();
+            });
+        }
+
         mpvPlayerListener.rendererSkipForward(() => {
             mediaSkipForward();
         });
@@ -131,6 +152,14 @@ export const useMainPlayerListener = () => {
             ipc?.removeAllListeners('renderer-player-volume-up');
             ipc?.removeAllListeners('renderer-player-volume-down');
             ipc?.removeAllListeners('renderer-player-error');
+
+            if ('mediaSession' in navigator) {
+                navigator.mediaSession.setActionHandler('play', null);
+                navigator.mediaSession.setActionHandler('pause', null);
+                navigator.mediaSession.setActionHandler('stop', null);
+                navigator.mediaSession.setActionHandler('nexttrack', null);
+                navigator.mediaSession.setActionHandler('previoustrack', null);
+            }
         };
     }, [
         decreaseVolume,


### PR DESCRIPTION
## Summary

- Adds macOS Now Playing / Control Center integration using the HTML5 MediaSession API
- The main process fetches album artwork and sends track metadata to the renderer via IPC; Electron automatically mirrors this into the OS-level Now Playing info-center
- Wires up MediaSession transport action handlers (`play`, `pause`, `stop`, `nexttrack`, `previoustrack`) so Control Center buttons and media keys control playback

## How it works

1. `now-playing.ts` — triggered on every `player-update-metadata` IPC event; fetches artwork as a data URL and sends metadata to the renderer via `update-media-session`
2. `app.tsx` — listens for `update-media-session` and updates `navigator.mediaSession` metadata and playback state
3. `use-main-player-listener.tsx` — registers/unregisters MediaSession action handlers alongside existing media key handlers

Requires "Media session" to be enabled in Settings → Hotkeys.

## Test plan

- [ ] Enable "Media session" in Settings → Hotkeys
- [ ] Play a track — verify title, artist, album and artwork appear in Control Center
- [ ] Use Control Center transport buttons to skip/pause — verify playback responds
- [ ] Pause playback — verify Control Center shows paused state
- [ ] Stop playback — verify Now Playing disappears from Control Center

🤖 Generated with [Claude Code](https://claude.com/claude-code)