### PR TITLE
fix: strip playback accelerators whenever any text input is focused

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -280,12 +280,12 @@ let currentRepeatMode: PlayerRepeat = PlayerRepeat.NONE;
 let currentSidebarCollapsed = false;
 let currentShuffleEnabled = false;
 let playbackMenuAccelerators: MenuPlaybackState['accelerators'] = {};
-let commandPaletteOpen = false;
+let inputFocused = false;
 
-ipcMain.on('command-palette-state', (_event, opened: boolean) => {
-    const next = !!opened;
-    if (commandPaletteOpen === next) return;
-    commandPaletteOpen = next;
+ipcMain.on('input-focus-state', (_event, focused: boolean) => {
+    const next = !!focused;
+    if (inputFocused === next) return;
+    inputFocused = next;
     if (isMacOS()) {
         rebuildMainMenu();
     }
@@ -350,7 +350,7 @@ const rebuildMainMenu = () => {
     if (!menuBuilder || !mainWindow) return;
 
     menuBuilder.buildMenu({
-        accelerators: commandPaletteOpen ? {} : playbackMenuAccelerators,
+        accelerators: inputFocused ? {} : playbackMenuAccelerators,
         playbackStatus: currentPlaybackStatus,
         privateMode: currentPrivateMode,
         repeatMode: currentRepeatMode,

--- a/src/preload/utils.ts
+++ b/src/preload/utils.ts
@@ -54,8 +54,8 @@ const forceGarbageCollection = (): boolean => {
     }
 };
 
-const setCommandPaletteOpen = (opened: boolean) => {
-    ipcRenderer.send('command-palette-state', opened);
+const setInputFocused = (focused: boolean) => {
+    ipcRenderer.send('input-focus-state', focused);
 };
 
 const rendererOpenSettings = (cb: () => void) => {
@@ -105,7 +105,7 @@ export const utils = {
     rendererTogglePrivateMode,
     rendererToggleSidebar,
     rendererUpdateAvailable,
-    setCommandPaletteOpen,
+    setInputFocused,
     startPowerSaveBlocker,
     stopPowerSaveBlocker,
 };

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -93,6 +93,7 @@ const AppEffects = () => (
         <GlobalShortcutsEffect />
         <LanguageEffect />
         <NativeMenuSyncEffect />
+        <InputFocusEffect />
     </>
 );
 
@@ -167,6 +168,45 @@ const LanguageEffect = () => {
 
 const NativeMenuSyncEffect = () => {
     useNativeMenuSync();
+
+    return null;
+};
+
+const InputFocusEffect = () => {
+    useEffect(() => {
+        if (!isElectron()) return;
+
+        const handleFocusIn = (e: FocusEvent) => {
+            const target = e.target as Element | null;
+            if (
+                target instanceof HTMLInputElement ||
+                target instanceof HTMLTextAreaElement ||
+                (target instanceof HTMLElement && target.isContentEditable)
+            ) {
+                window.api?.utils?.setInputFocused?.(true);
+            }
+        };
+
+        const handleFocusOut = (e: FocusEvent) => {
+            const related = e.relatedTarget as Element | null;
+            if (
+                related instanceof HTMLInputElement ||
+                related instanceof HTMLTextAreaElement ||
+                (related instanceof HTMLElement && related.isContentEditable)
+            ) {
+                return;
+            }
+            window.api?.utils?.setInputFocused?.(false);
+        };
+
+        document.addEventListener('focusin', handleFocusIn);
+        document.addEventListener('focusout', handleFocusOut);
+
+        return () => {
+            document.removeEventListener('focusin', handleFocusIn);
+            document.removeEventListener('focusout', handleFocusOut);
+        };
+    }, []);
 
     return null;
 };

--- a/src/renderer/store/app.store.ts
+++ b/src/renderer/store/app.store.ts
@@ -201,22 +201,17 @@ export const useAppStore = createWithEqualityFn<AppSlice>()(
                         set((state) => {
                             state.commandPalette.opened = false;
                         });
-                        window.api?.utils?.setCommandPaletteOpen?.(false);
                     },
                     open: () => {
                         set((state) => {
                             state.commandPalette.opened = true;
                         });
-                        window.api?.utils?.setCommandPaletteOpen?.(true);
                     },
                     opened: false,
                     toggle: () => {
-                        let nextOpened = false;
                         set((state) => {
                             state.commandPalette.opened = !state.commandPalette.opened;
-                            nextOpened = state.commandPalette.opened;
                         });
-                        window.api?.utils?.setCommandPaletteOpen?.(nextOpened);
                     },
                 },
                 commandPaletteSearchSectionsExpanded: {},


### PR DESCRIPTION
## Summary

- Replaces the command-palette-specific IPC approach from #2055 with document-level `focusin`/`focusout` listeners
- Accelerators are stripped whenever **any** `input`, `textarea`, or `contenteditable` gains focus — settings search, playlist creation modals, server forms, etc.
- Uses `relatedTarget` on `focusout` to avoid a false "unfocused" signal when tabbing between inputs
- No per-modal wiring needed; all current and future input surfaces are covered automatically

## Why

The previous fix only tracked command palette open state. The same macOS accelerator bug (Space triggering play/pause instead of inserting a character) reproduced in every other modal with a text field.

## Test plan

- [x] Open command palette → type space → playback should not toggle
- [x] Open settings (Cmd+,) → click search box → type space → playback should not toggle
- [x] Create a playlist → type in name field → space should insert, not toggle playback
- [x] Close any modal → Space should resume toggling playback normally
- [x] Tab between two inputs inside a modal → accelerators should stay disabled throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)