### PR TITLE
feat(playlists): add `isMissing` and `isPresent` operators to Navidrome smart playlist form

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -314,6 +314,8 @@
         "inTheRangeDate": "Is in the range (date)",
         "is": "Is",
         "isNot": "Is not",
+        "isMissing": "Is missing",
+        "isPresent": "Is present",
         "isGreaterThan": "Is greater than",
         "isLessThan": "Is less than",
         "matchesRegex": "Matches regex",

--- a/src/renderer/components/query-builder/query-builder-option.tsx
+++ b/src/renderer/components/query-builder/query-builder-option.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { Filters } from '/@/renderer/components/query-builder';
 import { ActionIcon } from '/@/shared/components/action-icon/action-icon';
@@ -102,19 +102,28 @@ const QueryValueInput = ({
     const isDatePickerOperator =
         operator === 'beforeDate' || operator === 'afterDate' || operator === 'inTheRangeDate';
 
+    const BooleanSelectComponent = useMemo(
+        () => (
+            <Select
+                data={[
+                    { label: 'true', value: 'true' },
+                    { label: 'false', value: 'false' },
+                ]}
+                onChange={onChange}
+                value={value}
+                {...props}
+            />
+        ),
+        [onChange, props, value],
+    );
+
+    if (operator === 'isMissing' || operator === 'isPresent') {
+        return BooleanSelectComponent;
+    }
+
     switch (type) {
         case 'boolean':
-            return (
-                <Select
-                    data={[
-                        { label: 'true', value: 'true' },
-                        { label: 'false', value: 'false' },
-                    ]}
-                    onChange={onChange}
-                    value={value}
-                    {...props}
-                />
-            );
+            return BooleanSelectComponent;
         case 'date':
             if (isDatePickerOperator && operator !== 'inTheRangeDate') {
                 const dateValue = value ? parseDateValue(value) : null;

--- a/src/shared/api/navidrome/navidrome-types.ts
+++ b/src/shared/api/navidrome/navidrome-types.ts
@@ -216,6 +216,17 @@ export const NDSongQueryPlaylistOperators = [
     },
 ];
 
+const NDPresenceOperators = [
+    {
+        label: i18n.t('filterOperator.isMissing'),
+        value: 'isMissing',
+    },
+    {
+        label: i18n.t('filterOperator.isPresent'),
+        value: 'isPresent',
+    }
+]
+
 export const NDSongQueryDateOperators = [
     {
         label: i18n.t('filterOperator.is'),
@@ -225,6 +236,7 @@ export const NDSongQueryDateOperators = [
         label: i18n.t('filterOperator.isNot'),
         value: 'isNot',
     },
+    ...NDPresenceOperators,
     {
         label: i18n.t('filterOperator.before'),
         value: 'before',
@@ -268,6 +280,7 @@ export const NDSongQueryStringOperators = [
         label: i18n.t('filterOperator.isNot'),
         value: 'isNot',
     },
+    ...NDPresenceOperators,
     {
         label: i18n.t('filterOperator.contains'),
         value: 'contains',
@@ -295,6 +308,7 @@ export const NDSongQueryBooleanOperators = [
         label: i18n.t('filterOperator.isNot'),
         value: 'isNot',
     },
+    ...NDPresenceOperators,
 ];
 
 export const NDSongQueryNumberOperators = [
@@ -306,6 +320,7 @@ export const NDSongQueryNumberOperators = [
         label: i18n.t('filterOperator.isNot'),
         value: 'isNot',
     },
+    ...NDPresenceOperators,
     {
         label: i18n.t('filterOperator.contains'),
         value: 'contains',

--- a/src/shared/api/navidrome/navidrome-types.ts
+++ b/src/shared/api/navidrome/navidrome-types.ts
@@ -224,8 +224,8 @@ const NDPresenceOperators = [
     {
         label: i18n.t('filterOperator.isPresent'),
         value: 'isPresent',
-    }
-]
+    },
+];
 
 export const NDSongQueryDateOperators = [
     {


### PR DESCRIPTION
Addresses #2138

# Summary

These changes add support for the `isMissing` and `isPresent` smart playlist operators introduced in [Navidrome v0.62.0](https://github.com/navidrome/navidrome/releases/tag/v0.62.0). 

# Testing

I have manually tested these changes in my development environment against my Navidrome server. I successfully created two smart playlists that show all tracks with the `genre` tag missing/present.

# Media

<img width="1129" height="588" alt="image" src="https://github.com/user-attachments/assets/d5731fa0-1a33-4f82-9ea4-7af4059a87d3" />
<img width="613" height="595" alt="image" src="https://github.com/user-attachments/assets/a8fc5e69-53c5-4538-99d7-9c71294dee94" />
<img width="534" height="247" alt="image" src="https://github.com/user-attachments/assets/2f3548fa-e14a-48a7-95b6-7bbadf559371" />

