### PR TITLE
feat: add 10-band graphic equalizer

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -209,6 +209,31 @@
         "trackWithCount_one": "{{count}} track",
         "trackWithCount_other": "{{count}} tracks"
     },
+    "equalizer": {
+        "bandLabelHz": "{{frequency}} Hz",
+        "bandLabelKHz": "{{frequency}} kHz",
+        "custom": "Custom",
+        "deletePresetLabel": "Delete preset",
+        "enabled": "Enabled",
+        "menuLabel": "Equalizer",
+        "openLabel": "Open…",
+        "preamp": "Pre-amp",
+        "preset": {
+            "bassBoost": "Bass Boost",
+            "classical": "Classical",
+            "flat": "Flat",
+            "jazz": "Jazz",
+            "pop": "Pop",
+            "rock": "Rock",
+            "vocal": "Vocal"
+        },
+        "presetLabel": "Preset",
+        "reset": "Reset",
+        "saveAs": "Save as preset…",
+        "saveDialogName": "Name",
+        "saveDialogTitle": "Save preset",
+        "title": "Equalizer"
+    },
     "error": {
         "apiRouteError": "Unable to route request",
         "audioDeviceFetchError": "An error occurred when trying to get audio devices",

--- a/src/renderer/features/player/components/audio-players.tsx
+++ b/src/renderer/features/player/components/audio-players.tsx
@@ -8,6 +8,7 @@ import { MainPlayerListenerHook } from '/@/renderer/features/player/audio-player
 import { MpvPlayer } from '/@/renderer/features/player/audio-player/mpv-player';
 import { WebPlayer } from '/@/renderer/features/player/audio-player/web-player';
 import { SleepTimerHook } from '/@/renderer/features/player/components/sleep-timer-button';
+import { EqualizerHook } from '/@/renderer/features/player/equalizer';
 import { AutoDJHook } from '/@/renderer/features/player/hooks/use-auto-dj';
 import { AutosaveHook } from '/@/renderer/features/player/hooks/use-autosave';
 import { MediaSessionHook } from '/@/renderer/features/player/hooks/use-media-session';
@@ -138,6 +139,7 @@ export const AudioPlayers = () => {
             <RadioAudioInstanceHook />
             <RadioMetadataHook />
             <VisualizerSystemAudioBridgeHook />
+            <EqualizerHook />
             <AutosaveHook />
             <AudioPlayersContent
                 audioContext={audioContext}

--- a/src/renderer/features/player/components/player-config.tsx
+++ b/src/renderer/features/player/components/player-config.tsx
@@ -2,6 +2,7 @@ import isElectron from 'is-electron';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { EqualizerEntry } from '/@/renderer/features/player/equalizer';
 import { useAudioDevices } from '/@/renderer/features/settings/components/playback/audio-settings';
 import { ListConfigTable } from '/@/renderer/features/shared/components/list-config-menu';
 import {
@@ -81,6 +82,11 @@ export const PlayerConfig = () => {
                 component: <CrossfadeDurationConfig />,
                 id: 'crossfadeDuration',
                 label: t('setting.crossfadeDuration'),
+            },
+            {
+                component: <EqualizerEntry />,
+                id: 'equalizer',
+                label: t('equalizer.menuLabel'),
             },
             {
                 component: null,

--- a/src/renderer/features/player/equalizer/BandSlider.tsx
+++ b/src/renderer/features/player/equalizer/BandSlider.tsx
@@ -1,0 +1,34 @@
+import styles from './equalizer-modal.module.css';
+import { EQ_GAIN_MAX, EQ_GAIN_MIN } from './equalizer.types';
+
+import { Slider } from '/@/shared/components/slider/slider';
+
+interface Props {
+    label: string;
+    onChange: (db: number) => void;
+    valueDb: number;
+}
+
+const formatDb = (db: number): string => {
+    const rounded = Math.round(db * 10) / 10;
+    if (rounded === 0) return '0.0';
+    const sign = rounded > 0 ? '+' : '';
+    return `${sign}${rounded.toFixed(1)}`;
+};
+
+export const BandSlider = ({ label, onChange, valueDb }: Props) => (
+    <div className={styles.band}>
+        <div className={styles.bandLabel}>{label}</div>
+        <Slider
+            classNames={{ root: styles.verticalSlider, track: styles.verticalTrack }}
+            label={null}
+            max={EQ_GAIN_MAX}
+            min={EQ_GAIN_MIN}
+            onChange={onChange}
+            orientation="vertical"
+            step={0.5}
+            value={valueDb}
+        />
+        <div className={styles.bandReadout}>{formatDb(valueDb)}</div>
+    </div>
+);

--- a/src/renderer/features/player/equalizer/EqualizerEntry.tsx
+++ b/src/renderer/features/player/equalizer/EqualizerEntry.tsx
@@ -1,0 +1,15 @@
+import { useTranslation } from 'react-i18next';
+
+import { useEqualizerModalStore } from './equalizer-modal.store';
+
+import { Button } from '/@/shared/components/button/button';
+
+export const EqualizerEntry = () => {
+    const { t } = useTranslation();
+    const open = useEqualizerModalStore((s) => s.open);
+    return (
+        <Button onClick={open} variant="subtle">
+            {t('equalizer.openLabel')}
+        </Button>
+    );
+};

--- a/src/renderer/features/player/equalizer/EqualizerHook.tsx
+++ b/src/renderer/features/player/equalizer/EqualizerHook.tsx
@@ -1,0 +1,16 @@
+import { useEqualizerModalStore } from './equalizer-modal.store';
+import { EqualizerModal } from './EqualizerModal';
+import { MpvEqualizerHook } from './MpvEqualizerHook';
+import { WebEqualizerHook } from './WebEqualizerHook';
+
+export const EqualizerHook = () => {
+    const isOpen = useEqualizerModalStore((s) => s.isOpen);
+    const close = useEqualizerModalStore((s) => s.close);
+    return (
+        <>
+            <MpvEqualizerHook />
+            <WebEqualizerHook />
+            <EqualizerModal isOpen={isOpen} onClose={close} />
+        </>
+    );
+};

--- a/src/renderer/features/player/equalizer/EqualizerModal.tsx
+++ b/src/renderer/features/player/equalizer/EqualizerModal.tsx
@@ -1,0 +1,73 @@
+import type { TFunction } from 'i18next';
+
+import { Modal } from '@mantine/core';
+import { useTranslation } from 'react-i18next';
+
+import { BandSlider } from './BandSlider';
+import styles from './equalizer-modal.module.css';
+import { useEqualizerActions, useEqualizerState } from './equalizer.actions';
+import { EQ_FREQUENCIES } from './equalizer.types';
+import { PresetMenu } from './PresetMenu';
+
+import { Button } from '/@/shared/components/button/button';
+import { Switch } from '/@/shared/components/switch/switch';
+
+interface Props {
+    isOpen: boolean;
+    onClose: () => void;
+}
+
+const formatBandLabel = (hz: number, t: TFunction): string =>
+    hz >= 1000
+        ? t('equalizer.bandLabelKHz', { frequency: hz / 1000 })
+        : t('equalizer.bandLabelHz', { frequency: hz });
+
+export const EqualizerModal = ({ isOpen, onClose }: Props) => {
+    const { t } = useTranslation();
+    const state = useEqualizerState();
+    const actions = useEqualizerActions();
+
+    return (
+        <Modal onClose={onClose} opened={isOpen} size="xl" title={t('equalizer.title')}>
+            <div className={styles.header}>
+                <PresetMenu
+                    activeId={state.activePresetId}
+                    customPresets={state.customPresets}
+                    onDelete={actions.deleteCustomPreset}
+                    onSave={actions.saveCustomPreset}
+                    onSelect={actions.applyPreset}
+                    t={t}
+                />
+                <Switch
+                    aria-label={t('equalizer.enabled')}
+                    checked={state.enabled}
+                    label={t('equalizer.enabled')}
+                    onChange={(e: any) => actions.setEnabled(e.currentTarget.checked)}
+                />
+            </div>
+
+            <div className={styles.bands}>
+                <BandSlider
+                    label={t('equalizer.preamp')}
+                    onChange={actions.setPreamp}
+                    valueDb={state.preamp}
+                />
+                <div aria-hidden="true" className={styles.divider} />
+                {EQ_FREQUENCIES.map((freq, i) => (
+                    <BandSlider
+                        key={freq}
+                        label={formatBandLabel(freq, t)}
+                        onChange={(db) => actions.setBand(i, db)}
+                        valueDb={state.bands[i]}
+                    />
+                ))}
+            </div>
+
+            <div className={styles.footer}>
+                <Button onClick={actions.reset} variant="default">
+                    {t('equalizer.reset')}
+                </Button>
+            </div>
+        </Modal>
+    );
+};

--- a/src/renderer/features/player/equalizer/MpvEqualizerHook.tsx
+++ b/src/renderer/features/player/equalizer/MpvEqualizerHook.tsx
@@ -1,0 +1,46 @@
+import isElectron from 'is-electron';
+import { useEffect, useMemo } from 'react';
+
+import { DEFAULT_EQUALIZER_STATE } from './equalizer.schema';
+import { EqualizerState } from './equalizer.types';
+import { createMpvEqDispatcher } from './mpv-eq-dispatcher';
+
+import { usePlaybackType } from '/@/renderer/store';
+import { useSettingsStore } from '/@/renderer/store/settings.store';
+import { PlayerType } from '/@/shared/types/types';
+
+const mpvPlayer = isElectron() ? (window as any).api?.mpvPlayer : null;
+
+const selector = (s: any): EqualizerState => s.playback?.equalizer ?? DEFAULT_EQUALIZER_STATE;
+
+export const MpvEqualizerHook = (): null => {
+    const playbackType = usePlaybackType();
+
+    const dispatcher = useMemo(
+        () =>
+            mpvPlayer?.setProperties
+                ? createMpvEqDispatcher({
+                      setProperties: (p) => mpvPlayer.setProperties(p),
+                  })
+                : null,
+        [],
+    );
+
+    useEffect(() => {
+        if (!dispatcher) return;
+        // initial dispatch on mount
+        dispatcher.dispatch(
+            selector(useSettingsStore.getState()),
+            playbackType === PlayerType.LOCAL,
+        );
+        const unsub = useSettingsStore.subscribe((curr, prev) => {
+            const eq = selector(curr);
+            const prevEq = selector(prev);
+            if (eq === prevEq) return; // shallow inequality is enough — actions always produce new ref
+            dispatcher.dispatch(eq, playbackType === PlayerType.LOCAL);
+        });
+        return unsub;
+    }, [dispatcher, playbackType]);
+
+    return null;
+};

--- a/src/renderer/features/player/equalizer/PresetMenu.tsx
+++ b/src/renderer/features/player/equalizer/PresetMenu.tsx
@@ -1,0 +1,87 @@
+import type { TFunction } from 'i18next';
+
+import { useState } from 'react';
+
+import styles from './equalizer-modal.module.css';
+import { EqualizerPreset } from './equalizer.types';
+import { BUILTIN_PRESETS } from './presets';
+
+import { Button } from '/@/shared/components/button/button';
+import { Select } from '/@/shared/components/select/select';
+import { TextInput } from '/@/shared/components/text-input/text-input';
+
+interface Props {
+    activeId: null | string;
+    customPresets: EqualizerPreset[];
+    onDelete: (id: string) => void;
+    onSave: (name: string) => void;
+    onSelect: (id: string) => void;
+    t: TFunction;
+}
+
+export const PresetMenu = ({ activeId, customPresets, onDelete, onSave, onSelect, t }: Props) => {
+    const [savingOpen, setSavingOpen] = useState(false);
+    const [name, setName] = useState('');
+
+    const data = [
+        ...BUILTIN_PRESETS.map((p) => ({ label: t(p.name), value: p.id })),
+        ...customPresets.map((p) => ({ label: p.name, value: p.id })),
+    ];
+    const selectValue = activeId ?? 'custom-marker';
+    const customRow = activeId
+        ? []
+        : [{ disabled: true, label: t('equalizer.custom'), value: 'custom-marker' }];
+
+    return (
+        <div>
+            <Select
+                aria-label={t('equalizer.preset')}
+                data={[...customRow, ...data]}
+                onChange={(v) => {
+                    if (v && v !== 'custom-marker') onSelect(v);
+                }}
+                value={selectValue}
+            />
+            {!savingOpen && (
+                <Button onClick={() => setSavingOpen(true)} variant="default">
+                    {t('equalizer.saveAs')}
+                </Button>
+            )}
+            {savingOpen && (
+                <>
+                    <TextInput
+                        aria-label={t('equalizer.saveDialogName')}
+                        onChange={(e: any) => setName(typeof e === 'string' ? e : e.target.value)}
+                        value={name}
+                    />
+                    <Button
+                        disabled={!name.trim()}
+                        onClick={() => {
+                            onSave(name.trim());
+                            setName('');
+                            setSavingOpen(false);
+                        }}
+                    >
+                        {t('equalizer.saveDialogTitle')}
+                    </Button>
+                </>
+            )}
+            {customPresets.length > 0 && (
+                <ul className={styles.customPresetList}>
+                    {customPresets.map((p) => (
+                        <li className={styles.customPresetRow} key={p.id}>
+                            <span className={styles.customPresetName}>{p.name}</span>
+                            <Button
+                                aria-label={`${t('equalizer.deletePresetLabel')}-${p.name}`}
+                                onClick={() => onDelete(p.id)}
+                                variant="subtle"
+                            >
+                                ×
+                            </Button>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+};

--- a/src/renderer/features/player/equalizer/WebEqualizerHook.tsx
+++ b/src/renderer/features/player/equalizer/WebEqualizerHook.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useRef } from 'react';
+
+import { DEFAULT_EQUALIZER_STATE } from './equalizer.schema';
+import { EqualizerState } from './equalizer.types';
+import { applyEqState, buildEqGraph, EqGraph, teardownEqGraph } from './web-eq-graph';
+
+import { useWebAudio } from '/@/renderer/features/player/hooks/use-webaudio';
+import { useSettingsStore } from '/@/renderer/store/settings.store';
+
+const selector = (s: any): EqualizerState => s.playback?.equalizer ?? DEFAULT_EQUALIZER_STATE;
+
+export const WebEqualizerHook = (): null => {
+    const { setWebAudio, webAudio } = useWebAudio();
+    const graphRef = useRef<EqGraph | null>(null);
+
+    // Depend on the STABLE inputs only — context + gains identity.
+    // The webAudio object identity changes when the visualizer-system-audio
+    // hook adds `visualizerInputs`, which must not retrigger graph rebuilds.
+    const context = webAudio?.context;
+    const gains = webAudio?.gains;
+
+    useEffect(() => {
+        if (!context || !gains?.length) return;
+        const graph = buildEqGraph(context, gains);
+        graphRef.current = graph;
+        applyEqState(graph, selector(useSettingsStore.getState()));
+
+        // Expose post-EQ tap nodes to the visualizer so its analyser reads the
+        // signal the user actually hears, not the raw source.
+        if (setWebAudio && webAudio) {
+            setWebAudio({ ...webAudio, visualizerInputs: graph.visualizerTaps });
+        }
+
+        const unsub = useSettingsStore.subscribe((curr, prev) => {
+            if (selector(curr) === selector(prev)) return;
+            if (graphRef.current) applyEqState(graphRef.current, selector(curr));
+        });
+
+        return () => {
+            unsub();
+            if (graphRef.current) {
+                teardownEqGraph(graphRef.current);
+                graphRef.current = null;
+            }
+            if (setWebAudio && webAudio) {
+                setWebAudio({ ...webAudio, visualizerInputs: undefined });
+            }
+        };
+        // setWebAudio + webAudio intentionally excluded — they're only read at
+        // setup/teardown and including them would loop on the very setWebAudio
+        // calls this effect makes.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [context, gains]);
+
+    return null;
+};

--- a/src/renderer/features/player/equalizer/equalizer-modal.module.css
+++ b/src/renderer/features/player/equalizer/equalizer-modal.module.css
@@ -1,0 +1,81 @@
+.bands {
+    display: grid;
+    grid-template-columns: 0.9fr 12px repeat(10, 1fr);
+    gap: 8px;
+    align-items: stretch;
+    padding: 16px 0 4px;
+}
+.band {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+}
+.bandLabel {
+    font-size: 11px;
+    line-height: 1.2;
+    text-align: center;
+    opacity: 0.8;
+    white-space: nowrap;
+}
+.bandReadout {
+    font-variant-numeric: tabular-nums;
+    font-size: 11px;
+    min-width: 32px;
+    text-align: center;
+    opacity: 0.85;
+}
+.verticalSlider {
+    height: 220px;
+}
+.verticalTrack {
+    width: 4px;
+    height: 100%;
+}
+.divider {
+    width: 1px;
+    background: rgba(255, 255, 255, 0.12);
+    align-self: stretch;
+    margin: 8px 4px;
+}
+.header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 8px;
+    flex-wrap: wrap;
+}
+.footer {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+    padding-top: 8px;
+}
+.customPresetList {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin: 8px 0 0;
+    padding: 0;
+    list-style: none;
+}
+.customPresetRow {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 4px 8px;
+    border-radius: 4px;
+}
+.customPresetRow:hover {
+    background: rgba(255, 255, 255, 0.05);
+}
+.customPresetName {
+    flex: 1;
+    font-size: 13px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}

--- a/src/renderer/features/player/equalizer/equalizer-modal.store.ts
+++ b/src/renderer/features/player/equalizer/equalizer-modal.store.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface EqualizerModalStore {
+    close: () => void;
+    isOpen: boolean;
+    open: () => void;
+}
+
+export const useEqualizerModalStore = create<EqualizerModalStore>((set) => ({
+    close: () => set({ isOpen: false }),
+    isOpen: false,
+    open: () => set({ isOpen: true }),
+}));

--- a/src/renderer/features/player/equalizer/equalizer.actions.ts
+++ b/src/renderer/features/player/equalizer/equalizer.actions.ts
@@ -1,0 +1,41 @@
+import { shallow } from 'zustand/shallow';
+
+import { DEFAULT_EQUALIZER_STATE } from './equalizer.schema';
+import * as T from './equalizer.transitions';
+import { EqualizerState } from './equalizer.types';
+
+import { useSettingsStore, useSettingsStoreActions } from '/@/renderer/store/settings.store';
+
+export interface ActionDeps {
+    getEq: () => EqualizerState;
+    setSettings: (partial: { playback: { equalizer: EqualizerState } }) => void;
+}
+
+export const applyAction = (
+    deps: ActionDeps,
+    transition: (s: EqualizerState) => EqualizerState,
+): void => {
+    const next = transition(deps.getEq());
+    deps.setSettings({ playback: { equalizer: next } });
+};
+
+const eqSelector = (s: any): EqualizerState => s.playback?.equalizer ?? DEFAULT_EQUALIZER_STATE;
+
+export const useEqualizerState = (): EqualizerState => useSettingsStore(eqSelector, shallow);
+
+export const useEqualizerActions = () => {
+    const { setSettings } = useSettingsStoreActions();
+    const deps: ActionDeps = {
+        getEq: () => eqSelector(useSettingsStore.getState() as any),
+        setSettings: (partial) => setSettings(partial as any),
+    };
+    return {
+        applyPreset: (id: string) => applyAction(deps, (s) => T.applyPreset(s, id)),
+        deleteCustomPreset: (id: string) => applyAction(deps, (s) => T.deleteCustomPreset(s, id)),
+        reset: () => applyAction(deps, T.reset),
+        saveCustomPreset: (name: string) => applyAction(deps, (s) => T.saveCustomPreset(s, name)),
+        setBand: (i: number, db: number) => applyAction(deps, (s) => T.setBand(s, i, db)),
+        setEnabled: (v: boolean) => applyAction(deps, (s) => T.setEnabled(s, v)),
+        setPreamp: (db: number) => applyAction(deps, (s) => T.setPreamp(s, db)),
+    };
+};

--- a/src/renderer/features/player/equalizer/equalizer.schema.ts
+++ b/src/renderer/features/player/equalizer/equalizer.schema.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+
+import {
+    EQ_BAND_COUNT,
+    EQ_GAIN_MAX,
+    EQ_GAIN_MIN,
+    EQ_PREAMP_MAX,
+    EQ_PREAMP_MIN,
+    EqualizerState,
+} from './equalizer.types';
+import { FLAT_PRESET_ID } from './presets';
+
+const clamp = (v: number, lo: number, hi: number): number => Math.min(hi, Math.max(lo, v));
+
+const clampedBand = z.number().transform((v) => clamp(v, EQ_GAIN_MIN, EQ_GAIN_MAX));
+const clampedPreamp = z.number().transform((v) => clamp(v, EQ_PREAMP_MIN, EQ_PREAMP_MAX));
+
+const PresetSchema = z.object({
+    bands: z.array(clampedBand).length(EQ_BAND_COUNT),
+    builtin: z.boolean(),
+    id: z.string(),
+    name: z.string(),
+    preamp: clampedPreamp,
+});
+
+export const DEFAULT_EQUALIZER_STATE: EqualizerState = {
+    activePresetId: FLAT_PRESET_ID,
+    bands: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    customPresets: [],
+    enabled: false,
+    preamp: 0,
+};
+
+const RawEqualizerSchema = z.object({
+    activePresetId: z.string().nullable(),
+    bands: z.array(clampedBand).length(EQ_BAND_COUNT),
+    customPresets: z.array(PresetSchema),
+    enabled: z.boolean(),
+    preamp: clampedPreamp,
+});
+
+export const EqualizerSettingsSchema = z.unknown().transform((input): EqualizerState => {
+    const parsed = RawEqualizerSchema.safeParse(input);
+    return parsed.success ? (parsed.data as unknown as EqualizerState) : DEFAULT_EQUALIZER_STATE;
+});

--- a/src/renderer/features/player/equalizer/equalizer.transitions.ts
+++ b/src/renderer/features/player/equalizer/equalizer.transitions.ts
@@ -1,0 +1,84 @@
+import { nanoid } from 'nanoid';
+
+import {
+    BandGains,
+    EQ_BAND_COUNT,
+    EQ_GAIN_MAX,
+    EQ_GAIN_MIN,
+    EQ_PREAMP_MAX,
+    EQ_PREAMP_MIN,
+    EqualizerState,
+} from './equalizer.types';
+import { BUILTIN_PRESETS, FLAT_PRESET_ID } from './presets';
+
+const clamp = (v: number, lo: number, hi: number): number => Math.min(hi, Math.max(lo, v));
+const flatBands = (): BandGains => [0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+
+const findPreset = (id: string, custom: EqualizerState['customPresets']) =>
+    BUILTIN_PRESETS.find((p) => p.id === id) ?? custom.find((p) => p.id === id);
+
+const uniqueName = (base: string, taken: string[]): string => {
+    if (!taken.includes(base)) return base;
+    let i = 2;
+    while (taken.includes(`${base} (${i})`)) i += 1;
+    return `${base} (${i})`;
+};
+
+export const setBand = (state: EqualizerState, index: number, db: number): EqualizerState => {
+    if (index < 0 || index >= EQ_BAND_COUNT) return state;
+    const next = [...state.bands] as unknown as number[];
+    next[index] = clamp(db, EQ_GAIN_MIN, EQ_GAIN_MAX);
+    return { ...state, activePresetId: null, bands: next as unknown as BandGains };
+};
+
+export const setPreamp = (state: EqualizerState, db: number): EqualizerState => ({
+    ...state,
+    activePresetId: null,
+    preamp: clamp(db, EQ_PREAMP_MIN, EQ_PREAMP_MAX),
+});
+
+export const setEnabled = (state: EqualizerState, enabled: boolean): EqualizerState => ({
+    ...state,
+    enabled,
+});
+
+export const applyPreset = (state: EqualizerState, id: string): EqualizerState => {
+    const preset = findPreset(id, state.customPresets);
+    if (!preset) return state;
+    return {
+        ...state,
+        activePresetId: preset.id,
+        bands: [...preset.bands] as unknown as BandGains,
+        preamp: preset.preamp,
+    };
+};
+
+export const reset = (state: EqualizerState): EqualizerState => ({
+    ...state,
+    activePresetId: FLAT_PRESET_ID,
+    bands: flatBands(),
+    preamp: 0,
+});
+
+export const saveCustomPreset = (state: EqualizerState, name: string): EqualizerState => {
+    const taken = state.customPresets.map((p) => p.name);
+    return {
+        ...state,
+        customPresets: [
+            ...state.customPresets,
+            {
+                bands: [...state.bands] as unknown as BandGains,
+                builtin: false,
+                id: `user:${nanoid(8)}`,
+                name: uniqueName(name, taken),
+                preamp: state.preamp,
+            },
+        ],
+    };
+};
+
+export const deleteCustomPreset = (state: EqualizerState, id: string): EqualizerState => ({
+    ...state,
+    activePresetId: state.activePresetId === id ? null : state.activePresetId,
+    customPresets: state.customPresets.filter((p) => p.id !== id),
+});

--- a/src/renderer/features/player/equalizer/equalizer.types.ts
+++ b/src/renderer/features/player/equalizer/equalizer.types.ts
@@ -1,0 +1,36 @@
+export const EQ_FREQUENCIES = [31, 62, 125, 250, 500, 1000, 2000, 4000, 8000, 16000] as const;
+export const EQ_BAND_COUNT = EQ_FREQUENCIES.length;
+export const EQ_GAIN_MIN = -12;
+export const EQ_GAIN_MAX = 12;
+export const EQ_PREAMP_MIN = -12;
+export const EQ_PREAMP_MAX = 12;
+export const EQ_BAND_Q = 1.0;
+
+export type BandGains = readonly [
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+];
+
+export interface EqualizerPreset {
+    bands: BandGains;
+    builtin: boolean;
+    id: string;
+    name: string;
+    preamp: number;
+}
+
+export interface EqualizerState {
+    activePresetId: null | string;
+    bands: BandGains;
+    customPresets: EqualizerPreset[];
+    enabled: boolean;
+    preamp: number;
+}

--- a/src/renderer/features/player/equalizer/index.ts
+++ b/src/renderer/features/player/equalizer/index.ts
@@ -1,0 +1,6 @@
+export { useEqualizerActions, useEqualizerState } from './equalizer.actions';
+export { DEFAULT_EQUALIZER_STATE, EqualizerSettingsSchema } from './equalizer.schema';
+export type { EqualizerState } from './equalizer.types';
+export { EqualizerEntry } from './EqualizerEntry';
+export { EqualizerHook } from './EqualizerHook';
+export { EqualizerModal } from './EqualizerModal';

--- a/src/renderer/features/player/equalizer/mpv-eq-builder.ts
+++ b/src/renderer/features/player/equalizer/mpv-eq-builder.ts
@@ -1,0 +1,13 @@
+import { EQ_BAND_Q, EQ_FREQUENCIES, EqualizerState } from './equalizer.types';
+
+export const buildMpvAfString = (state: EqualizerState): string => {
+    if (!state.enabled) return '';
+    const isFlat = state.preamp === 0 && state.bands.every((g) => g === 0);
+    if (isFlat) return '';
+
+    const parts: string[] = [`volume=${state.preamp}dB`];
+    EQ_FREQUENCIES.forEach((freq, i) => {
+        parts.push(`equalizer=f=${freq}:width_type=o:width=${EQ_BAND_Q * 2}:g=${state.bands[i]}`);
+    });
+    return parts.join(',');
+};

--- a/src/renderer/features/player/equalizer/mpv-eq-dispatcher.ts
+++ b/src/renderer/features/player/equalizer/mpv-eq-dispatcher.ts
@@ -1,0 +1,41 @@
+import { EqualizerState } from './equalizer.types';
+import { buildMpvAfString } from './mpv-eq-builder';
+
+export interface DispatcherDeps {
+    setProperties: (props: Record<string, unknown>) => void;
+}
+
+export const createMpvEqDispatcher = (deps: DispatcherDeps) => {
+    let pending = false;
+    let nextState: EqualizerState | null = null;
+    let nextIsLocal = false;
+    let wasLocalActive = false; // last frame we actually emitted under LOCAL
+
+    const flush = () => {
+        pending = false;
+        const state = nextState!;
+        const isLocal = nextIsLocal;
+        nextState = null;
+
+        if (!isLocal) {
+            if (wasLocalActive) {
+                deps.setProperties({ af: '' });
+                wasLocalActive = false;
+            }
+            return;
+        }
+
+        deps.setProperties({ af: buildMpvAfString(state) });
+        wasLocalActive = true;
+    };
+
+    return {
+        dispatch(state: EqualizerState, isLocal: boolean) {
+            nextState = state;
+            nextIsLocal = isLocal;
+            if (pending) return;
+            pending = true;
+            requestAnimationFrame(flush);
+        },
+    };
+};

--- a/src/renderer/features/player/equalizer/presets.ts
+++ b/src/renderer/features/player/equalizer/presets.ts
@@ -1,0 +1,57 @@
+import { BandGains, EqualizerPreset } from './equalizer.types';
+
+export const FLAT_PRESET_ID = 'builtin:flat';
+
+const z = (): BandGains => [0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+
+export const BUILTIN_PRESETS: EqualizerPreset[] = [
+    {
+        bands: z(),
+        builtin: true,
+        id: FLAT_PRESET_ID,
+        name: 'equalizer.preset.flat',
+        preamp: 0,
+    },
+    {
+        bands: [5, 4, 3, 1, -1, -1, 0, 2, 3, 3],
+        builtin: true,
+        id: 'builtin:rock',
+        name: 'equalizer.preset.rock',
+        preamp: -3,
+    },
+    {
+        bands: [-1, 0, 2, 4, 4, 3, 1, 0, -1, -1],
+        builtin: true,
+        id: 'builtin:pop',
+        name: 'equalizer.preset.pop',
+        preamp: -2,
+    },
+    {
+        bands: [3, 2, 1, 2, -1, -1, 0, 1, 2, 3],
+        builtin: true,
+        id: 'builtin:jazz',
+        name: 'equalizer.preset.jazz',
+        preamp: -2,
+    },
+    {
+        bands: [4, 3, 2, 0, 0, 0, -1, -2, -2, -3],
+        builtin: true,
+        id: 'builtin:classical',
+        name: 'equalizer.preset.classical',
+        preamp: -2,
+    },
+    {
+        bands: [6, 5, 4, 2, 0, 0, 0, 0, 0, 0],
+        builtin: true,
+        id: 'builtin:bassBoost',
+        name: 'equalizer.preset.bassBoost',
+        preamp: -4,
+    },
+    {
+        bands: [-2, -2, -1, 1, 3, 3, 2, 1, 0, -1],
+        builtin: true,
+        id: 'builtin:vocal',
+        name: 'equalizer.preset.vocal',
+        preamp: -2,
+    },
+];

--- a/src/renderer/features/player/equalizer/web-eq-graph.ts
+++ b/src/renderer/features/player/equalizer/web-eq-graph.ts
@@ -1,0 +1,103 @@
+import { EQ_BAND_Q, EQ_FREQUENCIES, EqualizerState } from './equalizer.types';
+
+export interface EqGraph {
+    context: AudioContext;
+    filterChains: BiquadFilterNode[][];
+    preamp: GainNode;
+    sourceGains: GainNode[];
+    // One tap node per source, placed between the filter chain end and the
+    // preamp. Exposed so the visualizer (which would otherwise read pre-EQ
+    // signal off `sourceGains`) can read post-EQ instead.
+    visualizerTaps: GainNode[];
+}
+
+const RAMP = 0.005;
+const dbToGain = (db: number) => Math.pow(10, db / 20);
+const INSTALLED = new WeakSet<GainNode>();
+
+export const buildEqGraph = (context: AudioContext, sourceGains: GainNode[]): EqGraph => {
+    for (const g of sourceGains) {
+        if (INSTALLED.has(g)) throw new Error('EqGraph already installed on this gain node');
+    }
+    const preamp = context.createGain();
+    preamp.gain.value = 1;
+
+    const visualizerTaps: GainNode[] = [];
+    const filterChains = sourceGains.map((sourceGain) => {
+        const chain = EQ_FREQUENCIES.map((freq) => {
+            const filter = context.createBiquadFilter();
+            filter.type = 'peaking';
+            filter.frequency.value = freq;
+            filter.Q.value = EQ_BAND_Q;
+            filter.gain.value = 0;
+            return filter;
+        });
+        const tap = context.createGain();
+        tap.gain.value = 1;
+        visualizerTaps.push(tap);
+
+        // Surgical: disconnect ONLY the destination edge, leaving analyser/visualizer fan-out alone.
+        try {
+            sourceGain.disconnect(context.destination);
+        } catch {
+            /* no-op */
+        }
+
+        sourceGain.connect(chain[0]);
+        for (let i = 0; i < chain.length - 1; i++) chain[i].connect(chain[i + 1]);
+        chain[chain.length - 1].connect(tap);
+        tap.connect(preamp);
+
+        INSTALLED.add(sourceGain);
+        return chain;
+    });
+
+    preamp.connect(context.destination);
+    return { context, filterChains, preamp, sourceGains, visualizerTaps };
+};
+
+export const applyEqState = (graph: EqGraph, state: EqualizerState): void => {
+    const now = graph.context.currentTime;
+    const linearPreamp = state.enabled ? dbToGain(state.preamp) : 1;
+    graph.preamp.gain.setTargetAtTime(linearPreamp, now, RAMP);
+    for (const chain of graph.filterChains) {
+        for (let i = 0; i < chain.length; i++) {
+            const bandDb = state.enabled ? state.bands[i] : 0;
+            chain[i].gain.setTargetAtTime(bandDb, now, RAMP);
+        }
+    }
+};
+
+export const teardownEqGraph = (graph: EqGraph): void => {
+    graph.sourceGains.forEach((sourceGain, i) => {
+        const firstFilter = graph.filterChains[i][0];
+        // Surgical: only disconnect the specific edge we created.
+        try {
+            sourceGain.disconnect(firstFilter);
+        } catch {
+            /* no-op */
+        }
+        INSTALLED.delete(sourceGain);
+        // Restore the original sourceGain → destination edge.
+        sourceGain.connect(graph.context.destination);
+    });
+    for (const chain of graph.filterChains) {
+        for (const f of chain)
+            try {
+                f.disconnect();
+            } catch {
+                /* no-op */
+            }
+    }
+    for (const tap of graph.visualizerTaps)
+        try {
+            tap.disconnect();
+        } catch {
+            /* no-op */
+        }
+    try {
+        graph.preamp.disconnect();
+    } catch {
+        /* no-op */
+    }
+};

--- a/src/renderer/features/player/utils/get-visualizer-audio-nodes.ts
+++ b/src/renderer/features/player/utils/get-visualizer-audio-nodes.ts
@@ -7,8 +7,7 @@ export function getVisualizerAudioNodes(
     playbackType: PlayerType,
 ): AudioNode[] {
     if (!webAudio) return [];
-    if (playbackType === PlayerType.LOCAL) {
-        return webAudio.visualizerInputs ?? [];
-    }
+    if (webAudio.visualizerInputs?.length) return webAudio.visualizerInputs;
+    if (playbackType === PlayerType.LOCAL) return [];
     return webAudio.gains;
 }

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -21,6 +21,10 @@ import {
     PLAYLIST_TABLE_COLUMNS,
     SONG_TABLE_COLUMNS,
 } from '/@/renderer/components/item-list/item-table-list/default-columns';
+import {
+    DEFAULT_EQUALIZER_STATE,
+    EqualizerSettingsSchema,
+} from '/@/renderer/features/player/equalizer/equalizer.schema';
 import { audiomotionanalyzerPresets } from '/@/renderer/features/visualizer/components/audiomotionanalyzer/presets';
 import { AppRoute } from '/@/renderer/router/routes';
 import { getEnvSettingsOverrides } from '/@/renderer/store/env-settings-overrides';
@@ -614,6 +618,7 @@ const PlayerFilterSchema = z.object({
 const PlaybackSettingsSchema = z.object({
     audioDeviceId: z.string().nullable().optional(),
     audioFadeOnStatusChange: z.boolean(),
+    equalizer: EqualizerSettingsSchema,
     filters: z.array(PlayerFilterSchema),
     mediaSession: z.boolean(),
     mpvAudioDeviceId: z.string().nullable().optional(),
@@ -1806,6 +1811,7 @@ const initialState: SettingsState = {
     playback: {
         audioDeviceId: undefined,
         audioFadeOnStatusChange: true,
+        equalizer: DEFAULT_EQUALIZER_STATE,
         filters: [],
         mediaSession: false,
         mpvAudioDeviceId: undefined,


### PR DESCRIPTION
## Summary

Adds a 10-band graphic equalizer accessible from the playerbar gear popover.
Works on both audio backends (mpv `af` filter chain and Web Audio
BiquadFilterNode chain) and persists with other playback settings. The Web
Audio backend also exposes its post-EQ signal to the visualizer, so the
spectrum tracks what the user actually hears.

## Why

This is one of the most-requested features for self-hosted music players in
the Subsonic / Navidrome / Jellyfin ecosystem, and Feishin already has the
audio plumbing for it on both backends — it just needed the DSP, state, and
UI wired in surgically.

## What's included

- 10-band ISO graphic EQ (31 Hz – 16 kHz), ±12 dB per band
- Manual pre-amp slider (±12 dB)
- Bypass / Enabled toggle
- 7 built-in presets (Flat, Rock, Pop, Jazz, Classical, Bass Boost, Vocal)
- User-savable named custom presets, with delete
- Mantine modal launched from the playerbar gear popover
- Both backends:
  - **mpv**: builds an `af` chain of FFmpeg `volume` + 10 `equalizer`
    filters, dispatched via the existing `mpvPlayer.setProperties` IPC
    with `requestAnimationFrame` coalescing. Clears `af` on bypass and on
    LOCAL→WEB switch.
  - **Web Audio**: inserts 10 `peaking` BiquadFilterNodes per source gain
    + a shared preamp GainNode between gains and destination. Uses
    target-specific disconnects so the visualizer analyser fan-out is
    preserved.
- Per-source unity-gain tap nodes exposed via `webAudio.visualizerInputs`
  so the visualizer reads post-EQ instead of pre-EQ.
- All visible strings via `t()`; English locale shipped (i18next-parser
  picks up the keys for other locales).
- Persistence via the existing settings store (Zod schema + persist
  middleware), so EQ settings round-trip through app restart.

## Implementation notes

- All new code lives under `src/renderer/features/player/equalizer/`. The
  upstream-file diff is **surgical**:
  - `settings.store.ts`: one new schema field + one default value
  - `audio-players.tsx`: one new `<EqualizerHook />` mount
  - `player-config.tsx`: one new option entry
  - `utils/get-visualizer-audio-nodes.ts`: prefer `visualizerInputs` when
    populated regardless of playback type (existing LOCAL+system-audio
    and WEB-only-gains behaviour preserved)
  - `i18n/locales/en.json`: new `equalizer` keys
- No changes under `src/main/`, `src/preload/`, or `src/remote/`.

## Out of scope

- Remote-control surface EQ (`src/remote/`)
- Auto preamp / clip detection
- Parametric EQ, variable Q, additional band counts
- Spectrum-analyzer overlay inside the EQ modal
- Sharing / importing presets

Happy to follow up on any of those in a separate PR if there's interest.

## Test plan

- [ ] Web backend: open gear → "Open…" under Equalizer, enable, slide bands → audible.
- [ ] Apply Bass Boost preset → audible bass.
- [ ] Toggle Enabled off → audio returns to flat in ~10 ms, no click.
- [ ] Save + delete a custom preset.
- [ ] Crossfade two tracks with EQ on → no glitches.
- [ ] mpv backend (if mpv installed): repeat.
- [ ] Backend switch mid-playback (LOCAL → WEB) → audio continues, mpv `af` cleared.
- [ ] Restart app → EQ state restored.
- [ ] Visualizer still works with EQ enabled, and visibly tracks band changes.
