### PR TITLE
fix: set RESOURCES_PATH relative to app.getAppPath()

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -335,7 +335,7 @@ if (isDevelopment) {
 }
 
 const RESOURCES_PATH = app.isPackaged
-    ? path.join(process.resourcesPath, 'assets')
+    ? path.join(path.dirname(app.getAppPath()), 'assets')
     : path.join(__dirname, '../../assets');
 
 const getAssetPath = (...paths: string[]): string => {


### PR DESCRIPTION
I’m packaging feishin for Arch Linux, and the tray icon is not shown. We run feishin
with system electron, so process.resourcesPath points to the resources
folder of the system electron, not the one from feishin.

```
Error: Failed to load image from path '/usr/lib/electron39/resources/assets/icons/icon.png'
    at createTray (/usr/lib/feishin/app.asar/src/main/index.ts:410)
```

This PR fixes the issue for Arch, I haven’t tested whether the app.getAppPath()
approach works on other platforms.
