### PR TITLE
Replace success toast with info when no songs are added

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -347,6 +347,7 @@
             "input_skipDuplicates": "skip duplicates",
             "searchOrCreate": "search $t(entity.playlist, {\"count\": 2}) or type to create a new one",
             "success": "added $t(entity.trackWithCount, {\"count\": {{message}} }) to $t(entity.playlistWithCount, {\"count\": {{numOfPlaylists}} })",
+            "noneAdded": "no tracks were added to $t(entity.playlist, {\"count\": 1}) '{{playlist}}'",
             "title": "add to $t(entity.playlist, {\"count\": 1})"
         },
         "createPlaylist": {

--- a/src/renderer/features/context-menu/actions/add-to-playlist-action.tsx
+++ b/src/renderer/features/context-menu/actions/add-to-playlist-action.tsx
@@ -411,7 +411,7 @@ export const AddToPlaylistAction = ({ items, itemType }: AddToPlaylistActionProp
                     <>
                         <ContextMenu.Item
                             key={recentPlaylist.id}
-                            onSelect={() => 
+                            onSelect={() =>
                                 handleAddToPlaylist(recentPlaylist.id, recentPlaylist.name)
                             }
                         >
@@ -428,9 +428,7 @@ export const AddToPlaylistAction = ({ items, itemType }: AddToPlaylistActionProp
                 {filteredPlaylists.map((playlist) => (
                     <ContextMenu.Item
                         key={playlist.id}
-                        onSelect={() => 
-                            handleAddToPlaylist(playlist.id, playlist.name)
-                        }
+                        onSelect={() => handleAddToPlaylist(playlist.id, playlist.name)}
                     >
                         {playlist.name}
                     </ContextMenu.Item>

--- a/src/renderer/features/context-menu/actions/add-to-playlist-action.tsx
+++ b/src/renderer/features/context-menu/actions/add-to-playlist-action.tsx
@@ -165,7 +165,7 @@ export const AddToPlaylistAction = ({ items, itemType }: AddToPlaylistActionProp
     );
 
     const handleAddToPlaylist = useCallback(
-        async (playlistId: string) => {
+        async (playlistId: string, playlistName: string) => {
             if (items.length === 0 || !serverId) return;
 
             try {
@@ -204,7 +204,7 @@ export const AddToPlaylistAction = ({ items, itemType }: AddToPlaylistActionProp
                 if (allSongIds.length === 0) {
                     toast.info({
                         message: t("form.addToPlaylist.noneAdded", {
-                            playlist: playlist.name,
+                            playlist: playlistName
                             postProcess: "sentenceCase",
                         }),
                     });
@@ -246,7 +246,7 @@ export const AddToPlaylistAction = ({ items, itemType }: AddToPlaylistActionProp
                 if (songsToAdd.length === 0) {
                     toast.info({
                         message: t("form.addToPlaylist.noneAdded", {
-                            playlist: playlist.name,
+                            playlist: playlistName
                             postProcess: "sentenceCase",
                         }),
                     });
@@ -411,7 +411,7 @@ export const AddToPlaylistAction = ({ items, itemType }: AddToPlaylistActionProp
                     <>
                         <ContextMenu.Item
                             key={recentPlaylist.id}
-                            onSelect={() => handleAddToPlaylist(recentPlaylist.id)}
+                            onSelect={() => handleAddToPlaylist(recentPlaylist.id, recentPlaylist.name)}
                         >
                             {recentPlaylist.name}
                         </ContextMenu.Item>
@@ -426,7 +426,7 @@ export const AddToPlaylistAction = ({ items, itemType }: AddToPlaylistActionProp
                 {filteredPlaylists.map((playlist) => (
                     <ContextMenu.Item
                         key={playlist.id}
-                        onSelect={() => handleAddToPlaylist(playlist.id)}
+                        onSelect={() => handleAddToPlaylist(playlist.id, playlist.name)}
                     >
                         {playlist.name}
                     </ContextMenu.Item>

--- a/src/renderer/features/context-menu/actions/add-to-playlist-action.tsx
+++ b/src/renderer/features/context-menu/actions/add-to-playlist-action.tsx
@@ -203,9 +203,9 @@ export const AddToPlaylistAction = ({ items, itemType }: AddToPlaylistActionProp
 
                 if (allSongIds.length === 0) {
                     toast.info({
-                        message: t("form.addToPlaylist.noneAdded", {
+                        message: t('form.addToPlaylist.noneAdded', {
                             playlist: playlistName,
-                            postProcess: "sentenceCase",
+                            postProcess: 'sentenceCase',
                         }),
                     });
                     return;
@@ -245,9 +245,9 @@ export const AddToPlaylistAction = ({ items, itemType }: AddToPlaylistActionProp
 
                 if (songsToAdd.length === 0) {
                     toast.info({
-                        message: t("form.addToPlaylist.noneAdded", {
+                        message: t('form.addToPlaylist.noneAdded', {
                             playlist: playlistName,
-                            postProcess: "sentenceCase",
+                            postProcess: 'sentenceCase',
                         }),
                     });
                     return;
@@ -411,7 +411,12 @@ export const AddToPlaylistAction = ({ items, itemType }: AddToPlaylistActionProp
                     <>
                         <ContextMenu.Item
                             key={recentPlaylist.id}
-                            onSelect={() => handleAddToPlaylist(recentPlaylist.id, recentPlaylist.name)}
+                            onSelect={() => 
+                                handleAddToPlaylist(
+                                    recentPlaylist.id,
+                                    recentPlaylist.name
+                                )
+                            }
                         >
                             {recentPlaylist.name}
                         </ContextMenu.Item>
@@ -426,7 +431,12 @@ export const AddToPlaylistAction = ({ items, itemType }: AddToPlaylistActionProp
                 {filteredPlaylists.map((playlist) => (
                     <ContextMenu.Item
                         key={playlist.id}
-                        onSelect={() => handleAddToPlaylist(playlist.id, playlist.name)}
+                        onSelect={() => 
+                            handleAddToPlaylist(
+                                playlist.id,
+                                playlist.name
+                            )
+                        }
                     >
                         {playlist.name}
                     </ContextMenu.Item>

--- a/src/renderer/features/context-menu/actions/add-to-playlist-action.tsx
+++ b/src/renderer/features/context-menu/actions/add-to-playlist-action.tsx
@@ -412,10 +412,7 @@ export const AddToPlaylistAction = ({ items, itemType }: AddToPlaylistActionProp
                         <ContextMenu.Item
                             key={recentPlaylist.id}
                             onSelect={() => 
-                                handleAddToPlaylist(
-                                    recentPlaylist.id,
-                                    recentPlaylist.name
-                                )
+                                handleAddToPlaylist(recentPlaylist.id, recentPlaylist.name)
                             }
                         >
                             {recentPlaylist.name}
@@ -432,10 +429,7 @@ export const AddToPlaylistAction = ({ items, itemType }: AddToPlaylistActionProp
                     <ContextMenu.Item
                         key={playlist.id}
                         onSelect={() => 
-                            handleAddToPlaylist(
-                                playlist.id,
-                                playlist.name
-                            )
+                            handleAddToPlaylist(playlist.id, playlist.name)
                         }
                     >
                         {playlist.name}

--- a/src/renderer/features/context-menu/actions/add-to-playlist-action.tsx
+++ b/src/renderer/features/context-menu/actions/add-to-playlist-action.tsx
@@ -202,11 +202,10 @@ export const AddToPlaylistAction = ({ items, itemType }: AddToPlaylistActionProp
                 }
 
                 if (allSongIds.length === 0) {
-                    toast.success({
-                        message: t('form.addToPlaylist.success', {
-                            message: 0,
-                            numOfPlaylists: 1,
-                            postProcess: 'sentenceCase',
+                    toast.info({
+                        message: t("form.addToPlaylist.noneAdded", {
+                            playlist: playlist.name,
+                            postProcess: "sentenceCase",
                         }),
                     });
                     return;
@@ -245,11 +244,10 @@ export const AddToPlaylistAction = ({ items, itemType }: AddToPlaylistActionProp
                 }
 
                 if (songsToAdd.length === 0) {
-                    toast.success({
-                        message: t('form.addToPlaylist.success', {
-                            message: 0,
-                            numOfPlaylists: 1,
-                            postProcess: 'sentenceCase',
+                    toast.info({
+                        message: t("form.addToPlaylist.noneAdded", {
+                            playlist: playlist.name,
+                            postProcess: "sentenceCase",
                         }),
                     });
                     return;

--- a/src/renderer/features/context-menu/actions/add-to-playlist-action.tsx
+++ b/src/renderer/features/context-menu/actions/add-to-playlist-action.tsx
@@ -204,7 +204,7 @@ export const AddToPlaylistAction = ({ items, itemType }: AddToPlaylistActionProp
                 if (allSongIds.length === 0) {
                     toast.info({
                         message: t("form.addToPlaylist.noneAdded", {
-                            playlist: playlistName
+                            playlist: playlistName,
                             postProcess: "sentenceCase",
                         }),
                     });
@@ -246,7 +246,7 @@ export const AddToPlaylistAction = ({ items, itemType }: AddToPlaylistActionProp
                 if (songsToAdd.length === 0) {
                     toast.info({
                         message: t("form.addToPlaylist.noneAdded", {
-                            playlist: playlistName
+                            playlist: playlistName,
                             postProcess: "sentenceCase",
                         }),
                     });


### PR DESCRIPTION
Previously showed success toast  with "added 0 songs to 1 playlist" message even thought it was not added to a playlist.

<img width="310" height="82" alt="image" src="https://github.com/user-attachments/assets/3b88ef3a-168f-4781-987b-054a9d828b10" />

Now shows info toast that nothing was added to a playlist.

<img width="303" height="89" alt="image" src="https://github.com/user-attachments/assets/c47a9186-12ea-452e-89cf-ea1a07e033e7" />
