### PR TITLE
Fix: Queue sidebar obscured by bottom controls

### DIFF
--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable perfectionist/sort-imports */
-import { MantineProvider } from '@mantine/core';
+import { Box, MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
 import 'overlayscrollbars/overlayscrollbars.css';
 import '/styles/overlayscrollbars.css';
@@ -79,7 +79,9 @@ const AppShell = memo(function AppShell() {
             <WebAudioContext.Provider value={webAudioProvider}>
                 <PlayerProvider>
                     <AudioPlayers />
-                    <AppRouter />
+                    <Box h="100%" pb={90}>
+                        <AppRouter />
+                    </Box>
                 </PlayerProvider>
             </WebAudioContext.Provider>
             <Suspense fallback={null}>


### PR DESCRIPTION
## Summary

The pinned queue sidebar was being obscured by the bottom player controls because the main content area did not account for the player's height. This has been fixed by wrapping the main application router in a container with bottom padding, ensuring there is enough space for content to be scrolled into view above the controls.

## Changes

- **src/renderer/app.tsx**: Import the Box component from Mantine to use as a layout container.
- **src/renderer/app.tsx**: Wrap the AppRouter in a Box component with bottom padding to prevent the player controls from overlapping the content. The Box is also given full height to ensure child layouts behave as expected.

## Related Issue

Closes #1895

