### PR TITLE
feat: allow setting the initial type of item displayed in the favorites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
-node_modules
-dist
-out
+*.log*
 .DS_Store
 .eslintcache
-*.log*
+.nvmrc
+dist
+node_modules
+out
+pnpm-workspace.yaml
 release

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -856,6 +856,8 @@
         "exportImportSettings_offendingKeyError": "\"{{offendingKey}}\" is incorrect - {{reason}}",
         "externalLinks_description": "Enables showing external links (Last.fm, MusicBrainz) on artist/album pages",
         "externalLinks": "Show external links",
+        "favoritesInitialType_description": "Sets the initial type of item to display in the favorites",
+        "favoritesInitialType": "Favorites initial type",
         "followCurrentSong_description": "Automatically scroll the play queue to the current playing song",
         "followCurrentSong": "Follow current song",
         "followLyric_description": "Scroll the lyric to the current playing position",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -861,6 +861,8 @@
         "homeFeatureStyle": "Style du carrousel de la page d’accueil",
         "homeFeatureStyle_optionMultiple": "Multiple",
         "homeFeatureStyle_optionSingle": "Simple",
+        "favoritesInitialType_description": "Contrôle le type d'élément favori à afficher initialement",
+        "favoritesInitialType": "Affichage initial des favoris",
         "blurExplicitImages": "Flouter les images explicites",
         "blurExplicitImages_description": "Les pochettes de titre et d'albums étiquetées comme explicites seront floutées",
         "enableGridMultiSelect": "Activer la sélection multiple dans la grille",

--- a/src/renderer/features/favorites/components/favorites-content.tsx
+++ b/src/renderer/features/favorites/components/favorites-content.tsx
@@ -27,11 +27,31 @@ export const FavoritesContent = ({ itemType }: FavoritesContentProps) => {
     return (
         <AnimatedPage>
             <Suspense fallback={<Spinner container />}>
+                {itemType === LibraryItem.ALBUM_ARTIST && <ArtistFavorites />}
                 {itemType === LibraryItem.ALBUM && <AlbumFavorites />}
                 {itemType === LibraryItem.SONG && <SongFavorites />}
-                {itemType === LibraryItem.ALBUM_ARTIST && <ArtistFavorites />}
             </Suspense>
         </AnimatedPage>
+    );
+};
+
+const ArtistFavorites = () => {
+    const { display, grid, itemsPerPage, pagination, table } = useListSettings(ItemListKey.ARTIST);
+    const { customFilters } = useListContext();
+
+    const albumArtistQuery: OverrideAlbumArtistListQuery = {
+        ...(customFilters as OverrideAlbumArtistListQuery),
+    };
+
+    return (
+        <AlbumArtistListView
+            display={display}
+            grid={grid}
+            itemsPerPage={itemsPerPage}
+            overrideQuery={albumArtistQuery}
+            pagination={pagination}
+            table={table}
+        />
     );
 };
 
