### PR TITLE
feat(lyrics): non-active lyric settings

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -540,6 +540,8 @@
                 "lyricOffset": "lyrics offset (ms)",
                 "lyricGap": "lyric gap",
                 "lyricSize": "lyric size",
+                "lyricOpacityNonActive": "non-active lyric opacity",
+                "lyricScaleNonActive": "non-active lyric scale",
                 "opacity": "opacity",
                 "showLyricMatch": "show lyric match",
                 "showLyricProvider": "show lyric provider",

--- a/src/renderer/features/lyrics/components/lyrics-settings-form.tsx
+++ b/src/renderer/features/lyrics/components/lyrics-settings-form.tsx
@@ -17,6 +17,7 @@ import { MultiSelect } from '/@/shared/components/multi-select/multi-select';
 import { NumberInput } from '/@/shared/components/number-input/number-input';
 import { SegmentedControl } from '/@/shared/components/segmented-control/segmented-control';
 import { Select } from '/@/shared/components/select/select';
+import { Slider } from '/@/shared/components/slider/slider';
 import { Stack } from '/@/shared/components/stack/stack';
 import { Switch } from '/@/shared/components/switch/switch';
 import { TextInput } from '/@/shared/components/text-input/text-input';
@@ -182,6 +183,48 @@ export const LyricsSettingsForm = ({ settingsKey }: LyricsSettingsFormProps) => 
             ),
             description: '',
             title: t('page.fullscreenPlayer.config.followCurrentLyric', {
+                postProcess: 'sentenceCase',
+            }),
+        },
+        {
+            control: (
+                <Slider
+                    defaultValue={displaySettings.opacityNonActive}
+                    label={(e) => (e * 100).toFixed(0) + '%'}
+                    max={1.0}
+                    min={0.0}
+                    onChangeEnd={(e) => {
+                        updateDisplaySetting({
+                            opacityNonActive: e,
+                        });
+                    }}
+                    step={0.01}
+                    w={100}
+                />
+            ),
+            description: '',
+            title: t(`${t('page.fullscreenPlayer.config.lyricOpacityNonActive')}`, {
+                postProcess: 'sentenceCase',
+            }),
+        },
+        {
+            control: (
+                <Slider
+                    defaultValue={displaySettings.scaleNonActive}
+                    label={(e) => (e * 100).toFixed(0) + '%'}
+                    max={1.0}
+                    min={0.5}
+                    onChangeEnd={(e) => {
+                        updateDisplaySetting({
+                            scaleNonActive: e,
+                        });
+                    }}
+                    step={0.01}
+                    w={100}
+                />
+            ),
+            description: '',
+            title: t(`${t('page.fullscreenPlayer.config.lyricScaleNonActive')}`, {
                 postProcess: 'sentenceCase',
             }),
         },

--- a/src/renderer/features/lyrics/lyric-line.module.css
+++ b/src/renderer/features/lyrics/lyric-line.module.css
@@ -4,21 +4,18 @@
     line-height: 1.2;
     color: var(--theme-colors-foreground);
     word-break: normal;
-    transition:
-        opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1),
-        transform 0.6s cubic-bezier(0.16, 1, 0.3, 1);
-
-    will-change: transform;
-
-    /* properties set by the lyrics container */
     opacity: var(--lyric-opacity);
     transform: scale(var(--lyric-scale));
     transform-origin: var(--lyric-scale-origin) center;
