### PR TITLE
Always use remote url for discord rpc image

### DIFF
--- a/src/renderer/api/jellyfin/jellyfin-api.ts
+++ b/src/renderer/api/jellyfin/jellyfin-api.ts
@@ -404,11 +404,12 @@ export const createAuthHeader = (): string => {
 };
 
 export const jfApiClient = (args: {
+    forceRemoteUrl?: boolean;
     server: null | ServerListItemWithCredential;
     signal?: AbortSignal;
     url?: string;
 }) => {
-    const { server, signal, url } = args;
+    const { forceRemoteUrl, server, signal, url } = args;
 
     return initClient(contract, {
         api: async ({ body, headers, method, path }) => {
@@ -418,7 +419,7 @@ export const jfApiClient = (args: {
             const { params, path: api } = parsePath(path);
 
             if (server) {
-                const serverUrl = getServerUrl(server);
+                const serverUrl = getServerUrl(server, forceRemoteUrl);
                 baseUrl = serverUrl;
                 token = server?.credential;
             } else {

--- a/src/renderer/api/navidrome/navidrome-api.ts
+++ b/src/renderer/api/navidrome/navidrome-api.ts
@@ -479,11 +479,12 @@ axiosClient.interceptors.response.use(
 );
 
 export const ndApiClient = (args: {
+    forceRemoteUrl?: boolean;
     server: null | ServerListItemWithCredential;
     signal?: AbortSignal;
     url?: string;
 }) => {
-    const { server, signal, url } = args;
+    const { forceRemoteUrl, server, signal, url } = args;
 
     return initClient(contract, {
         api: async ({ body, headers, method, path }) => {
@@ -493,7 +494,7 @@ export const ndApiClient = (args: {
             const { params, path: api } = parsePath(path);
 
             if (server) {
-                const serverUrl = getServerUrl(server);
+                const serverUrl = getServerUrl(server, forceRemoteUrl);
                 baseUrl = serverUrl ? `${serverUrl}/api` : undefined;
                 token = server?.ndCredential;
             } else {

--- a/src/renderer/api/subsonic/subsonic-api.ts
+++ b/src/renderer/api/subsonic/subsonic-api.ts
@@ -428,12 +428,13 @@ const silentlyTransformResponse = (data: any) => {
 };
 
 export const ssApiClient = (args: {
+    forceRemoteUrl?: boolean;
     server: null | ServerListItemWithCredential;
     signal?: AbortSignal;
     silent?: boolean;
     url?: string;
 }) => {
-    const { server, signal, silent, url } = args;
+    const { forceRemoteUrl, server, signal, silent, url } = args;
 
     return initClient(contract, {
         api: async ({ body, headers, method, path, rawQuery }) => {
@@ -443,7 +444,7 @@ export const ssApiClient = (args: {
             const { params, path: api } = parsePath(path);
 
             if (server) {
-                const serverUrl = getServerUrl(server);
+                const serverUrl = getServerUrl(server, forceRemoteUrl);
                 baseUrl = serverUrl ? `${serverUrl}/rest` : undefined;
                 const token = server.credential;
                 const params = token.split(/&?\w=/gm);

--- a/src/renderer/features/discord-rpc/use-discord-rpc.ts
+++ b/src/renderer/features/discord-rpc/use-discord-rpc.ts
@@ -284,7 +284,10 @@ export const useDiscordRpc = () => {
                         ) {
                             try {
                                 const info = await api.controller.getAlbumInfo({
-                                    apiClientProps: { serverId: song._serverId },
+                                    apiClientProps: {
+                                        forceRemoteUrl: true,
+                                        serverId: song._serverId,
+                                    },
                                     query: { id: song.albumId },
                                 });
 

--- a/src/shared/types/domain-types.ts
+++ b/src/shared/types/domain-types.ts
@@ -421,6 +421,7 @@ type ApiContext = {
 
 type BaseEndpointArgs = {
     apiClientProps: {
+        forceRemoteUrl?: boolean;
         server?: null | ServerListItemWithCredential;
         serverId: string;
         signal?: AbortSignal;


### PR DESCRIPTION
This PR fixes the broken image in the discord activity when using a local and public url with navidrome/subsonic.

- forwards the option that forces the usage of the remote url for api calls
- uses the forwarded option to acquire the album image url from the publicly available server