### PR TITLE
Exclude Feature Requests from stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -42,6 +42,6 @@ jobs:
 
 
                   stale-issue-label: 'stale'
-                  exempt-issue-labels: 'keep,security'
+                  exempt-issue-labels: 'keep,security,enhancement'
                   stale-pr-label: 'stale'
                   exempt-pr-labels: 'keep,security'


### PR DESCRIPTION
Adds the enhancement label to the stale action exemption list.

Feature requests generally do not become "stale" on their own, since they often remain valid until someone decides to implement them. This change prevents enhancement requests from being automatically marked as stale or closed due to inactivity.

The Idea for this came from https://github.com/jeffvli/feishin/issues/1238#issuecomment-4362966275

Love Feishin, keep it up :heart_hands: 