### PR TITLE
fix: recognize function keys (F1–F24) when assigning hotkeys

### DIFF
--- a/src/shared/utils/keyboard-code-to-hotkey.ts
+++ b/src/shared/utils/keyboard-code-to-hotkey.ts
@@ -61,6 +61,10 @@ export const keyboardCodeToHotkeyKey = (code: string): null | string => {
         return code.slice(5);
     }
 
+    if (/^F([1-9]|1\d|2[0-4])$/.test(code)) {
+        return code.toLowerCase();
+    }
+
     if (code.startsWith('Numpad')) {
         const suffix = code.slice(6);
         const numpadMapped = NUMPAD_CODE_TO_HOTKEY_KEY[suffix];


### PR DESCRIPTION
## Problem

Function keys can't be assigned as hotkeys. A user with rotary-encoder keys mapped to **F21/F22** found that pressing them in **Settings → Hotkeys** does nothing — the keypress is silently ignored. In fact this affects **every** function key (F1–F24), not just F13+.

## Root cause

`keyboardCodeToHotkeyKey` (`src/shared/utils/keyboard-code-to-hotkey.ts`) has branches for `Key*`, `Digit*`, and `Numpad*` codes plus a fixed lookup table, but **no branch for function keys**. `KeyboardEvent.code` values `"F1"`…`"F24"` therefore fall through to `return null`, and the capture handler (`hotkey-manager-settings.tsx`) drops any key that maps to `null`.

## Fix

Add a function-key branch that maps `F1`–`F24` to their lowercase form, consistent with how every other hotkey is stored (`mod+k`, `enter`, `space`, …):

```ts
if (/^F([1-9]|1\d|2[0-4])$/.test(code)) {
    return code.toLowerCase();
}
```

No other changes are needed:
- **Renderer (local shortcuts):** `toPhysicalHotkey` leaves `f21` untouched, and Mantine's `usePhysicalKeys` matching normalizes `KeyboardEvent.code` `"F21"` → `"f21"`, so it matches.
- **Main (global shortcuts + menu accelerators):** `hotkeyToElectronAccelerator` passes `f21` through unchanged, and Electron's `globalShortcut` accepts F1–F24 (the menu already uses `F11`).

## Testing

- Settings → Hotkeys → edit a binding → press a function key → the field now records it (e.g. `f21`, `mod+f21`, `shift+f21`).
- Assigned function keys fire correctly as both local and global shortcuts.


Closes #2156 