### PR TITLE
fix(player): step correctly when seeking rapidly

### DIFF
--- a/src/renderer/store/player.store.ts
+++ b/src/renderer/store/player.store.ts
@@ -1185,8 +1185,8 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                     });
                 },
                 mediaSeekToTimestamp: (timestamp: number) => {
-                    // Optimistically reflect the new position immediately so the UI
-                    // (seek bar, lyrics) doesn't lag behind the ~500ms engine poll.
+                    // See mediaSkipBackward: update the timestamp store right away to
+                    // avoid the stale-read left by the ~500ms engine poll.
                     setTimestampStore(timestamp);
                     set((state) => {
                         state.player.seekToTimestamp = uniqueSeekToTimestamp(timestamp);
@@ -1199,9 +1199,10 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                     const currentTimestamp = useTimestampStoreBase.getState().timestamp;
                     const newTimestamp = Math.max(0, currentTimestamp - timeToSkip);
 
-                    // Update the timestamp store right away so rapid presses compute
-                    // from the new position instead of the stale, poll-lagged value
-                    // (otherwise mashing repeatedly seeks to the same time).
+                    // Update the timestamp store right away so the UI and any
+                    // subsequent seek compute from the new position instead of the
+                    // stale value left by the ~500ms engine poll (otherwise mashing
+                    // the seek keys repeatedly lands on the same time).
                     setTimestampStore(newTimestamp);
                     set((state) => {
                         state.player.seekToTimestamp = uniqueSeekToTimestamp(newTimestamp);
@@ -1224,8 +1225,8 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                     const currentTimestamp = useTimestampStoreBase.getState().timestamp;
                     const newTimestamp = Math.min(duration - 1, currentTimestamp + timeToSkip);
 
-                    // See mediaSkipBackward: avoid the stale-read that makes rapid
-                    // presses seek to the same time.
+                    // See mediaSkipBackward: update the timestamp store right away to
+                    // avoid the stale-read left by the ~500ms engine poll.
                     setTimestampStore(newTimestamp);
                     set((state) => {
                         state.player.seekToTimestamp = uniqueSeekToTimestamp(newTimestamp);

--- a/src/renderer/store/player.store.ts
+++ b/src/renderer/store/player.store.ts
@@ -1185,6 +1185,9 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                     });
                 },
                 mediaSeekToTimestamp: (timestamp: number) => {
+                    // Optimistically reflect the new position immediately so the UI
+                    // (seek bar, lyrics) doesn't lag behind the ~500ms engine poll.
+                    setTimestampStore(timestamp);
                     set((state) => {
                         state.player.seekToTimestamp = uniqueSeekToTimestamp(timestamp);
                     });
@@ -1196,6 +1199,10 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                     const currentTimestamp = useTimestampStoreBase.getState().timestamp;
                     const newTimestamp = Math.max(0, currentTimestamp - timeToSkip);
 
+                    // Update the timestamp store right away so rapid presses compute
+                    // from the new position instead of the stale, poll-lagged value
+                    // (otherwise mashing repeatedly seeks to the same time).
+                    setTimestampStore(newTimestamp);
                     set((state) => {
                         state.player.seekToTimestamp = uniqueSeekToTimestamp(newTimestamp);
                     });
@@ -1217,6 +1224,9 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                     const currentTimestamp = useTimestampStoreBase.getState().timestamp;
                     const newTimestamp = Math.min(duration - 1, currentTimestamp + timeToSkip);
 
+                    // See mediaSkipBackward: avoid the stale-read that makes rapid
+                    // presses seek to the same time.
+                    setTimestampStore(newTimestamp);
                     set((state) => {
                         state.player.seekToTimestamp = uniqueSeekToTimestamp(newTimestamp);
                     });


### PR DESCRIPTION
Fixes #2083

## Problem

Rapidly pressing the seek shortcut repeatedly seeks to the same time instead of stepping. `mediaSkipBackward` / `mediaSkipForward` in `player.store.ts` compute the target relative to `useTimestampStoreBase`, which is only updated by the ~500ms engine poll (`web-player.tsx`, `mpv-player.tsx`, `wavesurfer-player.tsx`). Within that window every press reads the same stale position and recomputes the same target, so the time appears stuck for ~0.5–2s before advancing.

## Fix

Update the timestamp store immediately when a seek is issued, so subsequent presses compute from the new position. The engine poll then just reconciles to the same value. Also applied to `mediaSeekToTimestamp` so absolute seeks (slider / keyboard) reflect in the UI without the poll lag.

## Testing

- `pnpm run lint` (typecheck + eslint + stylelint) — passes
- `pnpm run build` — passes
- Verified manually: seeking now steps correctly (e.g. 0:30 → 0:25 → 0:20 → 0:15) when the shortcut is mashed, on the web backend.

---

🤖 Developed with AI assistance (Claude).
