### PR TITLE
Stretch the wavesurfer waveform to the full height

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -983,6 +983,8 @@
         "playerbarWaveformBarWidth": "waveform bar width",
         "playerbarWaveformGap": "waveform gap",
         "playerbarWaveformRadius": "waveform radius",
+        "playerbarWaveformStretch": "waveform stretch",
+        "playerbarWaveformStretch_description": "stretches the waveform to fill the available space",
         "preferLocalLyrics_description": "prefer local lyrics over remote lyrics when available",
         "preferLocalLyrics": "prefer local lyrics",
         "showLyricsInSidebar_description": "a panel will be added to the attached play queue that displays the lyrics",

--- a/src/renderer/features/player/components/playerbar-waveform.tsx
+++ b/src/renderer/features/player/components/playerbar-waveform.tsx
@@ -58,7 +58,7 @@ export const PlayerbarWaveform = () => {
         height: 18,
         interact: false,
         media: audioElementRef.current,
-        normalize: true,
+        normalize: playerbarSlider?.stretched ?? false,
         progressColor: primaryColor,
         waveColor,
     });

--- a/src/renderer/features/player/components/playerbar-waveform.tsx
+++ b/src/renderer/features/player/components/playerbar-waveform.tsx
@@ -58,7 +58,7 @@ export const PlayerbarWaveform = () => {
         height: 18,
         interact: false,
         media: audioElementRef.current,
-        normalize: false,
+        normalize: true,
         progressColor: primaryColor,
         waveColor,
     });

--- a/src/renderer/features/settings/components/general/control-settings.tsx
+++ b/src/renderer/features/settings/components/general/control-settings.tsx
@@ -479,6 +479,32 @@ export const ControlSettings = memo(() => {
                   },
                   {
                       control: (
+                          <Switch
+                              defaultChecked={playerbarSlider?.stretched ?? false}
+                              onChange={(e) =>
+                                  setSettings({
+                                      general: {
+                                          ...settings,
+                                          playerbarSlider: {
+                                              ...playerbarSlider,
+                                              stretched: e.currentTarget.checked,
+                                          },
+                                      },
+                                  })
+                              }
+                          />
+                      ),
+                      description: t('setting.playerbarWaveformStretch', {
+                          context: 'description',
+                          postProcess: 'sentenceCase',
+                      }),
+                      isHidden: false,
+                      title: t('setting.playerbarWaveformStretch', {
+                          postProcess: 'sentenceCase',
+                      }),
+                  },
+                  {
+                      control: (
                           <NumberInput
                               defaultValue={playerbarSlider?.loadingDelay ?? 2}
                               max={30}

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -306,6 +306,7 @@ const PlayerbarSliderSchema = z.object({
     barRadius: z.number(),
     barWidth: z.number(),
     loadingDelay: z.number(),
+    stretched: z.boolean(),
     type: PlayerbarSliderTypeSchema,
 });
 
@@ -1150,6 +1151,7 @@ const initialState: SettingsState = {
             barRadius: 4,
             barWidth: 2,
             loadingDelay: 2,
+            stretched: false,
             type: PlayerbarSliderType.SLIDER,
         },
         playerItems,


### PR DESCRIPTION
Currently with ```normalize: false``` the Wavesurfer waveform 'accurately' displays the loudness of the raw file, but in cases where that mastering is low volume the end result is very flat and not that useful

Changing to ```normalize: true``` will [stretch the waveform](https://wavesurfer.xyz/docs/types/wavesurfer.WaveSurferOptions) between min and max height (purely visual, has no effect on audio) to better convey the dynamic range of the track.

Before
<img width="485" height="75" alt="firefox_w7ppQ72rnS" src="https://github.com/user-attachments/assets/515acb9f-96d6-4439-86ac-4bf95c7744ef" />

After
<img width="480" height="77" alt="firefox_xTpxmdBFnI" src="https://github.com/user-attachments/assets/7cf14cd0-0fe0-41ee-8070-539b5bb34c2c" />
