### PR TITLE
fix: strip playback menu accelerators while command palette is open

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -280,6 +280,16 @@ let currentRepeatMode: PlayerRepeat = PlayerRepeat.NONE;
 let currentSidebarCollapsed = false;
 let currentShuffleEnabled = false;
 let playbackMenuAccelerators: MenuPlaybackState['accelerators'] = {};
+let commandPaletteOpen = false;
+
+ipcMain.on('command-palette-state', (_event, opened: boolean) => {
+    const next = !!opened;
+    if (commandPaletteOpen === next) return;
+    commandPaletteOpen = next;
+    if (isMacOS()) {
+        rebuildMainMenu();
+    }
+});
 
 if (process.env.NODE_ENV === 'production') {
     import('source-map-support').then((sourceMapSupport) => {
@@ -340,7 +350,7 @@ const rebuildMainMenu = () => {
     if (!menuBuilder || !mainWindow) return;
 
     menuBuilder.buildMenu({
-        accelerators: playbackMenuAccelerators,
+        accelerators: commandPaletteOpen ? {} : playbackMenuAccelerators,
         playbackStatus: currentPlaybackStatus,
         privateMode: currentPrivateMode,
         repeatMode: currentRepeatMode,

--- a/src/preload/utils.ts
+++ b/src/preload/utils.ts
@@ -54,6 +54,10 @@ const forceGarbageCollection = (): boolean => {
     }
 };
 
+const setCommandPaletteOpen = (opened: boolean) => {
+    ipcRenderer.send('command-palette-state', opened);
+};
+
 const rendererOpenSettings = (cb: () => void) => {
     ipcRenderer.on('renderer-open-settings', () => cb());
 };
@@ -101,6 +105,7 @@ export const utils = {
     rendererTogglePrivateMode,
     rendererToggleSidebar,
     rendererUpdateAvailable,
+    setCommandPaletteOpen,
     startPowerSaveBlocker,
     stopPowerSaveBlocker,
 };

--- a/src/renderer/store/app.store.ts
+++ b/src/renderer/store/app.store.ts
@@ -201,17 +201,22 @@ export const useAppStore = createWithEqualityFn<AppSlice>()(
                         set((state) => {
                             state.commandPalette.opened = false;
                         });
+                        window.api?.utils?.setCommandPaletteOpen?.(false);
                     },
                     open: () => {
                         set((state) => {
                             state.commandPalette.opened = true;
                         });
+                        window.api?.utils?.setCommandPaletteOpen?.(true);
                     },
                     opened: false,
                     toggle: () => {
+                        let nextOpened = false;
                         set((state) => {
                             state.commandPalette.opened = !state.commandPalette.opened;
+                            nextOpened = state.commandPalette.opened;
                         });
+                        window.api?.utils?.setCommandPaletteOpen?.(nextOpened);
                     },
                 },
                 commandPaletteSearchSectionsExpanded: {},


### PR DESCRIPTION
## Summary

On macOS, menu item accelerators (e.g. `Space` for Play/Pause) fire even when an `<input>` has focus. The renderer-side `useHotkeys` wrap from #1925 cannot prevent this — the menu intercepts the keystroke before it reaches the renderer. Result: typing a space in the command palette search toggles play/pause instead of inserting a space character.

This PR tracks the command palette open state in the main process via a new IPC channel. While the palette is open, the application menu is rebuilt with empty playback accelerators so single-key shortcuts (Space, etc.) no longer intercept keystrokes intended for the search input. Accelerators are restored when the palette closes.

### Changes
- `src/main/index.ts` — new `command-palette-state` IPC handler; `rebuildMainMenu` passes empty accelerators while palette is open
- `src/preload/utils.ts` — exposes `setCommandPaletteOpen(opened)` to renderer
- `src/renderer/store/app.store.ts` — sends IPC from `open`/`close`/`toggle` on the palette store slice

## Test plan

- [x] macOS: open command palette, type a query containing spaces — spaces insert in the input; play/pause does not fire
- [x] macOS: with palette closed, pressing space still toggles play/pause via the renderer hotkey
- [x] macOS: Play/Pause menu item still functions (click) when palette is open; accelerator label is hidden while open and restored when closed
- [ ] Linux/Windows: no behavioral change (menu rebuild is gated by `isMacOS()`)