### PR TITLE
fix: only show Jellyfin audio playlist

### DIFF
--- a/src/renderer/api/jellyfin/jellyfin-controller.ts
+++ b/src/renderer/api/jellyfin/jellyfin-controller.ts
@@ -928,6 +928,7 @@ export const JellyfinController: InternalControllerEndpoint = {
                 Fields: JF_FIELDS.PLAYLIST_LIST,
                 IncludeItemTypes: 'Playlist',
                 Limit: query.limit,
+                MediaTypes: 'Audio',
                 Recursive: true,
                 SearchTerm: query.searchTerm,
                 SortBy: playlistListSortMap.jellyfin[query.sortBy],


### PR DESCRIPTION
Hello there,

first of all I want to thank you for this superb music client. I noticed that Feishin displays not only playlists of the media type "Audio" but also of all other media types. In my case, Feishin not only displays playlist of songs but also playlists of videos which cannot be consumed by Feishin anyhow. This is only an issue for Jellyfin server because Navidrome and OpenSubsonic only support audio.

This PR adds a filtering parameter to the getter of playlists which filters by the media type "Audio". This way, only music playlists are returned and displayed by Feishin.

Let me know if this PR fits within the project. I am open to modifications of the PR.

Many Greetings
Maxi