### PR TITLE
fix(linux): remove unnecessary screen capture from audio loopback handler

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,7 +5,6 @@ import {
     app,
     BrowserWindow,
     BrowserWindowConstructorOptions,
-    desktopCapturer,
     globalShortcut,
     ipcMain,
     Menu,
@@ -734,19 +733,7 @@ async function createWindow(first = true): Promise<void> {
     });
 
     mainWindow.webContents.session.setDisplayMediaRequestHandler((_request, callback) => {
-        desktopCapturer
-            .getSources({ types: ['screen'] })
-            .then((sources) => {
-                if (sources.length > 0) {
-                    callback({ audio: 'loopback', video: sources[0] });
-                } else {
-                    callback({});
-                }
-            })
-            .catch((err) => {
-                log.warn('desktopCapturer.getSources failed', err);
-                callback({});
-            });
+        callback({ audio: 'loopback' });
     });
 
     if (!disableAutoUpdates() && store.get('disable_auto_updates') !== true) {


### PR DESCRIPTION
## Problem

<img width="766" height="790" alt="Screenshot_20260408_032622" src="https://github.com/user-attachments/assets/de0309b3-c7f5-40c3-8862-a3ba8ad7a209" />

On Wayland, Feishin shows an xdg-desktop-portal "Share screen" dialog on every launch. This happens because `setDisplayMediaRequestHandler` calls `desktopCapturer.getSources({ types: ['screen'] })`, which creates a new ScreenCast session each time. Electron does not persist PipeWire restore tokens across `desktopCapturer` sessions, so the dialog cannot be suppressed.

The video source provided by the handler is unused — the renderer requests `video: false` (since ef129e46) and only consumes audio tracks for the visualizer.

## Changes

- Removed `desktopCapturer.getSources()` call from the display media handler
- Simplified handler to `callback({ audio: 'loopback' })`
- Removed unused `desktopCapturer` import

## Alternatives considered

- **Pass video + strip tracks in renderer**: Does not solve the problem — `desktopCapturer.getSources()` still triggers the portal dialog
- **Platform-conditional logic** (skip video on Wayland only): Adds complexity for no benefit since video is unused on all platforms
- **PipeWire restore tokens**: Electron's `desktopCapturer.getSources()` API does not support storing or re-presenting restore tokens — this is an Electron limitation, not a portal bug

## Testing

- Arch Linux, KDE Plasma 6, Wayland, Electron 39
- Verified: no portal dialog on launch
- Verified: visualizer works with system audio loopback
- Verified: reverting to unpatched build reproduces the dialog