### PR TITLE
fix(macos): stop click on menu bar switching to feishin window 

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -431,19 +431,21 @@ const createTray = () => {
         },
     ]);
 
-    tray.on('click', () => {
-        if (store.get('window_minimize_to_tray')) {
-            if (mainWindow?.isVisible()) {
-                mainWindow?.hide();
+    if (!isMacOS()) {
+        tray.on('click', () => {
+            if (store.get('window_minimize_to_tray')) {
+                if (mainWindow?.isVisible()) {
+                    mainWindow?.hide();
+                } else {
+                    mainWindow?.show();
+                    createWinThumbarButtons();
+                }
             } else {
                 mainWindow?.show();
                 createWinThumbarButtons();
             }
-        } else {
-            mainWindow?.show();
-            createWinThumbarButtons();
-        }
-    });
+        });
+    }
 
     tray.setToolTip('Feishin');
     tray.setContextMenu(contextMenu);


### PR DESCRIPTION
Currently, clicking on the Feishin icon in the macOS menu bar (aka, I suppose, the "tray icon") immediately switches focus to  the Feishin window (see recording). This seems counter to the purpose of having such a menu. I therefore suggest wrapping the `click` handler in `if (!isMacOS())` so as to prevent this. 

**Before**
![before](https://github.com/user-attachments/assets/f60a3249-b642-43bd-aa34-3d221ddc0523)

**After**
![after](https://github.com/user-attachments/assets/65b39755-ef66-4e0a-a8fc-19a06f7a01d5)
