### PR TITLE
feat: Make "Clear" button "Refresh" when there are no lyrics found.

### DIFF
--- a/src/renderer/features/lyrics/lyrics-actions.tsx
+++ b/src/renderer/features/lyrics/lyrics-actions.tsx
@@ -131,7 +131,9 @@ export const LyricsActions = ({
                             uppercase
                             variant="subtle"
                         >
-                            {t('common.clear', { postProcess: 'sentenceCase' })}
+                            {hasLyrics
+                                ? t('common.clear', { postProcess: 'sentenceCase' })
+                                : t('common.refresh', { postProcess: 'sentenceCase' })}
                         </Button>
                     ) : null}
                 </Group>


### PR DESCRIPTION
Ref: #1919 - tl;dr: Button actually reloads/refreshes lyrics info from the server too, it makes it, oh well... clearer what it does in that case - allows to reread lyrics from server without clearing whole cache.

It uses existing `common.refresh` label for translation, so no new texts needed.
