### PR TITLE
also use external image url for discord-rpc with navidrome

### DIFF
--- a/src/renderer/features/discord-rpc/use-discord-rpc.ts
+++ b/src/renderer/features/discord-rpc/use-discord-rpc.ts
@@ -276,12 +276,12 @@ export const useDiscordRpc = () => {
 
                 if (discordSettings.showServerImage && song) {
                     if (song._uniqueId === currentSong?._uniqueId && imageUrlRef.current) {
-                        if (song._serverType === ServerType.JELLYFIN) {
-                            activity.largeImageKey = imageUrlRef.current;
-                        } else if (
-                            song._serverType === ServerType.NAVIDROME ||
-                            song._serverType === ServerType.SUBSONIC
+                        if (
+                            song._serverType === ServerType.JELLYFIN ||
+                            song._serverType === ServerType.NAVIDROME
                         ) {
+                            activity.largeImageKey = imageUrlRef.current;
+                        } else if (song._serverType === ServerType.SUBSONIC) {
                             try {
                                 const info = await api.controller.getAlbumInfo({
                                     apiClientProps: { serverId: song._serverId },


### PR DESCRIPTION
This just simply allows `ServerType.NAVIDROME` to also use `imageUrlRef.current` when available.

This seems to just work as it is. I tried to find the reason why this was separated in 72d0fca28b32a7c56fd98879032c2e8e10f48218, but I couldn't find an answer for it. So was there a reason behind the separation, or maybe just missing testing for the individual `ServerType`'s? 

Thanks in advance :)