### PR TITLE
discord rpc small fix: apply displayType via activity name field

### DIFF
--- a/src/renderer/features/discord-rpc/use-discord-rpc.ts
+++ b/src/renderer/features/discord-rpc/use-discord-rpc.ts
@@ -192,16 +192,28 @@ export const useDiscordRpc = () => {
                 [DiscordDisplayType.SONG_NAME]: DiscordStatusDisplayType.DETAILS,
             };
 
+            // Fallback `name` for Discord clients that ignore `status_display_type`.
+            const detailsText = truncate((song?.name && song.name.padEnd(2, ' ')) || 'Idle');
+            const stateText = truncate(
+                (artists && artists.padEnd(2, ' ')) || 'Unknown artist',
+            );
+            const nameByDisplayType: Record<DiscordDisplayType, string | undefined> = {
+                [DiscordDisplayType.ARTIST_NAME]: stateText,
+                [DiscordDisplayType.FEISHIN]: undefined,
+                [DiscordDisplayType.SONG_NAME]: detailsText,
+            };
+
             const activity: SetActivity = {
-                details: truncate((song?.name && song.name.padEnd(2, ' ')) || 'Idle'),
+                details: detailsText,
                 instance: false,
                 largeImageKey: undefined,
                 largeImageText: truncate(
                     (song?.album && song.album.padEnd(2, ' ')) || 'Unknown album',
                 ),
+                name: nameByDisplayType[discordSettings.displayType],
                 smallImageKey: undefined,
                 smallImageText: undefined,
-                state: truncate((artists && artists.padEnd(2, ' ')) || 'Unknown artist'),
+                state: stateText,
                 statusDisplayType: statusDisplayMap[discordSettings.displayType],
                 // I would love to use the actual type as opposed to hardcoding to 2,
                 // but manually installing the discord-types package appears to break things


### PR DESCRIPTION
The "Discord presence display type" setting in v1.13.0 had no effect on the
Discord activity header for some clients (e.g. Flatpak `com.discordapp.Discord`
v1.0.142). The header always rendered `Listening to Feishin` regardless of the
dropdown value.

Cause: those Discord clients ignore the `status_display_type` field on the
RPC activity, which is the only signal Feishin was sending to override the
header. The wire payload reaches Discord correctly (verified with a runtime
log on the main process) — the client just doesn't act on it.

Fix: set `activity.name` per `displayType` in addition to the existing
`statusDisplayType`. For `LISTENING` activities (type 2), Discord renders
`Listening to <name>`, and clients that don't recognize `status_display_type`
still honor `name`. Newer clients that read `status_display_type` continue
to work unchanged.

| displayType   | `name` sent     | Behavior on legacy client      |
| ------------- | --------------- | ------------------------------ |
| `ARTIST_NAME` | `<artists>`     | `Listening to <artists>`       |
| `SONG_NAME`   | `<song name>`   | `Listening to <song name>`     |
| `FEISHIN`     | `undefined`     | `Listening to Feishin` (default) |