### PR TITLE
fix(player): stop radio before starting track playback

### DIFF
--- a/src/renderer/store/player.store.ts
+++ b/src/renderer/store/player.store.ts
@@ -8,6 +8,7 @@ import { createWithEqualityFn } from 'zustand/traditional';
 
 import { eventEmitter } from '/@/renderer/events/event-emitter';
 import { createSelectors } from '/@/renderer/lib/zustand';
+import { useRadioStore as useRadioPlayerStore } from '/@/renderer/features/radio/hooks/use-radio-player';
 import { useSettingsStore } from '/@/renderer/store/settings.store';
 import {
     setTimestamp as setTimestampStore,
@@ -477,6 +478,10 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                             break;
                         }
                         case Play.NOW: {
+                            if (useRadioPlayerStore.getState().currentStreamUrl) {
+                                useRadioPlayerStore.getState().actions.stop();
+                            }
+
                             set((state) => {
                                 newItems.forEach((item) => {
                                     state.queue.songs[item._uniqueId] = item;
@@ -531,6 +536,10 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                             break;
                         }
                         case Play.SHUFFLE: {
+                            if (useRadioPlayerStore.getState().currentStreamUrl) {
+                                useRadioPlayerStore.getState().actions.stop();
+                            }
+
                             set((state) => {
                                 newItems.forEach((item) => {
                                     state.queue.songs[item._uniqueId] = item;

--- a/src/renderer/store/player.store.ts
+++ b/src/renderer/store/player.store.ts
@@ -7,8 +7,8 @@ import { useShallow } from 'zustand/react/shallow';
 import { createWithEqualityFn } from 'zustand/traditional';
 
 import { eventEmitter } from '/@/renderer/events/event-emitter';
-import { createSelectors } from '/@/renderer/lib/zustand';
 import { useRadioStore as useRadioPlayerStore } from '/@/renderer/features/radio/hooks/use-radio-player';
+import { createSelectors } from '/@/renderer/lib/zustand';
 import { useSettingsStore } from '/@/renderer/store/settings.store';
 import {
     setTimestamp as setTimestampStore,


### PR DESCRIPTION
When internet radio is streaming, clicking a track to play does nothing because the MPV engine guards check currentStreamUrl and bail early. Stop the radio stream before setting up the new queue on Play.NOW and Play.SHUFFLE so the audio engine proceeds normally.

Fixes #2038