### PR TITLE
Fetch discord image from lastfm if showServerImage is disabled & we have a key

### DIFF
--- a/src/renderer/features/discord-rpc/use-discord-rpc.ts
+++ b/src/renderer/features/discord-rpc/use-discord-rpc.ts
@@ -15,7 +15,6 @@ import {
     DiscordLinkType,
     useAppStore,
     useDiscordSettings,
-    useGeneralSettings,
     useLastfmApiKey,
     usePlayerSong,
     usePlayerStore,
@@ -48,7 +47,6 @@ const truncate = (field: string) =>
 
 export const useDiscordRpc = () => {
     const discordSettings = useDiscordSettings();
-    const generalSettings = useGeneralSettings();
     const lastfmApiKey = useLastfmApiKey();
     const privateMode = useAppStore((state) => state.privateMode);
     const [lastUniqueId, setlastUniqueId] = useState('');
@@ -287,8 +285,7 @@ export const useDiscordRpc = () => {
             }
 
             if (
-                (activity.largeImageKey === undefined ||
-                    (generalSettings.lastfmApiKey && !discordSettings.showServerImage)) &&
+                (activity.largeImageKey === undefined || !discordSettings.showServerImage) &&
                 lastfmApiKey &&
                 song?.album &&
                 song?.albumArtists.length

--- a/src/renderer/features/discord-rpc/use-discord-rpc.ts
+++ b/src/renderer/features/discord-rpc/use-discord-rpc.ts
@@ -15,6 +15,7 @@ import {
     DiscordLinkType,
     useAppStore,
     useDiscordSettings,
+    useGeneralSettings,
     useLastfmApiKey,
     usePlayerSong,
     usePlayerStore,
@@ -47,6 +48,7 @@ const truncate = (field: string) =>
 
 export const useDiscordRpc = () => {
     const discordSettings = useDiscordSettings();
+    const generalSettings = useGeneralSettings();
     const lastfmApiKey = useLastfmApiKey();
     const privateMode = useAppStore((state) => state.privateMode);
     const [lastUniqueId, setlastUniqueId] = useState('');
@@ -285,7 +287,8 @@ export const useDiscordRpc = () => {
             }
 
             if (
-                activity.largeImageKey === undefined &&
+                (activity.largeImageKey === undefined ||
+                    (generalSettings.lastfmApiKey && !discordSettings.showServerImage)) &&
                 lastfmApiKey &&
                 song?.album &&
                 song?.albumArtists.length


### PR DESCRIPTION
Fixes #2143

If showServerImage  is disabled (which is the setting to say if discord should use the image from your server or not), and we have a lastfm key then pull from lastfm to get an image.