@@ -69,26 +89,6 @@ const SongFavorites = () => {
             grid={grid}
             itemsPerPage={itemsPerPage}
             overrideQuery={songQuery}
-            pagination={pagination}
-            table={table}
-        />
-    );
-};
-
-const ArtistFavorites = () => {
-    const { display, grid, itemsPerPage, pagination, table } = useListSettings(ItemListKey.ARTIST);
-    const { customFilters } = useListContext();
-
-    const albumArtistQuery: OverrideAlbumArtistListQuery = {
-        ...(customFilters as OverrideAlbumArtistListQuery),
-    };
-
-    return (
-        <AlbumArtistListView
-            display={display}
-            grid={grid}
-            itemsPerPage={itemsPerPage}
-            overrideQuery={albumArtistQuery}
             pagination={pagination}
             table={table}
         />

--- a/src/renderer/features/favorites/components/favorites-header.tsx
+++ b/src/renderer/features/favorites/components/favorites-header.tsx
@@ -31,8 +31,8 @@ export const FavoritesHeader = ({ itemType }: FavoritesHeaderProps) => {
     const { customFilters, itemCount } = useListContext();
     const navigate = useNavigate();
 
-    const albumFilters = useAlbumListFilters();
     const albumArtistFilters = useAlbumArtistListFilters();
+    const albumFilters = useAlbumListFilters();
     const songFilters = useSongListFilters();
 
     const playQuery = useMemo(() => {
@@ -53,18 +53,18 @@ export const FavoritesHeader = ({ itemType }: FavoritesHeaderProps) => {
             ...query,
             ...(customFilters ?? {}),
         };
-    }, [albumFilters.query, albumArtistFilters.query, songFilters.query, customFilters, itemType]);
+    }, [albumArtistFilters.query, albumFilters.query, songFilters.query, customFilters, itemType]);
 
     const handleItemTypeChange = useCallback(
         (type: LibraryItem) => {
+            albumArtistFilters.clear();
             albumFilters.clear();
             songFilters.clear();
-            albumArtistFilters.clear();
 
             // Clear all URL search params except 'type'
             navigate(`?type=${type}`, { replace: true });
         },
-        [albumFilters, albumArtistFilters, songFilters, navigate],
+        [albumArtistFilters, albumFilters, songFilters, navigate],
     );
 
     return (
@@ -84,12 +84,12 @@ export const FavoritesHeader = ({ itemType }: FavoritesHeaderProps) => {
                                             <Icon icon="dropdown" size="xl" />
                                         </Group>
                                         <Text isMuted size="sm">
-                                            {itemType === LibraryItem.ALBUM &&
-                                                t('entity.album', {
-                                                    count: 2,
-                                                })}
                                             {itemType === LibraryItem.ALBUM_ARTIST &&
                                                 t('entity.artist', {
+                                                    count: 2,
+                                                })}
+                                            {itemType === LibraryItem.ALBUM &&
+                                                t('entity.album', {
                                                     count: 2,
                                                 })}
                                             {itemType === LibraryItem.SONG &&
@@ -101,11 +101,13 @@ export const FavoritesHeader = ({ itemType }: FavoritesHeaderProps) => {
                                 </DropdownMenu.Target>
                                 <DropdownMenu.Dropdown>
                                     <DropdownMenu.Item
-                                        isSelected={itemType === LibraryItem.SONG}
-                                        leftSection={<Icon icon="track" size="xl" />}
-                                        onClick={() => handleItemTypeChange(LibraryItem.SONG)}
+                                        isSelected={itemType === LibraryItem.ALBUM_ARTIST}
+                                        leftSection={<Icon icon="artist" size="xl" />}
+                                        onClick={() =>
+                                            handleItemTypeChange(LibraryItem.ALBUM_ARTIST)
+                                        }
                                     >
-                                        {t('entity.track', {
+                                        {t('entity.artist', {
                                             count: 2,
                                         })}
                                     </DropdownMenu.Item>
@@ -119,13 +121,11 @@ export const FavoritesHeader = ({ itemType }: FavoritesHeaderProps) => {
                                         })}
                                     </DropdownMenu.Item>
                                     <DropdownMenu.Item
-                                        isSelected={itemType === LibraryItem.ALBUM_ARTIST}
-                                        leftSection={<Icon icon="artist" size="xl" />}
-                                        onClick={() =>
-                                            handleItemTypeChange(LibraryItem.ALBUM_ARTIST)
-                                        }
+                                        isSelected={itemType === LibraryItem.SONG}
+                                        leftSection={<Icon icon="track" size="xl" />}
+                                        onClick={() => handleItemTypeChange(LibraryItem.SONG)}
                                     >
-                                        {t('entity.artist', {
+                                        {t('entity.track', {
                                             count: 2,
                                         })}
                                     </DropdownMenu.Item>
@@ -142,8 +142,8 @@ export const FavoritesHeader = ({ itemType }: FavoritesHeaderProps) => {
                 </Flex>
             </PageHeader>
             <FilterBar>
-                {itemType === LibraryItem.ALBUM && <AlbumListHeaderFilters />}
                 {itemType === LibraryItem.ALBUM_ARTIST && <AlbumArtistListHeaderFilters />}
+                {itemType === LibraryItem.ALBUM && <AlbumListHeaderFilters />}
                 {itemType === LibraryItem.SONG && <SongListHeaderFilters />}
             </FilterBar>
         </Stack>

--- a/src/renderer/features/favorites/routes/favorites-route.tsx
+++ b/src/renderer/features/favorites/routes/favorites-route.tsx
@@ -6,12 +6,14 @@ import { FavoritesContent } from '/@/renderer/features/favorites/components/favo
 import { FavoritesHeader } from '/@/renderer/features/favorites/components/favorites-header';
 import { AnimatedPage } from '/@/renderer/features/shared/components/animated-page';
 import { PageErrorBoundary } from '/@/renderer/features/shared/components/page-error-boundary';
+import { useFavoritesInitialType } from '/@/renderer/store';
 import { LibraryItem } from '/@/shared/types/domain-types';
 import { ItemListKey } from '/@/shared/types/types';
 
 const FavoritesRoute = () => {
     const [searchParams] = useSearchParams();
-    const itemType = (searchParams.get('type') as LibraryItem) || LibraryItem.SONG;
+    const initialType = useFavoritesInitialType();
+    const itemType = (searchParams.get('type') as LibraryItem) || initialType;
 
     const [itemCount, setItemCount] = useState<number | undefined>(undefined);
 

--- a/src/renderer/features/settings/components/general/application-settings.tsx
+++ b/src/renderer/features/settings/components/general/application-settings.tsx
@@ -17,6 +17,7 @@ import {
     SettingsSection,
 } from '/@/renderer/features/settings/components/settings-section';
 import {
+    FavoritesInitialType,
     HomeFeatureStyle,
     SideQueueLayout,
     SideQueueType,
@@ -32,6 +33,7 @@ import { Select } from '/@/shared/components/select/select';
 import { Slider } from '/@/shared/components/slider/slider';
 import { Switch } from '/@/shared/components/switch/switch';
 import { toast } from '/@/shared/components/toast/toast';
+import { LibraryItem } from '/@/shared/types/domain-types';
 import { FontType } from '/@/shared/types/types';
 
 const localSettings = isElectron() ? window.api.localSettings : null;
@@ -51,6 +53,27 @@ const HOME_FEATURE_STYLE_OPTIONS = [
             context: 'optionMultiple',
         }),
         value: HomeFeatureStyle.MULTIPLE,
+    },
+];
+
+const FAVORITES_INITIAL_TYPE_OPTIONS = [
+    {
+        label: t('entity.artist', {
+            count: 2,
+        }),
+        value: LibraryItem.ALBUM_ARTIST,
+    },
+    {
+        label: t('entity.album', {
+            count: 2,
+        }),
+        value: LibraryItem.ALBUM,
+    },
+    {
+        label: t('entity.track', {
+            count: 2,
+        }),
+        value: LibraryItem.SONG,
     },
 ];
 
@@ -396,6 +419,27 @@ export const ApplicationSettings = memo(() => {
             }),
             isHidden: false,
             title: t('setting.homeFeatureStyle'),
+        },
+        {
+            control: (
+                <Select
+                    data={FAVORITES_INITIAL_TYPE_OPTIONS}
+                    defaultValue={settings.favoritesInitialType}
+                    onChange={(e) => {
+                        setSettings({
+                            general: {
+                                ...settings,
+                                favoritesInitialType: e as FavoritesInitialType,
+                            },
+                        });
+                    }}
+                />
+            ),
+            description: t('setting.favoritesInitialType', {
+                context: 'description',
+            }),
+            isHidden: false,
+            title: t('setting.favoritesInitialType'),
         },
         {
             control: (

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -163,6 +163,12 @@ const BindingActionsSchema = z.enum([
     'listShowPlayingSong',
 ]);
 
+const FavoritesInitialTypeSchema = z.enum([
+    LibraryItem.ALBUM_ARTIST,
+    LibraryItem.ARTIST,
+    LibraryItem.SONG,
+]);
+
 const DiscordDisplayTypeSchema = z.enum(['artist', 'feishin', 'song']);
 
 const DiscordLinkTypeSchema = z.enum(['last_fm', 'musicbrainz', 'musicbrainz_last_fm', 'none']);
@@ -467,6 +473,7 @@ export const GeneralSettingsSchema = z.object({
     disabledContextMenu: z.record(z.string(), z.boolean()),
     enableGridMultiSelect: z.boolean(),
     externalLinks: z.boolean(),
+    favoritesInitialType: FavoritesInitialTypeSchema,
     followCurrentSong: z.boolean(),
     followSystemTheme: z.boolean(),
     genreTarget: GenreTargetSchema,
@@ -891,6 +898,9 @@ export type DataGridProps = {
 };
 
 export type DataTableProps = z.infer<typeof ItemTableListPropsSchema>;
+
+export type FavoritesInitialType = z.infer<typeof FavoritesInitialTypeSchema>;
+
 export type ItemDetailListProps = z.infer<typeof ItemDetailListPropsSchema>;
 export type ItemListSettings = {
     detail?: ItemDetailListProps;
@@ -1157,6 +1167,7 @@ const initialState: SettingsState = {
         disabledContextMenu: {},
         enableGridMultiSelect: false,
         externalLinks: true,
+        favoritesInitialType: LibraryItem.SONG,
         followCurrentSong: true,
         followSystemTheme: false,
         genreTarget: GenreTarget.TRACK,
@@ -2605,6 +2616,9 @@ export const useThemeSettings = () =>
         }),
         shallow,
     );
+
+export const useFavoritesInitialType = () =>
+    useSettingsStore((state) => state.general.favoritesInitialType, shallow);
 
 export const useSideQueueType = () =>
     useSettingsStore((state) => state.general.sideQueueType, shallow);


### PR DESCRIPTION
Hello Jeff & everybody!

First of all, thanks a lot for creating Feishin! After finally ditching Spotify, I've also recently moved my home server from Plex to the Jellyfin ecosystem, and Feishin is now by far my favorite music player <3

I'm not entirely sure about the PR etiquette here, but since I was scratching my own itch, I figured I might as well share this little change with the community. Long story short: most of the time, I listen to (and favorite) entire albums rather than single tracks, so I wanted to see my favorite albums directly in Feishin. Then again, to each their own. So there: same default, but this is now configurable \o/

Also, since I'm usually more of a Python guy, don't hesitate to let me know if something I did here was not great ^^