### PR TITLE
feat(artists): preserve artist detail scroll position on back navigation

### DIFF
--- a/src/renderer/components/native-scroll-area/use-native-scroll-persist.ts
+++ b/src/renderer/components/native-scroll-area/use-native-scroll-persist.ts
@@ -1,0 +1,53 @@
+import { RefObject, useEffect, useLayoutEffect } from 'react';
+import { useLocation, useNavigationType } from 'react-router';
+
+import { useScrollStore } from '/@/renderer/store/scroll.store';
+
+interface UseNativeScrollPersistProps {
+    enabled: boolean;
+    scrollRef: RefObject<HTMLDivElement | null>;
+}
+
+// Persists vertical scroll offset for a NativeScrollArea, keyed by react-router
+// location.key. Restores the saved offset only on POP navigation; PUSH/REPLACE
+// continue to start at the top.
+export const useNativeScrollPersist = ({ enabled, scrollRef }: UseNativeScrollPersistProps) => {
+    const location = useLocation();
+    const navigationType = useNavigationType();
+    const setOffset = useScrollStore((s) => s.setOffset);
+    const getOffset = useScrollStore((s) => s.getOffset);
+
+    useLayoutEffect(() => {
+        if (!enabled) return;
+        if (navigationType !== 'POP') return;
+        const node = scrollRef.current;
+        if (!node) return;
+
+        const saved = getOffset(location.key);
+        if (typeof saved !== 'number') return;
+
+        const applyOffset = () => {
+            if (!scrollRef.current) return;
+            scrollRef.current.scrollTop = saved;
+        };
+
+        applyOffset();
+        const raf = requestAnimationFrame(applyOffset);
+        return () => cancelAnimationFrame(raf);
+    }, [enabled, getOffset, location.key, navigationType, scrollRef]);
+
+    useEffect(() => {
+        if (!enabled) return;
+        const node = scrollRef.current;
+        if (!node) return;
+
+        const handleScroll = () => {
+            setOffset(location.key, node.scrollTop);
+        };
+
+        node.addEventListener('scroll', handleScroll, { passive: true });
+        return () => {
+            node.removeEventListener('scroll', handleScroll);
+        };
+    }, [enabled, location.key, scrollRef, setOffset]);
+};

--- a/src/renderer/features/artists/routes/album-artist-detail-route.tsx
+++ b/src/renderer/features/artists/routes/album-artist-detail-route.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router';
 
 import { useItemImageUrl } from '/@/renderer/components/item-image/item-image';
 import { NativeScrollArea } from '/@/renderer/components/native-scroll-area/native-scroll-area';
+import { useNativeScrollPersist } from '/@/renderer/components/native-scroll-area/use-native-scroll-persist';
 import { albumQueries } from '/@/renderer/features/albums/api/album-api';
 import { artistsQueries } from '/@/renderer/features/artists/api/artists-api';
 import { AlbumArtistDetailContent } from '/@/renderer/features/artists/components/album-artist-detail-content';
@@ -27,6 +28,8 @@ const AlbumArtistDetailRouteContent = () => {
     const server = useCurrentServer();
     const serverId = useCurrentServerId();
     const { artistBackground, artistBackgroundBlur } = useArtistBackground();
+
+    useNativeScrollPersist({ enabled: true, scrollRef: scrollAreaRef });
 
     const { albumArtistId, artistId } = useParams() as {
         albumArtistId?: string;


### PR DESCRIPTION
Closes #2042. The maintainer commented: "A PR would be appreciated!"

Adds a small `useNativeScrollPersist` hook that mirrors the existing `useItemListScrollPersist` pattern (persist by `location.key`, restore only on `POP`) and wires it into the album artist detail route. Scope is limited to that route per the issue; PUSH/REPLACE navigations still start at the top.