### PR TITLE
Fix playback hotkeys by preventing browser default

### DIFF
--- a/src/renderer/features/player/hooks/use-playback-hotkeys.ts
+++ b/src/renderer/features/player/hooks/use-playback-hotkeys.ts
@@ -13,11 +13,19 @@ export const usePlaybackHotkeys = () => {
         const bindingHandlers: Array<{
             binding: (typeof bindings)[keyof typeof bindings];
             handler: () => void;
+            options?: {
+                preventDefault?: boolean;
+                usePhysicalKeys?: boolean;
+            };
         }> = [
             { binding: bindings.next, handler: () => player.mediaNext() },
             { binding: bindings.pause, handler: () => player.mediaPause() },
             { binding: bindings.play, handler: () => player.mediaPlay() },
-            { binding: bindings.playPause, handler: () => player.mediaTogglePlayPause() },
+            {
+                binding: bindings.playPause,
+                handler: () => player.mediaTogglePlayPause(),
+                options: { preventDefault: true },
+            },
             { binding: bindings.previous, handler: () => player.mediaPrevious() },
             { binding: bindings.skipBackward, handler: () => player.mediaSkipBackward() },
             { binding: bindings.skipForward, handler: () => player.mediaSkipForward() },
@@ -27,9 +35,9 @@ export const usePlaybackHotkeys = () => {
         ];
 
         // Filter and map to hotkey items
-        bindingHandlers.forEach(({ binding, handler }) => {
+        bindingHandlers.forEach(({ binding, handler, options }) => {
             if (!binding.isGlobal && binding.hotkey && binding.hotkey !== '') {
-                hotkeyItems.push([binding.hotkey, handler]);
+                hotkeyItems.push([binding.hotkey, handler, options]);
             }
         });
 

--- a/src/renderer/features/player/hooks/use-playback-hotkeys.ts
+++ b/src/renderer/features/player/hooks/use-playback-hotkeys.ts
@@ -29,7 +29,7 @@ export const usePlaybackHotkeys = () => {
         // Filter and map to hotkey items
         bindingHandlers.forEach(({ binding, handler }) => {
             if (!binding.isGlobal && binding.hotkey && binding.hotkey !== '') {
-                hotkeyItems.push([binding.hotkey, handler, { preventDefault: true }]); // Prevent default to avoid conflicts with shortcuts
+                hotkeyItems.push([binding.hotkey, handler]);
             }
         });
 

--- a/src/renderer/features/player/hooks/use-playback-hotkeys.ts
+++ b/src/renderer/features/player/hooks/use-playback-hotkeys.ts
@@ -13,19 +13,11 @@ export const usePlaybackHotkeys = () => {
         const bindingHandlers: Array<{
             binding: (typeof bindings)[keyof typeof bindings];
             handler: () => void;
-            options?: {
-                preventDefault?: boolean;
-                usePhysicalKeys?: boolean;
-            };
         }> = [
             { binding: bindings.next, handler: () => player.mediaNext() },
             { binding: bindings.pause, handler: () => player.mediaPause() },
             { binding: bindings.play, handler: () => player.mediaPlay() },
-            {
-                binding: bindings.playPause,
-                handler: () => player.mediaTogglePlayPause(),
-                options: { preventDefault: true },
-            },
+            { binding: bindings.playPause, handler: () => player.mediaTogglePlayPause() },
             { binding: bindings.previous, handler: () => player.mediaPrevious() },
             { binding: bindings.skipBackward, handler: () => player.mediaSkipBackward() },
             { binding: bindings.skipForward, handler: () => player.mediaSkipForward() },
@@ -35,9 +27,9 @@ export const usePlaybackHotkeys = () => {
         ];
 
         // Filter and map to hotkey items
-        bindingHandlers.forEach(({ binding, handler, options }) => {
+        bindingHandlers.forEach(({ binding, handler }) => {
             if (!binding.isGlobal && binding.hotkey && binding.hotkey !== '') {
-                hotkeyItems.push([binding.hotkey, handler, options]);
+                hotkeyItems.push([binding.hotkey, handler, { preventDefault: true }]); // Prevent default to avoid conflicts with shortcuts
             }
         });
 

--- a/src/shared/utils/hotkeys.ts
+++ b/src/shared/utils/hotkeys.ts
@@ -33,5 +33,5 @@ export const withPhysicalKeys = (hotkeys: HotkeyItem[]): HotkeyItem[] =>
     hotkeys.map(([hotkey, handler, options]) => [
         toPhysicalHotkey(hotkey),
         handler,
-        { ...options, usePhysicalKeys: true },
+        { ...options, preventDefault: true, usePhysicalKeys: true },
     ]);


### PR DESCRIPTION
## Problem
Playback hotkeys could trigger browser default behavior (for example, spacebar was not reliably triggering play/pause, and the page would scroll instead) instead of only controlling playback.

## Fix
Update playback hotkey handling to always call `preventDefault` for every playback hotkey.