+    transition:
+        opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1),
+        transform 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+    will-change: transform;
 }
 
 .lyric-line:global(.active) {
     opacity: 1 !important;
-    transform: scale(1.0);
+    transform: scale(1);
 }
 
 .lyric-line:global(.unsynchronized) {

--- a/src/renderer/features/lyrics/lyric-line.module.css
+++ b/src/renderer/features/lyrics/lyric-line.module.css
@@ -4,14 +4,21 @@
     line-height: 1.2;
     color: var(--theme-colors-foreground);
     word-break: normal;
-    opacity: 0.35;
     transition:
-        opacity 0.3s ease-in-out,
-        transform 0.3s ease-in-out;
+        opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1),
+        transform 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+
+    will-change: transform;
+
+    /* properties set by the lyrics container */
+    opacity: var(--lyric-opacity);
+    transform: scale(var(--lyric-scale));
+    transform-origin: var(--lyric-scale-origin) center;
 }
 
 .lyric-line:global(.active) {
     opacity: 1 !important;
+    transform: scale(1.0);
 }
 
 .lyric-line:global(.unsynchronized) {

--- a/src/renderer/features/lyrics/synchronized-lyrics.tsx
+++ b/src/renderer/features/lyrics/synchronized-lyrics.tsx
@@ -49,6 +49,11 @@ export const SynchronizedLyrics = ({
                 ? displaySettings.fontSize
                 : 24,
         gap: displaySettings.gap && displaySettings.gap !== 0 ? displaySettings.gap : 24,
+        opacityNonActive: displaySettings.opacityNonActive,
+        scaleNonActive:
+            displaySettings.scaleNonActive && displaySettings.scaleNonActive !== 0
+                ? displaySettings.scaleNonActive
+                : 0.95,
     };
     const { mediaSeekToTimestamp } = usePlayerActions();
     const status = usePlayerStatus();
@@ -308,7 +313,18 @@ export const SynchronizedLyrics = ({
             onMouseEnter={showScrollbar}
             onMouseLeave={hideScrollbar}
             ref={containerRef}
-            style={{ gap: `${settings.gap}px`, ...style }}
+            style={
+                {
+                    // opacity/scale is set here for every lyric,
+                    // and then overwritten by CSS for active lyrics
+                    // to prevent expensive rerenders each lyric
+                    '--lyric-opacity': settings.opacityNonActive,
+                    '--lyric-scale': settings.scaleNonActive,
+                    '--lyric-scale-origin': settings.alignment,
+                    gap: `${settings.gap}px`,
+                    ...style,
+                } as React.CSSProperties
+            }
         >
             {settings.showProvider && source && (
                 <LyricLine

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -536,6 +536,8 @@ const LyricsDisplaySettingsSchema = z.object({
     fontSizeUnsync: z.number(),
     gap: z.number(),
     gapUnsync: z.number(),
+    opacityNonActive: z.number(),
+    scaleNonActive: z.number(),
 });
 
 const LyricsSettingsSchema = z.object({
@@ -1794,6 +1796,8 @@ const initialState: SettingsState = {
             fontSizeUnsync: 24,
             gap: 24,
             gapUnsync: 24,
+            opacityNonActive: 0.8,
+            scaleNonActive: 0.95,
         },
     },
     playback: {
@@ -2198,10 +2202,7 @@ export const useSettingsStore = createWithEqualityFn<SettingsSlice>()(
 
                         // Extract display settings
                         const displaySettings = {
-                            fontSize: defaultSettings.fontSize || 24,
-                            fontSizeUnsync: defaultSettings.fontSizeUnsync || 24,
-                            gap: defaultSettings.gap || 24,
-                            gapUnsync: defaultSettings.gapUnsync || 24,
+                            ...defaultSettings,
                         };
 
                         // Remove display properties from main settings

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -1796,7 +1796,7 @@ const initialState: SettingsState = {
             fontSizeUnsync: 24,
             gap: 24,
             gapUnsync: 24,
-            opacityNonActive: 0.8,
+            opacityNonActive: 0.2,
             scaleNonActive: 0.95,
         },
     },

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -2202,7 +2202,10 @@ export const useSettingsStore = createWithEqualityFn<SettingsSlice>()(
 
                         // Extract display settings
                         const displaySettings = {
-                            ...defaultSettings,
+                            fontSize: defaultSettings.fontSize || 24,
+                            fontSizeUnsync: defaultSettings.fontSizeUnsync || 24,
+                            gap: defaultSettings.gap || 24,
+                            gapUnsync: defaultSettings.gapUnsync || 24,
                         };
 
                         // Remove display properties from main settings
@@ -2212,7 +2215,10 @@ export const useSettingsStore = createWithEqualityFn<SettingsSlice>()(
 
                         state.lyrics = mainSettings;
                         state.lyricsDisplay = {
-                            default: displaySettings,
+                            default: {
+                                ...state.lyricsDisplay.default,
+                                ...displaySettings,
+                            },
                         };
                     }
                 }


### PR DESCRIPTION
this pr adds additional lyric controls which allow for further customisation of the display of lyrics:
- non-active lyric opacity
- non-active lyric scale

<img width="1920" height="1080" alt="New Project" src="https://github.com/user-attachments/assets/71a3db57-9a5b-461c-89ad-1c4b4933843b" />

i personally found the stock contrast between active and non-active lyrics too small, so adding these settings allows a user to customize it to their liking

the scale and opacity are implemented using CSS variables to avoid re-rendering when a lyric state changes