### PR TITLE
fix: preserve infinite list cache on component remount (fixes random sort reshuffling)

### DIFF
--- a/src/renderer/components/item-list/helpers/item-list-infinite-loader.ts
+++ b/src/renderer/components/item-list/helpers/item-list-infinite-loader.ts
@@ -169,7 +169,9 @@ export const useItemListInfiniteLoader = ({
 
         // If data already exists in the cache (survived component unmount),
         // preserve it and skip the reset to avoid reshuffling random order
-        const existingData = queryClient.getQueryData<InfiniteLoaderCacheData | undefined>(dataQueryKey);
+        const existingData = queryClient.getQueryData<InfiniteLoaderCacheData | undefined>(
+            dataQueryKey,
+        );
         if (existingData?.dataMap && existingData.dataMap.size > 0) {
             previousDataQueryKeyRef.current = currentDataQueryKey;
             return;

--- a/src/renderer/components/item-list/helpers/item-list-infinite-loader.ts
+++ b/src/renderer/components/item-list/helpers/item-list-infinite-loader.ts
@@ -165,7 +165,16 @@ export const useItemListInfiniteLoader = ({
             // Track the last fetched page
             lastFetchedPageRef.current = Math.max(lastFetchedPageRef.current, pageNumber);
         },
-        [itemsPerPage, query, queryClient, serverId, dataQueryKey, listQueryFn, itemType],
+        [
+            itemsPerPage,
+            query,
+            queryClient,
+            serverId,
+            dataQueryKey,
+            listQueryFn,
+            itemType,
+            isRandomSort,
+        ],
     );
 
     // Reset the loaded pages and refetch current page when the query changes

--- a/src/renderer/components/item-list/helpers/item-list-infinite-loader.ts
+++ b/src/renderer/components/item-list/helpers/item-list-infinite-loader.ts
@@ -169,8 +169,8 @@ export const useItemListInfiniteLoader = ({
 
         // If data already exists in the cache (survived component unmount),
         // preserve it and skip the reset to avoid reshuffling random order
-        const existingData = queryClient.getQueryData<InfiniteLoaderCacheData>(dataQueryKey);
-        if (existingData?.dataMap?.size > 0) {
+        const existingData = queryClient.getQueryData<InfiniteLoaderCacheData | undefined>(dataQueryKey);
+        if (existingData?.dataMap && existingData.dataMap.size > 0) {
             previousDataQueryKeyRef.current = currentDataQueryKey;
             return;
         }

--- a/src/renderer/components/item-list/helpers/item-list-infinite-loader.ts
+++ b/src/renderer/components/item-list/helpers/item-list-infinite-loader.ts
@@ -110,7 +110,7 @@ export const useItemListInfiniteLoader = ({
 
     const fetchPage = useCallback(
         async (pageNumber: number) => {
-            const existingData = queryClient.getQueryData(dataQueryKey);
+            const existingData = queryClient.getQueryData<InfiniteLoaderCacheData>(dataQueryKey);
             if (existingData?.pagesLoaded?.[pageNumber]) {
                 lastFetchedPageRef.current = Math.max(lastFetchedPageRef.current, pageNumber);
                 return;
@@ -169,7 +169,7 @@ export const useItemListInfiniteLoader = ({
 
         // If data already exists in the cache (survived component unmount),
         // preserve it and skip the reset to avoid reshuffling random order
-        const existingData = queryClient.getQueryData(dataQueryKey);
+        const existingData = queryClient.getQueryData<InfiniteLoaderCacheData>(dataQueryKey);
         if (existingData?.dataMap?.size > 0) {
             previousDataQueryKeyRef.current = currentDataQueryKey;
             return;

--- a/src/renderer/components/item-list/helpers/item-list-infinite-loader.ts
+++ b/src/renderer/components/item-list/helpers/item-list-infinite-loader.ts
@@ -108,7 +108,7 @@ export const useItemListInfiniteLoader = ({
         [serverId, itemType, query],
     );
 
-    const isRandomSort = dataQueryKey[3]?.sortBy === 'random';
+    const isRandomSort = query?.sortBy === 'random';
 
     const fetchPage = useCallback(
         async (pageNumber: number) => {

--- a/src/renderer/components/item-list/helpers/item-list-infinite-loader.ts
+++ b/src/renderer/components/item-list/helpers/item-list-infinite-loader.ts
@@ -110,6 +110,12 @@ export const useItemListInfiniteLoader = ({
 
     const fetchPage = useCallback(
         async (pageNumber: number) => {
+            const existingData = queryClient.getQueryData(dataQueryKey);
+            if (existingData?.pagesLoaded?.[pageNumber]) {
+                lastFetchedPageRef.current = Math.max(lastFetchedPageRef.current, pageNumber);
+                return;
+            }
+
             const startIndex = pageNumber * itemsPerPage;
             const queryParams = {
                 limit: itemsPerPage,
@@ -160,6 +166,14 @@ export const useItemListInfiniteLoader = ({
     // Reset the loaded pages and refetch current page when the query changes
     useEffect(() => {
         const currentDataQueryKey = JSON.stringify(dataQueryKey);
+
+        // If data already exists in the cache (survived component unmount),
+        // preserve it and skip the reset to avoid reshuffling random order
+        const existingData = queryClient.getQueryData(dataQueryKey);
+        if (existingData?.dataMap?.size > 0) {
+            previousDataQueryKeyRef.current = currentDataQueryKey;
+            return;
+        }
 
         if (previousDataQueryKeyRef.current === currentDataQueryKey || isRefetchingRef.current) {
             return;

--- a/src/renderer/components/item-list/helpers/item-list-infinite-loader.ts
+++ b/src/renderer/components/item-list/helpers/item-list-infinite-loader.ts
@@ -129,6 +129,7 @@ export const useItemListInfiniteLoader = ({
             };
 
             const result = await queryClient.fetchQuery({
+                gcTime: isRandomSort ? 1000 * 60 * 10 : 1000 * 15,
                 queryFn: async ({ signal }) => {
                     const result = await listQueryFn({
                         apiClientProps: { serverId, signal },
@@ -138,6 +139,7 @@ export const useItemListInfiniteLoader = ({
                     return result;
                 },
                 queryKey: queryKeys[getListQueryKeyName(itemType)].list(serverId, queryParams),
+                staleTime: isRandomSort ? 1000 * 60 * 10 : 1000 * 15,
             });
 
             // Update the query data with the fetched page

--- a/src/renderer/components/item-list/helpers/item-list-infinite-loader.ts
+++ b/src/renderer/components/item-list/helpers/item-list-infinite-loader.ts
@@ -103,6 +103,8 @@ export const useItemListInfiniteLoader = ({
         setItemCount(totalItemCount);
     }, [setItemCount, totalItemCount]);
 
+    const isRandomSort = query?.sortBy === 'random';
+
     const dataQueryKey = useMemo(
         () => [serverId, 'item-list-infinite-loader', itemType, query],
         [serverId, itemType, query],
@@ -110,10 +112,13 @@ export const useItemListInfiniteLoader = ({
 
     const fetchPage = useCallback(
         async (pageNumber: number) => {
-            const existingData = queryClient.getQueryData<InfiniteLoaderCacheData>(dataQueryKey);
-            if (existingData?.pagesLoaded?.[pageNumber]) {
-                lastFetchedPageRef.current = Math.max(lastFetchedPageRef.current, pageNumber);
-                return;
+            if (isRandomSort) {
+                const existingData =
+                    queryClient.getQueryData<InfiniteLoaderCacheData>(dataQueryKey);
+                if (existingData?.pagesLoaded?.[pageNumber]) {
+                    lastFetchedPageRef.current = Math.max(lastFetchedPageRef.current, pageNumber);
+                    return;
+                }
             }
 
             const startIndex = pageNumber * itemsPerPage;
@@ -167,14 +172,14 @@ export const useItemListInfiniteLoader = ({
     useEffect(() => {
         const currentDataQueryKey = JSON.stringify(dataQueryKey);
 
-        // If data already exists in the cache (survived component unmount),
-        // preserve it and skip the reset to avoid reshuffling random order
-        const existingData = queryClient.getQueryData<InfiniteLoaderCacheData | undefined>(
-            dataQueryKey,
-        );
-        if (existingData?.dataMap && existingData.dataMap.size > 0) {
-            previousDataQueryKeyRef.current = currentDataQueryKey;
-            return;
+        if (isRandomSort) {
+            const existingData = queryClient.getQueryData<InfiniteLoaderCacheData | undefined>(
+                dataQueryKey,
+            );
+            if (existingData?.dataMap && existingData.dataMap.size > 0) {
+                previousDataQueryKeyRef.current = currentDataQueryKey;
+                return;
+            }
         }
 
         if (previousDataQueryKeyRef.current === currentDataQueryKey || isRefetchingRef.current) {

--- a/src/renderer/components/item-list/helpers/item-list-infinite-loader.ts
+++ b/src/renderer/components/item-list/helpers/item-list-infinite-loader.ts
@@ -103,12 +103,12 @@ export const useItemListInfiniteLoader = ({
         setItemCount(totalItemCount);
     }, [setItemCount, totalItemCount]);
 
-    const isRandomSort = query?.sortBy === 'random';
-
     const dataQueryKey = useMemo(
         () => [serverId, 'item-list-infinite-loader', itemType, query],
         [serverId, itemType, query],
     );
+
+    const isRandomSort = dataQueryKey[3]?.sortBy === 'random';
 
     const fetchPage = useCallback(
         async (pageNumber: number) => {

--- a/src/renderer/components/item-list/helpers/item-list-infinite-loader.ts
+++ b/src/renderer/components/item-list/helpers/item-list-infinite-loader.ts
@@ -13,7 +13,7 @@ import { useListContext } from '/@/renderer/context/list-context';
 import { eventEmitter } from '/@/renderer/events/event-emitter';
 import { UserFavoriteEventPayload, UserRatingEventPayload } from '/@/renderer/events/events';
 import { getListRefreshMutationKey } from '/@/renderer/features/shared/components/list-refresh-button';
-import { LibraryItem } from '/@/shared/types/domain-types';
+import { LibraryItem, SortKeyRandom } from '/@/shared/types/domain-types';
 
 export const getListQueryKeyName = (itemType: LibraryItem): string => {
     switch (itemType) {
@@ -108,7 +108,7 @@ export const useItemListInfiniteLoader = ({
         [serverId, itemType, query],
     );
 
-    const isRandomSort = query?.sortBy === 'random';
+    const isRandomSort = query?.sortBy === SortKeyRandom;
 
     const fetchPage = useCallback(
         async (pageNumber: number) => {

--- a/src/renderer/components/item-list/helpers/item-list-paginated-loader.ts
+++ b/src/renderer/components/item-list/helpers/item-list-paginated-loader.ts
@@ -12,7 +12,7 @@ import { useListContext } from '/@/renderer/context/list-context';
 import { eventEmitter } from '/@/renderer/events/event-emitter';
 import { UserFavoriteEventPayload, UserRatingEventPayload } from '/@/renderer/events/events';
 import { getListRefreshMutationKey } from '/@/renderer/features/shared/components/list-refresh-button';
-import { LibraryItem } from '/@/shared/types/domain-types';
+import { LibraryItem, SortKeyRandom } from '/@/shared/types/domain-types';
 
 const getQueryKeyName = (itemType: LibraryItem): string => {
     switch (itemType) {
@@ -76,7 +76,7 @@ export const useItemListPaginatedLoader = ({
     const fetchRange = getFetchRange(currentPage, itemsPerPage);
     const startIndex = fetchRange.startIndex;
 
-    const isRandomSort = query?.sortBy === 'random';
+    const isRandomSort = query?.sortBy === SortKeyRandom;
 
     const queryParams = useMemo(
         () => ({

--- a/src/renderer/components/item-list/helpers/item-list-paginated-loader.ts
+++ b/src/renderer/components/item-list/helpers/item-list-paginated-loader.ts
@@ -88,7 +88,7 @@ export const useItemListPaginatedLoader = ({
     );
 
     const { data } = useQuery({
-        gcTime: isRandomSort ? 1000 * 60 * 60 : 1000 * 15,
+        gcTime: isRandomSort ? 1000 * 60 * 10 : 1000 * 15,
         placeholderData: { items: getInitialData(itemsPerPage) },
         queryFn: async ({ signal }) => {
             const result = await listQueryFn({
@@ -99,7 +99,7 @@ export const useItemListPaginatedLoader = ({
             return result;
         },
         queryKey: queryKeys[getQueryKeyName(itemType)].list(serverId, queryParams),
-        staleTime: isRandomSort ? 1000 * 60 * 60 : 1000 * 15,
+        staleTime: isRandomSort ? 1000 * 60 * 10 : 1000 * 15,
     });
 
     const refreshMutation = useMutation({

--- a/src/renderer/components/item-list/helpers/item-list-paginated-loader.ts
+++ b/src/renderer/components/item-list/helpers/item-list-paginated-loader.ts
@@ -76,6 +76,8 @@ export const useItemListPaginatedLoader = ({
     const fetchRange = getFetchRange(currentPage, itemsPerPage);
     const startIndex = fetchRange.startIndex;
 
+    const isRandomSort = query?.sortBy === 'random';
+
     const queryParams = useMemo(
         () => ({
             limit: itemsPerPage,
@@ -86,7 +88,7 @@ export const useItemListPaginatedLoader = ({
     );
 
     const { data } = useQuery({
-        gcTime: 1000 * 15,
+        gcTime: isRandomSort ? 1000 * 60 * 60 : 1000 * 15,
         placeholderData: { items: getInitialData(itemsPerPage) },
         queryFn: async ({ signal }) => {
             const result = await listQueryFn({
@@ -97,7 +99,7 @@ export const useItemListPaginatedLoader = ({
             return result;
         },
         queryKey: queryKeys[getQueryKeyName(itemType)].list(serverId, queryParams),
-        staleTime: 1000 * 15,
+        staleTime: isRandomSort ? 1000 * 60 * 60 : 1000 * 15,
     });
 
     const refreshMutation = useMutation({

--- a/src/shared/types/domain-types.ts
+++ b/src/shared/types/domain-types.ts
@@ -465,6 +465,8 @@ export const tagListSortMap: TagListSortMap = {
     },
 };
 
+export const SortKeyRandom = 'random';
+
 export enum AlbumListSort {
     ALBUM_ARTIST = 'albumArtist',
     ARTIST = 'artist',
@@ -476,7 +478,7 @@ export enum AlbumListSort {
     ID = 'id',
     NAME = 'name',
     PLAY_COUNT = 'playCount',
-    RANDOM = 'random',
+    RANDOM = SortKeyRandom,
     RATING = 'rating',
     RECENTLY_ADDED = 'recentlyAdded',
     RECENTLY_PLAYED = 'recentlyPlayed',
@@ -598,7 +600,7 @@ export enum SongListSort {
     ID = 'id',
     NAME = 'name',
     PLAY_COUNT = 'playCount',
-    RANDOM = 'random',
+    RANDOM = SortKeyRandom,
     RATING = 'rating',
     RECENTLY_ADDED = 'recentlyAdded',
     RECENTLY_PLAYED = 'recentlyPlayed',
@@ -725,7 +727,7 @@ export enum AlbumArtistListSort {
     FAVORITED = 'favorited',
     NAME = 'name',
     PLAY_COUNT = 'playCount',
-    RANDOM = 'random',
+    RANDOM = SortKeyRandom,
     RATING = 'rating',
     RECENTLY_ADDED = 'recentlyAdded',
     RELEASE_DATE = 'releaseDate',
@@ -814,7 +816,7 @@ export enum ArtistListSort {
     FAVORITED = 'favorited',
     NAME = 'name',
     PLAY_COUNT = 'playCount',
-    RANDOM = 'random',
+    RANDOM = SortKeyRandom,
     RATING = 'rating',
     RECENTLY_ADDED = 'recentlyAdded',
     RELEASE_DATE = 'releaseDate',


### PR DESCRIPTION
## Problem

When browsing artists/albums with `sortBy` set to **Random**, clicking into an item and navigating back causes the list to reshuffle — every item is in a different position. This happens because:

1. Navigating to a detail view completely unmounts the list route component
2. On remount, `useItemListInfiniteLoader` resets its internal `useRef` guard (`previousDataQueryKeyRef`), causing the reset `useEffect` to fire
3. All cached pages are cleared and re-fetched from the server with `sortBy: random`, which returns a different ordering each time

## Changes

**`src/shared/types/domain-types.ts`**

Added a shared `SortKeyRandom = 'random'` const that all four sort enums (`AlbumListSort`, `SongListSort`, `AlbumArtistListSort`, `ArtistListSort`) reference:

```ts
export const SortKeyRandom = 'random';

export enum AlbumListSort {
    ...
    RANDOM = SortKeyRandom,
    ...
}
```

**`src/renderer/components/item-list/helpers/item-list-infinite-loader.ts`**

Both guards are now scoped to random sort only (checked via `query.sortBy === SortKeyRandom`):

1. **`fetchPage`:** When random sort is active, skip network fetch if the page is already loaded — prevents re-fetching a different random ordering
2. **Reset `useEffect`:** When random sort is active, check if React Query already has cached data for `dataQueryKey` (survives unmount via stable key hashing). If data exists, skip the reset entirely

Non-random sorts are completely unaffected — both guards are skipped.

**`src/renderer/components/item-list/helpers/item-list-paginated-loader.ts`**

When random sort is active, `staleTime` and `gcTime` are extended to 10 minutes (from the default 15s), so the cached page survives navigation away and back without re-fetching. Explicit Refresh still works — `invalidateQueries()` forces re-fetch regardless of `staleTime`.

## Why this works

- React Query hashes query keys deterministically — loaded pages in the infinite loader survive unmount (within cache lifetime)
- Scroll position is already restored via `useScrollStore` on `POP` navigation
- The explicit Refresh button still works — it intentionally resets data and re-fetches
- Filter/sort changes produce a new query key, naturally triggering a fresh fetch

## Testing

- [x] Navigate to Artists with sort set to Random
- [x] Click an artist → detail view loads
- [x] Navigate back → the same random order is preserved
- [x] Click Refresh → a new random order is fetched
- [x] Switch sort to Name → normal deterministic order
- [x] Switch back to Random → new random order

*AI-assisted Pull Request*