### PR TITLE
feat(player): add Listen Together synchronized playback

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
         "postinstall": "electron-builder install-app-deps",
         "lint": "pnpm run typecheck && pnpm run lint-code && pnpm run lint-styles",
         "lint:fix": "pnpm run lint-code:fix && pnpm run lint-styles:fix",
+        "test": "vitest run",
+        "test:watch": "vitest",
         "lint-code": "eslint --max-warnings=0 --cache .",
         "lint-code:fix": "eslint --cache --fix .",
         "lint-styles": "stylelint --max-warnings=0 'src/**/*.{css,scss}'",
@@ -183,7 +185,8 @@
         "vite-plugin-conditional-import": "^0.1.7",
         "vite-plugin-dynamic-import": "^1.6.0",
         "vite-plugin-ejs": "^1.7.0",
-        "vite-plugin-pwa": "^1.3.0"
+        "vite-plugin-pwa": "^1.3.0",
+        "vitest": "^3.2.6"
     },
     "packageManager": "pnpm@11.5.2",
     "productName": "feishin"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -343,6 +343,9 @@ importers:
       vite-plugin-pwa:
         specifier: ^1.3.0
         version: 1.3.0(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.48.0))(workbox-build@7.3.0(@types/babel__core@7.20.5))(workbox-window@7.3.0)
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@24.13.1)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.48.0)
 
 packages:
 
@@ -2113,8 +2116,14 @@ packages:
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/electron-localshortcut@3.1.3':
     resolution: {integrity: sha512-D+CRdDTRZ4/9UmcSaZ5qvW4uq2VyyVmqsH9cdNReB4CL6MSIgyhr9w2PKeNEb0J/ZS7db7irJM/+ZiA5uSQsLw==}
@@ -2249,6 +2258,35 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  '@vitest/expect@3.2.6':
+    resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
+
+  '@vitest/mocker@3.2.6':
+    resolution: {integrity: sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.6':
+    resolution: {integrity: sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==}
+
+  '@vitest/runner@3.2.6':
+    resolution: {integrity: sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==}
+
+  '@vitest/snapshot@3.2.6':
+    resolution: {integrity: sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==}
+
+  '@vitest/spy@3.2.6':
+    resolution: {integrity: sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==}
+
+  '@vitest/utils@3.2.6':
+    resolution: {integrity: sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==}
+
   '@vladfrangu/async_event_emitter@2.4.7':
     resolution: {integrity: sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==}
     engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
@@ -2379,6 +2417,10 @@ packages:
   asn1js@3.0.10:
     resolution: {integrity: sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==}
     engines: {node: '>=12.0.0'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
@@ -2599,12 +2641,20 @@ packages:
   caniuse-lite@1.0.30001797:
     resolution: {integrity: sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
   charenc@0.0.2:
     resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   cheerio-select@2.1.0:
     resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
@@ -2829,6 +2879,10 @@ packages:
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deep-equal@1.1.2:
     resolution: {integrity: sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==}
@@ -3202,6 +3256,9 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -3211,6 +3268,10 @@ packages:
 
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
@@ -3881,6 +3942,9 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
@@ -4036,6 +4100,9 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
@@ -4433,6 +4500,13 @@ packages:
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   pause-stream@0.0.11:
     resolution: {integrity: sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==}
@@ -5008,6 +5082,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -5085,9 +5162,15 @@ packages:
     resolution: {integrity: sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stat-mode@1.0.0:
     resolution: {integrity: sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==}
     engines: {node: '>= 6'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -5157,6 +5240,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   strnum@2.3.0:
     resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
@@ -5289,9 +5375,27 @@ packages:
   tiny-typed-emitter@2.1.0:
     resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
@@ -5499,6 +5603,11 @@ packages:
     resolution: {integrity: sha512-0QwqXteBNXgnLCdWdvPQBX6FXRHtIH3VhJPTd5Lwn28tJXc34YqSCWUmkOvtJHBmB3gGoPtrOKk3Ts8/kEZ9aA==}
     engines: {node: '>=10.13.0'}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite-plugin-conditional-import@0.1.7:
     resolution: {integrity: sha512-q1galZvTv2K0Sjo+41AlXIatqA5ai6njfU+vO4Gn399c5Q7skvNU250J5baQDNdRL6iOMl+IgfYGNMYN1n2rSA==}
 
@@ -5562,6 +5671,34 @@ packages:
       yaml:
         optional: true
 
+  vitest@3.2.6:
+    resolution: {integrity: sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.6
+      '@vitest/ui': 3.2.6
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
@@ -5622,6 +5759,11 @@ packages:
   which@5.0.0:
     resolution: {integrity: sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -7573,9 +7715,16 @@ snapshots:
       '@types/node': 24.13.1
       '@types/responselike': 1.0.3
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/electron-localshortcut@3.1.3':
     dependencies:
@@ -7748,6 +7897,48 @@ snapshots:
       vite: 7.3.5(@types/node@24.13.1)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.48.0)
     transitivePeerDependencies:
       - supports-color
+
+  '@vitest/expect@3.2.6':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.6(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.48.0))':
+    dependencies:
+      '@vitest/spy': 3.2.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.5(@types/node@24.13.1)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.48.0)
+
+  '@vitest/pretty-format@3.2.6':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.6':
+    dependencies:
+      '@vitest/utils': 3.2.6
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.6':
+    dependencies:
+      '@vitest/pretty-format': 3.2.6
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.6':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.6':
+    dependencies:
+      '@vitest/pretty-format': 3.2.6
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@vladfrangu/async_event_emitter@2.4.7': {}
 
@@ -7941,6 +8132,8 @@ snapshots:
       pvtsutils: 1.3.6
       pvutils: 1.1.5
       tslib: 2.8.1
+
+  assertion-error@2.0.1: {}
 
   astral-regex@2.0.0: {}
 
@@ -8203,12 +8396,22 @@ snapshots:
 
   caniuse-lite@1.0.30001797: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
   charenc@0.0.2: {}
+
+  check-error@2.1.3: {}
 
   cheerio-select@2.1.0:
     dependencies:
@@ -8437,6 +8640,8 @@ snapshots:
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
+
+  deep-eql@5.0.2: {}
 
   deep-equal@1.1.2:
     dependencies:
@@ -9021,6 +9226,10 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
 
   event-stream@3.3.4:
@@ -9038,6 +9247,8 @@ snapshots:
       bare-events: 2.9.1
     transitivePeerDependencies:
       - bare-abort-controller
+
+  expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
 
@@ -9760,6 +9971,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
@@ -9889,6 +10102,8 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  loupe@3.2.1: {}
 
   lowercase-keys@2.0.0: {}
 
@@ -10281,6 +10496,10 @@ snapshots:
       minipass: 7.1.3
 
   path-type@4.0.0: {}
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   pause-stream@0.0.11:
     dependencies:
@@ -10875,6 +11094,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -10949,7 +11170,11 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
+  stackback@0.0.2: {}
+
   stat-mode@1.0.0: {}
+
+  std-env@3.10.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -11067,6 +11292,10 @@ snapshots:
   strip-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
 
   strnum@2.3.0: {}
 
@@ -11262,10 +11491,20 @@ snapshots:
 
   tiny-typed-emitter@2.1.0: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   tmp-promise@3.0.3:
     dependencies:
@@ -11507,6 +11746,27 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
+  vite-node@3.2.4(@types/node@24.13.1)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.48.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.5(@types/node@24.13.1)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.48.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-plugin-conditional-import@0.1.7:
     dependencies:
       es-module-lexer: 1.5.0
@@ -11549,6 +11809,48 @@ snapshots:
       jiti: 2.7.0
       sugarss: 5.0.1(postcss@8.5.15)
       terser: 5.48.0
+
+  vitest@3.2.6(@types/debug@4.1.13)(@types/node@24.13.1)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.48.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.6
+      '@vitest/mocker': 3.2.6(vite@7.3.5(@types/node@24.13.1)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.48.0))
+      '@vitest/pretty-format': 3.2.6
+      '@vitest/runner': 3.2.6
+      '@vitest/snapshot': 3.2.6
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.5(@types/node@24.13.1)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.48.0)
+      vite-node: 3.2.4(@types/node@24.13.1)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.48.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.13
+      '@types/node': 24.13.1
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   void-elements@3.1.0: {}
 
@@ -11639,6 +11941,11 @@ snapshots:
   which@5.0.0:
     dependencies:
       isexe: 3.1.5
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1448,6 +1448,10 @@
         "statusLive": "live",
         "statusOffline": "offline",
         "title": "Listen Together",
-        "you": "(you)"
+        "you": "(you)",
+        "cancel": "Cancel",
+        "controlRequestBody": "{{username}} wants to control playback.",
+        "controlRequestTitle": "Control requested",
+        "setUrlInSettings": "Set the sync server URL in Settings → Playback."
     }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -630,7 +630,8 @@
             "transcoding": "Transcoding",
             "discord": "Discord",
             "logger": "Logger",
-            "playerFilters": "Player Filters"
+            "playerFilters": "Player Filters",
+            "listenTogether": "Listen Together"
         },
         "sidebar": {
             "albumArtists": "$t(entity.albumArtist, {\"count\": 2})",
@@ -1143,7 +1144,11 @@
         "queryBuilderCustomFields_inputLabel": "Label",
         "queryBuilderCustomFields_inputTag": "Tag",
         "queryBuilderCustomFields": "Custom fields",
-        "queryBuilderCustomFields_description": "Add custom fields to use in query builders"
+        "queryBuilderCustomFields_description": "Add custom fields to use in query builders",
+        "enableListenTogether": "Enable Listen Together",
+        "enableListenTogether_description": "Synchronize playback with friends in a shared room. Adds a Listen Together control to the player bar. Turning this off leaves any active room and disconnects.",
+        "listenTogetherUrl": "Sync server URL",
+        "listenTogetherUrl_description": "Base URL of the listen-together server. The ws(s):// endpoint is derived automatically."
     },
     "table": {
         "column": {
@@ -1414,5 +1419,35 @@
                 "z": "Z"
             }
         }
+    },
+    "listenTogether": {
+        "clockOffset": "Clock offset",
+        "code": "Code",
+        "controlRequested": "{{username}} requested control",
+        "copied": "Copied",
+        "copy": "Copy",
+        "createRoom": "Create a room",
+        "enabled": "Enabled",
+        "followHost": "Follow host",
+        "giveControl": "Give control",
+        "hostBadge": "host",
+        "join": "Join",
+        "leave": "Leave",
+        "orJoin": "or join",
+        "requestControl": "Request control",
+        "room": "Room {{code}}",
+        "roomCode": "Room code",
+        "roomCodePlaceholder": "G7KQ2M",
+        "save": "Save",
+        "serverUrl": "Sync server URL",
+        "serverUrlPlaceholder": "https://party.example.com",
+        "setUrlFirst": "Set a sync server URL and select a server first",
+        "statusCorrecting": "correcting",
+        "statusDetached": "detached",
+        "statusInSync": "in sync",
+        "statusLive": "live",
+        "statusOffline": "offline",
+        "title": "Listen Together",
+        "you": "(you)"
     }
 }

--- a/src/renderer/api/sync/sync-client.test.ts
+++ b/src/renderer/api/sync/sync-client.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SyncSocket } from './sync-client';
+
+type Listener = (e: { data?: string }) => void;
+
+// A minimal fake WebSocket: records what the client sends and lets a test drive
+// the open/message/close events the SyncSocket listens for.
+class FakeWebSocket {
+    static CLOSED = 3;
+    static last: FakeWebSocket | undefined;
+    static OPEN = 1;
+
+    natural = false;
+    readyState = 0;
+    sent: string[] = [];
+    url: string;
+
+    private listeners: Record<string, Listener[]> = {};
+
+    constructor(url: string) {
+        this.url = url;
+        FakeWebSocket.last = this;
+    }
+
+    addEventListener(type: string, cb: Listener) {
+        (this.listeners[type] ||= []).push(cb);
+    }
+
+    close() {
+        this.readyState = FakeWebSocket.CLOSED;
+        this.emit('close', {});
+    }
+
+    emit(type: string, e: { data?: string }) {
+        (this.listeners[type] || []).forEach((cb) => cb(e));
+    }
+
+    fireMessage(obj: unknown) {
+        this.emit('message', { data: JSON.stringify(obj) });
+    }
+
+    fireOpen() {
+        this.readyState = FakeWebSocket.OPEN;
+        this.emit('open', {});
+    }
+
+    send(data: string) {
+        this.sent.push(data);
+    }
+}
+
+const CREDS = { credential: 'u=alice&s=salt&t=tok', serverUrl: 'https://music.example.com' };
+const WS_URL = 'wss://party.example.com/ws';
+
+let originalWebSocket: unknown;
+
+beforeEach(() => {
+    originalWebSocket = (globalThis as { WebSocket: unknown }).WebSocket;
+    (globalThis as { WebSocket: unknown }).WebSocket = FakeWebSocket;
+    FakeWebSocket.last = undefined;
+});
+
+afterEach(() => {
+    (globalThis as { WebSocket: unknown }).WebSocket = originalWebSocket;
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+});
+
+const lastSocket = () => {
+    const ws = FakeWebSocket.last;
+    if (!ws) throw new Error('no socket created');
+    return ws;
+};
+
+const parseSent = (ws: FakeWebSocket): Array<{ data?: any; event: string }> =>
+    ws.sent.map((s) => JSON.parse(s));
+
+describe('SyncSocket', () => {
+    it('authenticates with parsed credentials on open', () => {
+        const onConnectedChange = vi.fn();
+        const s = new SyncSocket(WS_URL, CREDS, { onConnectedChange });
+        s.connect();
+        const ws = lastSocket();
+        ws.fireOpen();
+
+        const auth = parseSent(ws).find((m) => m.event === 'authenticate');
+        expect(auth?.data).toMatchObject({ salt: 'salt', token: 'tok', username: 'alice' });
+        expect(onConnectedChange).toHaveBeenCalledWith(true);
+        s.close();
+    });
+
+    it('computes the clock offset from a pong', () => {
+        const onClockOffset = vi.fn();
+        const s = new SyncSocket(WS_URL, CREDS, { onClockOffset });
+        s.connect();
+        const ws = lastSocket();
+        ws.fireOpen();
+        ws.fireMessage({ data: { memberId: 'm1', username: 'alice' }, event: 'authenticated' });
+
+        vi.spyOn(Date, 'now').mockReturnValue(1100); // t2 at pong receipt
+        ws.fireMessage({ data: { serverTimeMs: 2000, t0: 1000 }, event: 'pong' });
+
+        // offset = serverTimeMs - (t0 + t2) / 2 = 2000 - (1000 + 1100) / 2 = 950
+        expect(onClockOffset).toHaveBeenCalledWith(950);
+        expect(s.clockOffsetMs).toBe(950);
+        s.close();
+    });
+
+    it('stamps clientTimeMs on an outbound transport', () => {
+        const s = new SyncSocket(WS_URL, CREDS, {});
+        s.connect();
+        const ws = lastSocket();
+        ws.fireOpen();
+        s.sendTransport({ playing: true, positionMs: 0, queueIndex: 0, trackId: 'a' });
+
+        const tr = parseSent(ws).find((m) => m.event === 'transport');
+        expect(typeof tr?.data.clientTimeMs).toBe('number');
+        s.close();
+    });
+
+    it('clears the room when a pending join fails, but not on later errors', () => {
+        const onError = vi.fn();
+        const onRoomClosed = vi.fn();
+        const s = new SyncSocket(WS_URL, CREDS, { onError, onRoomClosed });
+        s.connect();
+        const ws = lastSocket();
+        ws.fireOpen();
+        ws.fireMessage({ data: { memberId: 'm1', username: 'alice' }, event: 'authenticated' });
+
+        s.joinRoom('ABC123');
+        ws.fireMessage({ data: { message: 'room not found: ABC123' }, event: 'error' });
+        expect(onError).toHaveBeenCalledWith('room not found: ABC123');
+        expect(onRoomClosed).toHaveBeenCalledTimes(1);
+
+        // Once a room is established, an unrelated error must not tear it down.
+        s.joinRoom('XYZ789');
+        ws.fireMessage({
+            data: {
+                hostMemberId: 'm1',
+                members: [{ id: 'm1', username: 'alice' }],
+                roomId: 'XYZ789',
+                seq: 1,
+                transport: {
+                    playing: false,
+                    positionMs: 0,
+                    queue: [],
+                    queueIndex: -1,
+                    serverTimeMs: 1,
+                    trackId: '',
+                },
+            },
+            event: 'roomState',
+        });
+        ws.fireMessage({ data: { message: 'cannot pass control' }, event: 'error' });
+        expect(onRoomClosed).toHaveBeenCalledTimes(1);
+        s.close();
+    });
+
+    it('reconnects after an unexpected close', () => {
+        vi.useFakeTimers();
+        const s = new SyncSocket(WS_URL, CREDS, {});
+        s.connect();
+        const ws1 = lastSocket();
+        ws1.fireOpen();
+
+        ws1.close(); // unnatural close schedules a reconnect
+        expect(FakeWebSocket.last).toBe(ws1);
+        vi.advanceTimersByTime(1000); // default backoff
+        expect(FakeWebSocket.last).not.toBe(ws1);
+        s.close();
+    });
+});

--- a/src/renderer/api/sync/sync-client.test.ts
+++ b/src/renderer/api/sync/sync-client.test.ts
@@ -157,8 +157,10 @@ describe('SyncSocket', () => {
         s.close();
     });
 
-    it('reconnects after an unexpected close', () => {
+    it('reconnects (with jittered backoff) after an unexpected close', () => {
         vi.useFakeTimers();
+        // Pin the jitter so the scheduled delay is deterministic: 0.5 * 1000ms backoff.
+        vi.spyOn(Math, 'random').mockReturnValue(0.5);
         const s = new SyncSocket(WS_URL, CREDS, {});
         s.connect();
         const ws1 = lastSocket();
@@ -166,7 +168,9 @@ describe('SyncSocket', () => {
 
         ws1.close(); // unnatural close schedules a reconnect
         expect(FakeWebSocket.last).toBe(ws1);
-        vi.advanceTimersByTime(1000); // default backoff
+        vi.advanceTimersByTime(499); // before the jittered 500ms delay: no reconnect yet
+        expect(FakeWebSocket.last).toBe(ws1);
+        vi.advanceTimersByTime(1); // now past it
         expect(FakeWebSocket.last).not.toBe(ws1);
         s.close();
     });

--- a/src/renderer/api/sync/sync-client.ts
+++ b/src/renderer/api/sync/sync-client.ts
@@ -33,6 +33,10 @@ interface StatefulWebSocket extends WebSocket {
 
 const PING_INTERVAL_MS = 10_000;
 const MAX_BACKOFF_MS = 15_000;
+// How long a min-RTT clock sample stays "best". Within the window the lowest-RTT
+// sample wins (most accurate offset); past it we take the next sample regardless
+// so the offset keeps re-converging as machine clocks drift over a long session.
+const CLOCK_SAMPLE_TTL_MS = 60_000;
 
 export class SyncSocket {
     get clockOffsetMs(): number {
@@ -43,6 +47,7 @@ export class SyncSocket {
     }
     private backoff = 1000;
     private best = { offset: 0, rtt: Number.POSITIVE_INFINITY };
+    private bestAt = 0;
     private readonly callbacks: SyncSocketCallbacks;
     private closedByUser = false;
     private creds: SyncCredentials;
@@ -101,7 +106,9 @@ export class SyncSocket {
     }
 
     sendTransport(input: SyncTransportInput): void {
-        this.send({ data: input, event: 'transport' });
+        // Stamp a fresh monotonic clock at actual send time so the server can
+        // drop transports that arrive out of order.
+        this.send({ data: { ...input, clientTimeMs: Date.now() }, event: 'transport' });
     }
 
     private clearTimers(): void {
@@ -140,8 +147,12 @@ export class SyncSocket {
                 const t2 = Date.now();
                 const rtt = t2 - msg.data.t0;
                 const offset = msg.data.serverTimeMs - (msg.data.t0 + t2) / 2;
-                if (rtt < this.best.rtt) {
+                // Take the sample if it has a lower RTT (more accurate) or if the
+                // current best has aged out, so the offset re-converges over time.
+                const stale = t2 - this.bestAt > CLOCK_SAMPLE_TTL_MS;
+                if (rtt < this.best.rtt || stale) {
                     this.best = { offset, rtt };
+                    this.bestAt = t2;
                     this.callbacks.onClockOffset?.(offset);
                 }
                 break;
@@ -177,6 +188,7 @@ export class SyncSocket {
         socket.addEventListener('close', () => {
             this.clearTimers();
             this.best = { offset: 0, rtt: Number.POSITIVE_INFINITY };
+            this.bestAt = 0;
             this.callbacks.onConnectedChange?.(false);
             if (!socket.natural && !this.closedByUser) this.scheduleReconnect();
         });

--- a/src/renderer/api/sync/sync-client.ts
+++ b/src/renderer/api/sync/sync-client.ts
@@ -24,6 +24,9 @@ export interface SyncSocketCallbacks {
     onConnectedChange?: (connected: boolean) => void;
     onControlRequested?: (fromMemberId: string, fromUsername: string) => void;
     onError?: (message: string) => void;
+    // Fired when a pending create/join fails (e.g. the room was reaped while we
+    // were briefly disconnected). The consumer should clear its room state.
+    onRoomClosed?: () => void;
     onRoomState?: (state: SyncRoomState) => void;
 }
 
@@ -53,6 +56,9 @@ export class SyncSocket {
     private creds: SyncCredentials;
     private desired: { roomId?: string; type: 'create' | 'join' | 'none' } = { type: 'none' };
     private memberId = '';
+    // True between sending a create/join and getting the resulting roomState, so a
+    // failure in that window can be surfaced as a room-closed event.
+    private pendingRoomOp = false;
     private pingTimer?: ReturnType<typeof setInterval>;
     private reconnectTimer?: ReturnType<typeof setTimeout>;
 
@@ -84,16 +90,19 @@ export class SyncSocket {
 
     createRoom(): void {
         this.desired = { type: 'create' };
+        this.pendingRoomOp = true;
         this.send({ event: 'createRoom' });
     }
 
     joinRoom(roomId: string): void {
         this.desired = { roomId, type: 'join' };
+        this.pendingRoomOp = true;
         this.send({ data: { roomId }, event: 'joinRoom' });
     }
 
     leaveRoom(): void {
         this.desired = { type: 'none' };
+        this.pendingRoomOp = false;
         this.send({ event: 'leaveRoom' });
     }
 
@@ -131,8 +140,11 @@ export class SyncSocket {
                 this.callbacks.onAuthenticated?.(msg.data.memberId);
                 this.startClockSync();
                 // Re-establish room membership after a reconnect.
-                if (this.desired.type === 'create') this.send({ event: 'createRoom' });
-                else if (this.desired.type === 'join' && this.desired.roomId) {
+                if (this.desired.type === 'create') {
+                    this.pendingRoomOp = true;
+                    this.send({ event: 'createRoom' });
+                } else if (this.desired.type === 'join' && this.desired.roomId) {
+                    this.pendingRoomOp = true;
                     this.send({ data: { roomId: this.desired.roomId }, event: 'joinRoom' });
                 }
                 break;
@@ -142,6 +154,14 @@ export class SyncSocket {
                 break;
             case 'error':
                 this.callbacks.onError?.(msg.data.message);
+                // A failure while a create/join is in flight (e.g. the room was
+                // reaped during a brief disconnect) means we have no valid room:
+                // stop trying to rejoin it and tell the consumer to clear state.
+                if (this.pendingRoomOp) {
+                    this.pendingRoomOp = false;
+                    this.desired = { type: 'none' };
+                    this.callbacks.onRoomClosed?.();
+                }
                 break;
             case 'pong': {
                 const t2 = Date.now();
@@ -158,6 +178,7 @@ export class SyncSocket {
                 break;
             }
             case 'roomState':
+                this.pendingRoomOp = false;
                 this.callbacks.onRoomState?.(msg.data);
                 break;
         }

--- a/src/renderer/api/sync/sync-client.ts
+++ b/src/renderer/api/sync/sync-client.ts
@@ -1,0 +1,207 @@
+// SyncSocket: the low-level WebSocket client for the listen-together server.
+// It owns the connection lifecycle, authentication, NTP-style clock sync, and
+// reconnect. It is framework-agnostic (no React, no store) — sync.store.ts wraps
+// it and exposes the session to the UI.
+//
+// Modeled on Feishin's existing remote-control client (src/remote/store/index.ts).
+
+import {
+    SyncClientEvent,
+    SyncRoomState,
+    SyncServerEvent,
+    SyncTransportInput,
+} from '/@/shared/types/sync-types';
+
+export interface SyncCredentials {
+    // The Subsonic credential string Feishin stores: "u=<user>&s=<salt>&t=<token>".
+    credential: string;
+    serverUrl: string;
+}
+
+export interface SyncSocketCallbacks {
+    onAuthenticated?: (memberId: string) => void;
+    onClockOffset?: (offsetMs: number) => void;
+    onConnectedChange?: (connected: boolean) => void;
+    onControlRequested?: (fromMemberId: string, fromUsername: string) => void;
+    onError?: (message: string) => void;
+    onRoomState?: (state: SyncRoomState) => void;
+}
+
+interface StatefulWebSocket extends WebSocket {
+    natural: boolean;
+}
+
+const PING_INTERVAL_MS = 10_000;
+const MAX_BACKOFF_MS = 15_000;
+
+export class SyncSocket {
+    get clockOffsetMs(): number {
+        return this.best.offset;
+    }
+    get currentMemberId(): string {
+        return this.memberId;
+    }
+    private backoff = 1000;
+    private best = { offset: 0, rtt: Number.POSITIVE_INFINITY };
+    private readonly callbacks: SyncSocketCallbacks;
+    private closedByUser = false;
+    private creds: SyncCredentials;
+    private desired: { roomId?: string; type: 'create' | 'join' | 'none' } = { type: 'none' };
+    private memberId = '';
+    private pingTimer?: ReturnType<typeof setInterval>;
+    private reconnectTimer?: ReturnType<typeof setTimeout>;
+
+    private socket?: StatefulWebSocket;
+
+    private readonly url: string;
+
+    constructor(url: string, creds: SyncCredentials, callbacks: SyncSocketCallbacks) {
+        this.url = url;
+        this.creds = creds;
+        this.callbacks = callbacks;
+    }
+
+    close(): void {
+        this.closedByUser = true;
+        this.clearTimers();
+        if (this.socket) {
+            this.socket.natural = true;
+            this.socket.close();
+            this.socket = undefined;
+        }
+        this.callbacks.onConnectedChange?.(false);
+    }
+
+    connect(): void {
+        this.closedByUser = false;
+        this.open();
+    }
+
+    createRoom(): void {
+        this.desired = { type: 'create' };
+        this.send({ event: 'createRoom' });
+    }
+
+    joinRoom(roomId: string): void {
+        this.desired = { roomId, type: 'join' };
+        this.send({ data: { roomId }, event: 'joinRoom' });
+    }
+
+    leaveRoom(): void {
+        this.desired = { type: 'none' };
+        this.send({ event: 'leaveRoom' });
+    }
+
+    passControl(toMemberId: string): void {
+        this.send({ data: { toMemberId }, event: 'passControl' });
+    }
+
+    requestControl(): void {
+        this.send({ event: 'requestControl' });
+    }
+
+    sendTransport(input: SyncTransportInput): void {
+        this.send({ data: input, event: 'transport' });
+    }
+
+    private clearTimers(): void {
+        if (this.pingTimer) clearInterval(this.pingTimer);
+        if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+        this.pingTimer = undefined;
+        this.reconnectTimer = undefined;
+    }
+
+    private handleMessage(raw: string): void {
+        let msg: SyncServerEvent;
+        try {
+            msg = JSON.parse(raw) as SyncServerEvent;
+        } catch {
+            return;
+        }
+        switch (msg.event) {
+            case 'authenticated': {
+                this.memberId = msg.data.memberId;
+                this.callbacks.onAuthenticated?.(msg.data.memberId);
+                this.startClockSync();
+                // Re-establish room membership after a reconnect.
+                if (this.desired.type === 'create') this.send({ event: 'createRoom' });
+                else if (this.desired.type === 'join' && this.desired.roomId) {
+                    this.send({ data: { roomId: this.desired.roomId }, event: 'joinRoom' });
+                }
+                break;
+            }
+            case 'controlRequested':
+                this.callbacks.onControlRequested?.(msg.data.fromMemberId, msg.data.fromUsername);
+                break;
+            case 'error':
+                this.callbacks.onError?.(msg.data.message);
+                break;
+            case 'pong': {
+                const t2 = Date.now();
+                const rtt = t2 - msg.data.t0;
+                const offset = msg.data.serverTimeMs - (msg.data.t0 + t2) / 2;
+                if (rtt < this.best.rtt) {
+                    this.best = { offset, rtt };
+                    this.callbacks.onClockOffset?.(offset);
+                }
+                break;
+            }
+            case 'roomState':
+                this.callbacks.onRoomState?.(msg.data);
+                break;
+        }
+    }
+
+    private open(): void {
+        const socket = new WebSocket(this.url) as StatefulWebSocket;
+        socket.natural = false;
+        this.socket = socket;
+
+        socket.addEventListener('open', () => {
+            this.backoff = 1000;
+            const params = new URLSearchParams(this.creds.credential);
+            this.send({
+                data: {
+                    salt: params.get('s') ?? undefined,
+                    serverUrl: this.creds.serverUrl,
+                    token: params.get('t') ?? undefined,
+                    username: params.get('u') ?? '',
+                },
+                event: 'authenticate',
+            });
+            this.callbacks.onConnectedChange?.(true);
+        });
+
+        socket.addEventListener('message', (e) => this.handleMessage(e.data as string));
+
+        socket.addEventListener('close', () => {
+            this.clearTimers();
+            this.best = { offset: 0, rtt: Number.POSITIVE_INFINITY };
+            this.callbacks.onConnectedChange?.(false);
+            if (!socket.natural && !this.closedByUser) this.scheduleReconnect();
+        });
+
+        socket.addEventListener('error', () => socket.close());
+    }
+
+    private scheduleReconnect(): void {
+        this.reconnectTimer = setTimeout(() => this.open(), this.backoff);
+        this.backoff = Math.min(this.backoff * 2, MAX_BACKOFF_MS);
+    }
+
+    private send(event: SyncClientEvent): void {
+        if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+            this.socket.send(JSON.stringify(event));
+        }
+    }
+
+    private startClockSync(): void {
+        if (this.pingTimer) clearInterval(this.pingTimer);
+        const ping = () => this.send({ data: { t0: Date.now() }, event: 'ping' });
+        ping();
+        // A quick burst right after connect helps the offset converge fast.
+        setTimeout(ping, 300);
+        setTimeout(ping, 800);
+        this.pingTimer = setInterval(ping, PING_INTERVAL_MS);
+    }
+}

--- a/src/renderer/api/sync/sync-client.ts
+++ b/src/renderer/api/sync/sync-client.ts
@@ -218,7 +218,11 @@ export class SyncSocket {
     }
 
     private scheduleReconnect(): void {
-        this.reconnectTimer = setTimeout(() => this.open(), this.backoff);
+        // Full jitter: wait a random time in (0, backoff]. A server restart drops
+        // every client at once; jitter spreads the reconnects out instead of
+        // hammering it in lockstep. The backoff ceiling still doubles up to the cap.
+        const delay = Math.random() * this.backoff;
+        this.reconnectTimer = setTimeout(() => this.open(), delay);
         this.backoff = Math.min(this.backoff * 2, MAX_BACKOFF_MS);
     }
 

--- a/src/renderer/api/sync/sync-util.test.ts
+++ b/src/renderer/api/sync/sync-util.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { idsEqual } from './sync-util';
+
+describe('idsEqual', () => {
+    it('treats same-order identical lists as equal', () => {
+        expect(idsEqual(['a', 'b', 'c'], ['a', 'b', 'c'])).toBe(true);
+        expect(idsEqual([], [])).toBe(true);
+    });
+
+    it('is order-sensitive', () => {
+        expect(idsEqual(['a', 'b'], ['b', 'a'])).toBe(false);
+    });
+
+    it('distinguishes different lengths', () => {
+        expect(idsEqual(['a'], ['a', 'b'])).toBe(false);
+    });
+});

--- a/src/renderer/api/sync/sync-util.ts
+++ b/src/renderer/api/sync/sync-util.ts
@@ -1,0 +1,6 @@
+// Small pure helpers for the sync feature, kept dependency-free so they're easy
+// to unit-test in isolation.
+
+/** Order-sensitive equality of two track-id lists. */
+export const idsEqual = (a: readonly string[], b: readonly string[]): boolean =>
+    a.length === b.length && a.every((id, i) => id === b[i]);

--- a/src/renderer/features/player/components/audio-players.tsx
+++ b/src/renderer/features/player/components/audio-players.tsx
@@ -28,6 +28,7 @@ import {
     useIsRadioActive,
 } from '/@/renderer/features/radio/hooks/use-radio-player';
 import { RemoteHook } from '/@/renderer/features/remote/hooks/use-remote';
+import { SyncSessionHook } from '/@/renderer/features/sync/use-sync-session';
 import { VisualizerSystemAudioBridgeHook } from '/@/renderer/features/visualizer/components/visualizer-system-audio-bridge';
 import { useSettingsStore } from '/@/renderer/store';
 import {
@@ -136,6 +137,7 @@ export const AudioPlayers = () => {
             <MediaSessionHook />
             <PlaybackHotkeysHook />
             <RemoteHook />
+            <SyncSessionHook />
             <AutoDJHook />
             <QueueRestoreTimestampHook />
             <InitialTimestampRestoreHook />

--- a/src/renderer/features/player/components/right-controls.tsx
+++ b/src/renderer/features/player/components/right-controls.tsx
@@ -10,6 +10,7 @@ import { usePlayer } from '/@/renderer/features/player/context/player-context';
 import { useSetRating } from '/@/renderer/features/shared/hooks/use-set-rating';
 import { useCreateFavorite } from '/@/renderer/features/shared/mutations/create-favorite-mutation';
 import { useDeleteFavorite } from '/@/renderer/features/shared/mutations/delete-favorite-mutation';
+import { ListenTogetherControl } from '/@/renderer/features/sync/listen-together-control';
 import { useHotkeys } from '/@/renderer/hooks/use-hotkeys';
 import {
     AUTO_DJ_MODE,
@@ -84,6 +85,7 @@ export const RightControls = () => {
                 <AutoDJButton />
             </Group>
             <Group align="center" gap="xs" wrap="nowrap">
+                <ListenTogetherControl />
                 <SleepTimerButton />
                 <PlayerConfig />
                 <LyricsButton />

--- a/src/renderer/features/settings/components/playback/listen-together-settings.tsx
+++ b/src/renderer/features/settings/components/playback/listen-together-settings.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import {
     SettingOption,
@@ -12,6 +13,7 @@ import { TextInput } from '/@/shared/components/text-input/text-input';
 // store backs both, so the enable toggle and sidecar URL stay in sync wherever
 // they're edited.
 export const ListenTogetherSettings = memo(() => {
+    const { t } = useTranslation();
     const { enabled, sidecarUrl } = useSyncSettings();
     const actions = useSyncActions();
 
@@ -19,14 +21,13 @@ export const ListenTogetherSettings = memo(() => {
         {
             control: (
                 <Switch
-                    aria-label="Enable Listen Together"
+                    aria-label={t('setting.enableListenTogether')}
                     checked={enabled}
                     onChange={(e) => actions.setEnabled(e.currentTarget.checked)}
                 />
             ),
-            description:
-                'Synchronize playback with friends in a shared room. Adds a "Listen Together" control to the player bar. Turning this off leaves any active room and disconnects.',
-            title: 'Enable Listen Together',
+            description: t('setting.enableListenTogether', { context: 'description' }),
+            title: t('setting.enableListenTogether'),
         },
         {
             control: (
@@ -37,15 +38,14 @@ export const ListenTogetherSettings = memo(() => {
                         if (url === sidecarUrl) return;
                         actions.setSidecarUrl(url);
                     }}
-                    placeholder="https://party.example.com"
+                    placeholder={t('listenTogether.serverUrlPlaceholder')}
                 />
             ),
-            description:
-                'Base URL of the listen-together server. The ws(s):// endpoint is derived automatically.',
+            description: t('setting.listenTogetherUrl', { context: 'description' }),
             isHidden: !enabled,
-            title: 'Sync server URL',
+            title: t('setting.listenTogetherUrl'),
         },
     ];
 
-    return <SettingsSection options={options} title="Listen Together" />;
+    return <SettingsSection options={options} title={t('page.setting.listenTogether')} />;
 });

--- a/src/renderer/features/settings/components/playback/listen-together-settings.tsx
+++ b/src/renderer/features/settings/components/playback/listen-together-settings.tsx
@@ -1,0 +1,51 @@
+import { memo } from 'react';
+
+import {
+    SettingOption,
+    SettingsSection,
+} from '/@/renderer/features/settings/components/settings-section';
+import { useSyncActions, useSyncSettings } from '/@/renderer/store/sync.store';
+import { Switch } from '/@/shared/components/switch/switch';
+import { TextInput } from '/@/shared/components/text-input/text-input';
+
+// Settings-page counterpart to the player-bar "Listen Together" popover. The same
+// store backs both, so the enable toggle and sidecar URL stay in sync wherever
+// they're edited.
+export const ListenTogetherSettings = memo(() => {
+    const { enabled, sidecarUrl } = useSyncSettings();
+    const actions = useSyncActions();
+
+    const options: SettingOption[] = [
+        {
+            control: (
+                <Switch
+                    aria-label="Enable Listen Together"
+                    checked={enabled}
+                    onChange={(e) => actions.setEnabled(e.currentTarget.checked)}
+                />
+            ),
+            description:
+                'Synchronize playback with friends in a shared room. Adds a "Listen Together" control to the player bar. Turning this off leaves any active room and disconnects.',
+            title: 'Enable Listen Together',
+        },
+        {
+            control: (
+                <TextInput
+                    defaultValue={sidecarUrl}
+                    onBlur={(e) => {
+                        const url = e.currentTarget.value.trim();
+                        if (url === sidecarUrl) return;
+                        actions.setSidecarUrl(url);
+                    }}
+                    placeholder="https://party.example.com"
+                />
+            ),
+            description:
+                'Base URL of the listen-together server. The ws(s):// endpoint is derived automatically.',
+            isHidden: !enabled,
+            title: 'Sync server URL',
+        },
+    ];
+
+    return <SettingsSection options={options} title="Listen Together" />;
+});

--- a/src/renderer/features/settings/components/playback/playback-tab.tsx
+++ b/src/renderer/features/settings/components/playback/playback-tab.tsx
@@ -5,6 +5,7 @@ import { shallow } from 'zustand/shallow';
 import { AudioSettings } from '/@/renderer/features/settings/components/playback/audio-settings';
 import { AutoDJSettings } from '/@/renderer/features/settings/components/playback/auto-dj-settings';
 import { EqSettings } from '/@/renderer/features/settings/components/playback/eq-settings';
+import { ListenTogetherSettings } from '/@/renderer/features/settings/components/playback/listen-together-settings';
 import { PlayerFilterSettings } from '/@/renderer/features/settings/components/playback/player-filter-settings';
 import { TranscodeSettings } from '/@/renderer/features/settings/components/playback/transcode-settings';
 import { useSettingsStore } from '/@/renderer/store';
@@ -45,6 +46,8 @@ export const PlaybackTab = memo(() => {
             <PlayerFilterSettings />
             <Divider />
             <AutoDJSettings />
+            <Divider />
+            <ListenTogetherSettings />
         </Stack>
     );
 });

--- a/src/renderer/features/sync/listen-together-control.tsx
+++ b/src/renderer/features/sync/listen-together-control.tsx
@@ -1,0 +1,187 @@
+import { useState } from 'react';
+
+import { useSyncActions, useSyncRoom, useSyncSettings } from '/@/renderer/store/sync.store';
+import { ActionIcon } from '/@/shared/components/action-icon/action-icon';
+import { Badge } from '/@/shared/components/badge/badge';
+import { Button } from '/@/shared/components/button/button';
+import { CopyButton } from '/@/shared/components/copy-button/copy-button';
+import { Divider } from '/@/shared/components/divider/divider';
+import { Group } from '/@/shared/components/group/group';
+import { Popover } from '/@/shared/components/popover/popover';
+import { Stack } from '/@/shared/components/stack/stack';
+import { Switch } from '/@/shared/components/switch/switch';
+import { TextInput } from '/@/shared/components/text-input/text-input';
+import { Text } from '/@/shared/components/text/text';
+import { Tooltip } from '/@/shared/components/tooltip/tooltip';
+
+export const ListenTogetherControl = () => {
+    const { enabled, sidecarUrl } = useSyncSettings();
+    const room = useSyncRoom();
+    const actions = useSyncActions();
+
+    const [opened, setOpened] = useState(false);
+    const [joinCode, setJoinCode] = useState('');
+    const [urlDraft, setUrlDraft] = useState(sidecarUrl);
+
+    const inRoom = !!room.roomId;
+
+    return (
+        <Popover
+            onChange={setOpened}
+            opened={opened}
+            position="top"
+            shadow="md"
+            width={320}
+            withArrow
+        >
+            <Popover.Target>
+                <Button
+                    onClick={() => setOpened((o) => !o)}
+                    size="compact-sm"
+                    variant={inRoom ? 'filled' : 'subtle'}
+                >
+                    {inRoom ? `Room ${room.roomId}` : 'Listen Together'}
+                </Button>
+            </Popover.Target>
+
+            <Popover.Dropdown>
+                <Stack gap="sm">
+                    <Group justify="space-between">
+                        <Text fw={600}>Listen Together</Text>
+                        <Switch
+                            aria-label="Enable Listen Together"
+                            checked={enabled}
+                            label="Enabled"
+                            onChange={(e) => actions.setEnabled(e.currentTarget.checked)}
+                        />
+                    </Group>
+
+                    {enabled && (
+                        <>
+                            <Group align="flex-end" gap="xs" wrap="nowrap">
+                                <TextInput
+                                    label="Sync server URL"
+                                    onChange={(e) => setUrlDraft(e.currentTarget.value)}
+                                    placeholder="https://party.example.com"
+                                    style={{ flex: 1 }}
+                                    value={urlDraft}
+                                />
+                                <Button
+                                    disabled={urlDraft.trim() === sidecarUrl}
+                                    onClick={() => actions.setSidecarUrl(urlDraft.trim())}
+                                    size="compact-sm"
+                                    variant="default"
+                                >
+                                    Save
+                                </Button>
+                            </Group>
+
+                            {inRoom ? (
+                                <RoomPanel actions={actions} room={room} />
+                            ) : (
+                                <>
+                                    <Button fullWidth onClick={() => actions.createRoom()}>
+                                        Create a room
+                                    </Button>
+                                    <Divider label="or join" labelPosition="center" />
+                                    <Group align="flex-end" gap="xs" wrap="nowrap">
+                                        <TextInput
+                                            label="Room code"
+                                            onChange={(e) =>
+                                                setJoinCode(e.currentTarget.value.toUpperCase())
+                                            }
+                                            placeholder="G7KQ2M"
+                                            style={{ flex: 1 }}
+                                            value={joinCode}
+                                        />
+                                        <Button
+                                            disabled={joinCode.trim().length < 4}
+                                            onClick={() => actions.joinRoom(joinCode)}
+                                            size="compact-sm"
+                                        >
+                                            Join
+                                        </Button>
+                                    </Group>
+                                </>
+                            )}
+                        </>
+                    )}
+                </Stack>
+            </Popover.Dropdown>
+        </Popover>
+    );
+};
+
+interface RoomPanelProps {
+    actions: ReturnType<typeof useSyncActions>;
+    room: ReturnType<typeof useSyncRoom>;
+}
+
+const RoomPanel = ({ actions, room }: RoomPanelProps) => (
+    <Stack gap="xs">
+        <Group justify="space-between">
+            <Group gap="xs">
+                <Text isMuted size="sm">
+                    Code
+                </Text>
+                <Text fw={700}>{room.roomId}</Text>
+            </Group>
+            <Group gap="xs">
+                <CopyButton value={room.roomId}>
+                    {({ copied, copy }) => (
+                        <Button onClick={copy} size="compact-xs" variant="default">
+                            {copied ? 'Copied' : 'Copy'}
+                        </Button>
+                    )}
+                </CopyButton>
+                <Badge color={room.connected ? 'teal' : 'red'} variant="light">
+                    {room.connected ? 'live' : 'offline'}
+                </Badge>
+            </Group>
+        </Group>
+
+        <Stack gap={4} style={{ maxHeight: 160, overflowY: 'auto' }}>
+            {room.members.map((m) => {
+                const isMemberHost = m.id === room.hostMemberId;
+                const isMe = m.id === room.memberId;
+                return (
+                    <Group justify="space-between" key={m.id}>
+                        <Group gap="xs">
+                            <Text size="sm">
+                                {m.username}
+                                {isMe ? ' (you)' : ''}
+                            </Text>
+                            {isMemberHost && (
+                                <Badge color="blue" size="xs" variant="light">
+                                    host
+                                </Badge>
+                            )}
+                        </Group>
+                        {room.isHost && !isMemberHost && (
+                            <Tooltip label="Give control">
+                                <ActionIcon
+                                    onClick={() => actions.passControl(m.id)}
+                                    size="sm"
+                                    variant="subtle"
+                                >
+                                    ⇄
+                                </ActionIcon>
+                            </Tooltip>
+                        )}
+                    </Group>
+                );
+            })}
+        </Stack>
+
+        <Group grow>
+            {!room.isHost && (
+                <Button onClick={() => actions.requestControl()} variant="default">
+                    Request control
+                </Button>
+            )}
+            <Button onClick={() => actions.leaveRoom()} variant="state-error">
+                Leave
+            </Button>
+        </Group>
+    </Stack>
+);

--- a/src/renderer/features/sync/listen-together-control.tsx
+++ b/src/renderer/features/sync/listen-together-control.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import {
     useSyncActions,
@@ -27,6 +28,7 @@ const DRIFT_OK_MS = 250;
 const formatOffset = (ms: number) => `${ms >= 0 ? '+' : ''}${Math.round(ms)} ms`;
 
 export const ListenTogetherControl = () => {
+    const { t } = useTranslation();
     const { enabled, sidecarUrl } = useSyncSettings();
     const room = useSyncRoom();
     const actions = useSyncActions();
@@ -52,18 +54,20 @@ export const ListenTogetherControl = () => {
                     size="compact-sm"
                     variant={inRoom ? 'filled' : 'subtle'}
                 >
-                    {inRoom ? `Room ${room.roomId}` : 'Listen Together'}
+                    {inRoom
+                        ? t('listenTogether.room', { code: room.roomId })
+                        : t('listenTogether.title')}
                 </Button>
             </Popover.Target>
 
             <Popover.Dropdown>
                 <Stack gap="sm">
                     <Group justify="space-between">
-                        <Text fw={600}>Listen Together</Text>
+                        <Text fw={600}>{t('listenTogether.title')}</Text>
                         <Switch
-                            aria-label="Enable Listen Together"
+                            aria-label={t('listenTogether.enabled')}
                             checked={enabled}
-                            label="Enabled"
+                            label={t('listenTogether.enabled')}
                             onChange={(e) => actions.setEnabled(e.currentTarget.checked)}
                         />
                     </Group>
@@ -72,9 +76,9 @@ export const ListenTogetherControl = () => {
                         <>
                             <Group align="flex-end" gap="xs" wrap="nowrap">
                                 <TextInput
-                                    label="Sync server URL"
+                                    label={t('listenTogether.serverUrl')}
                                     onChange={(e) => setUrlDraft(e.currentTarget.value)}
-                                    placeholder="https://party.example.com"
+                                    placeholder={t('listenTogether.serverUrlPlaceholder')}
                                     style={{ flex: 1 }}
                                     value={urlDraft}
                                 />
@@ -84,7 +88,7 @@ export const ListenTogetherControl = () => {
                                     size="compact-sm"
                                     variant="default"
                                 >
-                                    Save
+                                    {t('listenTogether.save')}
                                 </Button>
                             </Group>
 
@@ -93,16 +97,19 @@ export const ListenTogetherControl = () => {
                             ) : (
                                 <>
                                     <Button fullWidth onClick={() => actions.createRoom()}>
-                                        Create a room
+                                        {t('listenTogether.createRoom')}
                                     </Button>
-                                    <Divider label="or join" labelPosition="center" />
+                                    <Divider
+                                        label={t('listenTogether.orJoin')}
+                                        labelPosition="center"
+                                    />
                                     <Group align="flex-end" gap="xs" wrap="nowrap">
                                         <TextInput
-                                            label="Room code"
+                                            label={t('listenTogether.roomCode')}
                                             onChange={(e) =>
                                                 setJoinCode(e.currentTarget.value.toUpperCase())
                                             }
-                                            placeholder="G7KQ2M"
+                                            placeholder={t('listenTogether.roomCodePlaceholder')}
                                             style={{ flex: 1 }}
                                             value={joinCode}
                                         />
@@ -111,7 +118,7 @@ export const ListenTogetherControl = () => {
                                             onClick={() => actions.joinRoom(joinCode)}
                                             size="compact-sm"
                                         >
-                                            Join
+                                            {t('listenTogether.join')}
                                         </Button>
                                     </Group>
                                 </>
@@ -130,11 +137,16 @@ interface RoomPanelProps {
 }
 
 const RoomPanel = ({ actions, room }: RoomPanelProps) => {
+    const { t } = useTranslation();
     const health = useSyncHealth();
     const following = useSyncFollowing();
 
     const inSync = Math.abs(health.lastDriftMs) <= DRIFT_OK_MS;
-    const syncLabel = !following ? 'detached' : inSync ? 'in sync' : 'correcting';
+    const syncLabel = !following
+        ? t('listenTogether.statusDetached')
+        : inSync
+          ? t('listenTogether.statusInSync')
+          : t('listenTogether.statusCorrecting');
     const syncColor = !following ? 'gray' : inSync ? 'teal' : 'yellow';
 
     return (
@@ -142,7 +154,7 @@ const RoomPanel = ({ actions, room }: RoomPanelProps) => {
             <Group justify="space-between">
                 <Group gap="xs">
                     <Text isMuted size="sm">
-                        Code
+                        {t('listenTogether.code')}
                     </Text>
                     <Text fw={700}>{room.roomId}</Text>
                 </Group>
@@ -150,19 +162,21 @@ const RoomPanel = ({ actions, room }: RoomPanelProps) => {
                     <CopyButton value={room.roomId}>
                         {({ copied, copy }) => (
                             <Button onClick={copy} size="compact-xs" variant="default">
-                                {copied ? 'Copied' : 'Copy'}
+                                {copied ? t('listenTogether.copied') : t('listenTogether.copy')}
                             </Button>
                         )}
                     </CopyButton>
                     <Badge color={room.connected ? 'teal' : 'red'} variant="light">
-                        {room.connected ? 'live' : 'offline'}
+                        {room.connected
+                            ? t('listenTogether.statusLive')
+                            : t('listenTogether.statusOffline')}
                     </Badge>
                 </Group>
             </Group>
 
             <Group justify="space-between">
                 <Text isMuted size="xs">
-                    Clock offset
+                    {t('listenTogether.clockOffset')}
                 </Text>
                 <Group gap="xs">
                     <Text size="xs">{formatOffset(health.clockOffsetMs)}</Text>
@@ -183,16 +197,16 @@ const RoomPanel = ({ actions, room }: RoomPanelProps) => {
                             <Group gap="xs">
                                 <Text size="sm">
                                     {m.username}
-                                    {isMe ? ' (you)' : ''}
+                                    {isMe ? ` ${t('listenTogether.you')}` : ''}
                                 </Text>
                                 {isMemberHost && (
                                     <Badge color="blue" size="xs" variant="light">
-                                        host
+                                        {t('listenTogether.hostBadge')}
                                     </Badge>
                                 )}
                             </Group>
                             {room.isHost && !isMemberHost && (
-                                <Tooltip label="Give control">
+                                <Tooltip label={t('listenTogether.giveControl')}>
                                     <ActionIcon
                                         onClick={() => actions.passControl(m.id)}
                                         size="sm"
@@ -209,9 +223,9 @@ const RoomPanel = ({ actions, room }: RoomPanelProps) => {
 
             {!room.isHost && (
                 <Switch
-                    aria-label="Follow host playback"
+                    aria-label={t('listenTogether.followHost')}
                     checked={following}
-                    label="Follow host"
+                    label={t('listenTogether.followHost')}
                     onChange={(e) => actions.setFollowing(e.currentTarget.checked)}
                 />
             )}
@@ -219,11 +233,11 @@ const RoomPanel = ({ actions, room }: RoomPanelProps) => {
             <Group grow>
                 {!room.isHost && (
                     <Button onClick={() => actions.requestControl()} variant="default">
-                        Request control
+                        {t('listenTogether.requestControl')}
                     </Button>
                 )}
                 <Button onClick={() => actions.leaveRoom()} variant="state-error">
-                    Leave
+                    {t('listenTogether.leave')}
                 </Button>
             </Group>
         </Stack>

--- a/src/renderer/features/sync/listen-together-control.tsx
+++ b/src/renderer/features/sync/listen-together-control.tsx
@@ -1,6 +1,12 @@
 import { useState } from 'react';
 
-import { useSyncActions, useSyncRoom, useSyncSettings } from '/@/renderer/store/sync.store';
+import {
+    useSyncActions,
+    useSyncFollowing,
+    useSyncHealth,
+    useSyncRoom,
+    useSyncSettings,
+} from '/@/renderer/store/sync.store';
 import { ActionIcon } from '/@/shared/components/action-icon/action-icon';
 import { Badge } from '/@/shared/components/badge/badge';
 import { Button } from '/@/shared/components/button/button';
@@ -13,6 +19,12 @@ import { Switch } from '/@/shared/components/switch/switch';
 import { TextInput } from '/@/shared/components/text-input/text-input';
 import { Text } from '/@/shared/components/text/text';
 import { Tooltip } from '/@/shared/components/tooltip/tooltip';
+
+// Drift below this (ms) is treated as "in sync" for the status badge. Mirrors the
+// DRIFT_THRESHOLD_SEC the follower uses before hard-seeking in use-sync-session.
+const DRIFT_OK_MS = 250;
+
+const formatOffset = (ms: number) => `${ms >= 0 ? '+' : ''}${Math.round(ms)} ms`;
 
 export const ListenTogetherControl = () => {
     const { enabled, sidecarUrl } = useSyncSettings();
@@ -117,71 +129,103 @@ interface RoomPanelProps {
     room: ReturnType<typeof useSyncRoom>;
 }
 
-const RoomPanel = ({ actions, room }: RoomPanelProps) => (
-    <Stack gap="xs">
-        <Group justify="space-between">
-            <Group gap="xs">
-                <Text isMuted size="sm">
-                    Code
-                </Text>
-                <Text fw={700}>{room.roomId}</Text>
-            </Group>
-            <Group gap="xs">
-                <CopyButton value={room.roomId}>
-                    {({ copied, copy }) => (
-                        <Button onClick={copy} size="compact-xs" variant="default">
-                            {copied ? 'Copied' : 'Copy'}
-                        </Button>
-                    )}
-                </CopyButton>
-                <Badge color={room.connected ? 'teal' : 'red'} variant="light">
-                    {room.connected ? 'live' : 'offline'}
-                </Badge>
-            </Group>
-        </Group>
+const RoomPanel = ({ actions, room }: RoomPanelProps) => {
+    const health = useSyncHealth();
+    const following = useSyncFollowing();
 
-        <Stack gap={4} style={{ maxHeight: 160, overflowY: 'auto' }}>
-            {room.members.map((m) => {
-                const isMemberHost = m.id === room.hostMemberId;
-                const isMe = m.id === room.memberId;
-                return (
-                    <Group justify="space-between" key={m.id}>
-                        <Group gap="xs">
-                            <Text size="sm">
-                                {m.username}
-                                {isMe ? ' (you)' : ''}
-                            </Text>
-                            {isMemberHost && (
-                                <Badge color="blue" size="xs" variant="light">
-                                    host
-                                </Badge>
+    const inSync = Math.abs(health.lastDriftMs) <= DRIFT_OK_MS;
+    const syncLabel = !following ? 'detached' : inSync ? 'in sync' : 'correcting';
+    const syncColor = !following ? 'gray' : inSync ? 'teal' : 'yellow';
+
+    return (
+        <Stack gap="xs">
+            <Group justify="space-between">
+                <Group gap="xs">
+                    <Text isMuted size="sm">
+                        Code
+                    </Text>
+                    <Text fw={700}>{room.roomId}</Text>
+                </Group>
+                <Group gap="xs">
+                    <CopyButton value={room.roomId}>
+                        {({ copied, copy }) => (
+                            <Button onClick={copy} size="compact-xs" variant="default">
+                                {copied ? 'Copied' : 'Copy'}
+                            </Button>
+                        )}
+                    </CopyButton>
+                    <Badge color={room.connected ? 'teal' : 'red'} variant="light">
+                        {room.connected ? 'live' : 'offline'}
+                    </Badge>
+                </Group>
+            </Group>
+
+            <Group justify="space-between">
+                <Text isMuted size="xs">
+                    Clock offset
+                </Text>
+                <Group gap="xs">
+                    <Text size="xs">{formatOffset(health.clockOffsetMs)}</Text>
+                    {!room.isHost && (
+                        <Badge color={syncColor} size="xs" variant="light">
+                            {syncLabel}
+                        </Badge>
+                    )}
+                </Group>
+            </Group>
+
+            <Stack gap={4} style={{ maxHeight: 160, overflowY: 'auto' }}>
+                {room.members.map((m) => {
+                    const isMemberHost = m.id === room.hostMemberId;
+                    const isMe = m.id === room.memberId;
+                    return (
+                        <Group justify="space-between" key={m.id}>
+                            <Group gap="xs">
+                                <Text size="sm">
+                                    {m.username}
+                                    {isMe ? ' (you)' : ''}
+                                </Text>
+                                {isMemberHost && (
+                                    <Badge color="blue" size="xs" variant="light">
+                                        host
+                                    </Badge>
+                                )}
+                            </Group>
+                            {room.isHost && !isMemberHost && (
+                                <Tooltip label="Give control">
+                                    <ActionIcon
+                                        onClick={() => actions.passControl(m.id)}
+                                        size="sm"
+                                        variant="subtle"
+                                    >
+                                        ⇄
+                                    </ActionIcon>
+                                </Tooltip>
                             )}
                         </Group>
-                        {room.isHost && !isMemberHost && (
-                            <Tooltip label="Give control">
-                                <ActionIcon
-                                    onClick={() => actions.passControl(m.id)}
-                                    size="sm"
-                                    variant="subtle"
-                                >
-                                    ⇄
-                                </ActionIcon>
-                            </Tooltip>
-                        )}
-                    </Group>
-                );
-            })}
-        </Stack>
+                    );
+                })}
+            </Stack>
 
-        <Group grow>
             {!room.isHost && (
-                <Button onClick={() => actions.requestControl()} variant="default">
-                    Request control
-                </Button>
+                <Switch
+                    aria-label="Follow host playback"
+                    checked={following}
+                    label="Follow host"
+                    onChange={(e) => actions.setFollowing(e.currentTarget.checked)}
+                />
             )}
-            <Button onClick={() => actions.leaveRoom()} variant="state-error">
-                Leave
-            </Button>
-        </Group>
-    </Stack>
-);
+
+            <Group grow>
+                {!room.isHost && (
+                    <Button onClick={() => actions.requestControl()} variant="default">
+                        Request control
+                    </Button>
+                )}
+                <Button onClick={() => actions.leaveRoom()} variant="state-error">
+                    Leave
+                </Button>
+            </Group>
+        </Stack>
+    );
+};

--- a/src/renderer/features/sync/listen-together-control.tsx
+++ b/src/renderer/features/sync/listen-together-control.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import {
+    usePendingControlRequest,
     useSyncActions,
     useSyncFollowing,
     useSyncHealth,
@@ -14,6 +15,7 @@ import { Button } from '/@/shared/components/button/button';
 import { CopyButton } from '/@/shared/components/copy-button/copy-button';
 import { Divider } from '/@/shared/components/divider/divider';
 import { Group } from '/@/shared/components/group/group';
+import { ConfirmModal, Modal } from '/@/shared/components/modal/modal';
 import { Popover } from '/@/shared/components/popover/popover';
 import { Stack } from '/@/shared/components/stack/stack';
 import { Switch } from '/@/shared/components/switch/switch';
@@ -21,113 +23,117 @@ import { TextInput } from '/@/shared/components/text-input/text-input';
 import { Text } from '/@/shared/components/text/text';
 import { Tooltip } from '/@/shared/components/tooltip/tooltip';
 
-// Drift below this (ms) is treated as "in sync" for the status badge. Mirrors the
-// DRIFT_THRESHOLD_SEC the follower uses before hard-seeking in use-sync-session.
-const DRIFT_OK_MS = 250;
-
 const formatOffset = (ms: number) => `${ms >= 0 ? '+' : ''}${Math.round(ms)} ms`;
 
+// Enabling the feature and setting the sync server URL live in Settings → Playback;
+// this player-bar control only manages rooms, and is hidden until enabled there.
 export const ListenTogetherControl = () => {
     const { t } = useTranslation();
     const { enabled, sidecarUrl } = useSyncSettings();
     const room = useSyncRoom();
     const actions = useSyncActions();
+    const pendingRequest = usePendingControlRequest();
 
     const [opened, setOpened] = useState(false);
     const [joinCode, setJoinCode] = useState('');
-    const [urlDraft, setUrlDraft] = useState(sidecarUrl);
+
+    if (!enabled) return null;
 
     const inRoom = !!room.roomId;
+    const configured = sidecarUrl.trim().length > 0;
 
     return (
-        <Popover
-            onChange={setOpened}
-            opened={opened}
-            position="top"
-            shadow="md"
-            width={320}
-            withArrow
-        >
-            <Popover.Target>
-                <Button
-                    onClick={() => setOpened((o) => !o)}
-                    size="compact-sm"
-                    variant={inRoom ? 'filled' : 'subtle'}
-                >
-                    {inRoom
-                        ? t('listenTogether.room', { code: room.roomId })
-                        : t('listenTogether.title')}
-                </Button>
-            </Popover.Target>
+        <>
+            <Popover
+                onChange={setOpened}
+                opened={opened}
+                position="top"
+                shadow="md"
+                width={320}
+                withArrow
+            >
+                <Popover.Target>
+                    <Button
+                        onClick={() => setOpened((o) => !o)}
+                        size="compact-sm"
+                        variant={inRoom ? 'filled' : 'subtle'}
+                    >
+                        {inRoom
+                            ? t('listenTogether.room', { code: room.roomId })
+                            : t('listenTogether.title')}
+                    </Button>
+                </Popover.Target>
 
-            <Popover.Dropdown>
-                <Stack gap="sm">
-                    <Group justify="space-between">
+                <Popover.Dropdown>
+                    <Stack gap="sm">
                         <Text fw={600}>{t('listenTogether.title')}</Text>
-                        <Switch
-                            aria-label={t('listenTogether.enabled')}
-                            checked={enabled}
-                            label={t('listenTogether.enabled')}
-                            onChange={(e) => actions.setEnabled(e.currentTarget.checked)}
-                        />
-                    </Group>
 
-                    {enabled && (
-                        <>
-                            <Group align="flex-end" gap="xs" wrap="nowrap">
-                                <TextInput
-                                    label={t('listenTogether.serverUrl')}
-                                    onChange={(e) => setUrlDraft(e.currentTarget.value)}
-                                    placeholder={t('listenTogether.serverUrlPlaceholder')}
-                                    style={{ flex: 1 }}
-                                    value={urlDraft}
-                                />
-                                <Button
-                                    disabled={urlDraft.trim() === sidecarUrl}
-                                    onClick={() => actions.setSidecarUrl(urlDraft.trim())}
-                                    size="compact-sm"
-                                    variant="default"
-                                >
-                                    {t('listenTogether.save')}
+                        {!configured ? (
+                            <Text isMuted size="sm">
+                                {t('listenTogether.setUrlInSettings')}
+                            </Text>
+                        ) : inRoom ? (
+                            <RoomPanel actions={actions} room={room} />
+                        ) : (
+                            <>
+                                <Button fullWidth onClick={() => actions.createRoom()}>
+                                    {t('listenTogether.createRoom')}
                                 </Button>
-                            </Group>
-
-                            {inRoom ? (
-                                <RoomPanel actions={actions} room={room} />
-                            ) : (
-                                <>
-                                    <Button fullWidth onClick={() => actions.createRoom()}>
-                                        {t('listenTogether.createRoom')}
-                                    </Button>
-                                    <Divider
-                                        label={t('listenTogether.orJoin')}
-                                        labelPosition="center"
+                                <Divider
+                                    label={t('listenTogether.orJoin')}
+                                    labelPosition="center"
+                                />
+                                <Group align="flex-end" gap="xs" wrap="nowrap">
+                                    <TextInput
+                                        label={t('listenTogether.roomCode')}
+                                        onChange={(e) =>
+                                            setJoinCode(e.currentTarget.value.toUpperCase())
+                                        }
+                                        placeholder={t('listenTogether.roomCodePlaceholder')}
+                                        style={{ flex: 1 }}
+                                        value={joinCode}
                                     />
-                                    <Group align="flex-end" gap="xs" wrap="nowrap">
-                                        <TextInput
-                                            label={t('listenTogether.roomCode')}
-                                            onChange={(e) =>
-                                                setJoinCode(e.currentTarget.value.toUpperCase())
-                                            }
-                                            placeholder={t('listenTogether.roomCodePlaceholder')}
-                                            style={{ flex: 1 }}
-                                            value={joinCode}
-                                        />
-                                        <Button
-                                            disabled={joinCode.trim().length < 4}
-                                            onClick={() => actions.joinRoom(joinCode)}
-                                            size="compact-sm"
-                                        >
-                                            {t('listenTogether.join')}
-                                        </Button>
-                                    </Group>
-                                </>
-                            )}
-                        </>
-                    )}
-                </Stack>
-            </Popover.Dropdown>
-        </Popover>
+                                    <Button
+                                        disabled={joinCode.trim().length < 4}
+                                        onClick={() => actions.joinRoom(joinCode)}
+                                        size="compact-sm"
+                                    >
+                                        {t('listenTogether.join')}
+                                    </Button>
+                                </Group>
+                            </>
+                        )}
+                    </Stack>
+                </Popover.Dropdown>
+            </Popover>
+
+            <Modal
+                handlers={{
+                    close: () => actions.dismissControlRequest(),
+                    open: () => {},
+                    toggle: () => {},
+                }}
+                opened={!!pendingRequest}
+                title={t('listenTogether.controlRequestTitle')}
+            >
+                <ConfirmModal
+                    labels={{
+                        cancel: t('listenTogether.cancel'),
+                        confirm: t('listenTogether.giveControl'),
+                    }}
+                    onCancel={() => actions.dismissControlRequest()}
+                    onConfirm={() => actions.approveControlRequest()}
+                >
+                    <Text>
+                        {pendingRequest
+                            ? t('listenTogether.controlRequestBody', {
+                                  username: pendingRequest.username,
+                              })
+                            : ''}
+                    </Text>
+                </ConfirmModal>
+            </Modal>
+        </>
     );
 };
 
@@ -141,13 +147,12 @@ const RoomPanel = ({ actions, room }: RoomPanelProps) => {
     const health = useSyncHealth();
     const following = useSyncFollowing();
 
-    const inSync = Math.abs(health.lastDriftMs) <= DRIFT_OK_MS;
     const syncLabel = !following
         ? t('listenTogether.statusDetached')
-        : inSync
-          ? t('listenTogether.statusInSync')
-          : t('listenTogether.statusCorrecting');
-    const syncColor = !following ? 'gray' : inSync ? 'teal' : 'yellow';
+        : health.syncing
+          ? t('listenTogether.statusCorrecting')
+          : t('listenTogether.statusInSync');
+    const syncColor = !following ? 'gray' : health.syncing ? 'yellow' : 'teal';
 
     return (
         <Stack gap="xs">

--- a/src/renderer/features/sync/use-sync-session.tsx
+++ b/src/renderer/features/sync/use-sync-session.tsx
@@ -10,6 +10,7 @@ import debounce from 'lodash/debounce';
 import { useEffect, useRef } from 'react';
 
 import { api } from '/@/renderer/api';
+import { idsEqual } from '/@/renderer/api/sync/sync-util';
 import {
     subscribeCurrentTrack,
     subscribePlayerQueue,
@@ -106,9 +107,7 @@ export const useSyncSession = (): void => {
                 if (t.trackId && t.trackId !== currentId) {
                     const index = Math.max(0, t.queueIndex);
                     const loadedIds = queueRef.current.map((s) => s.id);
-                    const sameQueue =
-                        loadedIds.length === t.queue.length &&
-                        loadedIds.every((id, i) => id === t.queue[i]);
+                    const sameQueue = idsEqual(loadedIds, t.queue);
                     if (sameQueue) {
                         // Queue is already loaded (e.g. the host skipped within the
                         // shared queue): just switch track + seek, no need to
@@ -149,20 +148,28 @@ export const useSyncSession = (): void => {
     }, [seq, isHost, following]);
 
     // ---- Host: emit transport on local playback changes ----
+    const lastSentQueueRef = useRef<string[]>([]);
     useEffect(() => {
         if (!connected || !isHost) return;
+
+        // Re-send the full queue on the first emit after becoming host.
+        lastSentQueueRef.current = [];
 
         const emit = () => {
             if (applyingRemoteRef.current) return;
             const data = playerDataRef.current;
             const queueIds = queueRef.current.map((s) => s.id);
             const positionMs = Math.round(useTimestampStoreBase.getState().timestamp * 1000);
+            // Only include the queue when it actually changed; otherwise omit it so
+            // the server keeps the current one (saves resending it on every seek).
+            const queueChanged = !idsEqual(queueIds, lastSentQueueRef.current);
+            if (queueChanged) lastSentQueueRef.current = queueIds;
             sendTransport({
                 playing: data.status === PlayerStatus.PLAYING,
                 positionMs,
-                queue: queueIds,
                 queueIndex: data.index,
                 trackId: data.currentSong?.id ?? '',
+                ...(queueChanged ? { queue: queueIds } : {}),
             });
         };
 

--- a/src/renderer/features/sync/use-sync-session.tsx
+++ b/src/renderer/features/sync/use-sync-session.tsx
@@ -1,0 +1,158 @@
+// useSyncSession — the glue between the listen-together session and Feishin's
+// player. Mount it once (e.g. in audio-players.tsx). It:
+//   * applies inbound roomState to the player (followers), with clock-corrected
+//     drift handling and queue resolution, guarded against feedback; and
+//   * emits the host's transport whenever local playback changes (debounced).
+//
+// Modeled on src/renderer/features/player/audio-player/hooks/use-player-events.ts.
+
+import debounce from 'lodash/debounce';
+import { useEffect, useRef } from 'react';
+
+import { api } from '/@/renderer/api';
+import {
+    subscribeCurrentTrack,
+    subscribePlayerQueue,
+    subscribePlayerSeekToTimestamp,
+    subscribePlayerStatus,
+    useCurrentServerId,
+    usePlayerActions,
+    usePlayerData,
+    usePlayerQueue,
+    useTimestampStoreBase,
+} from '/@/renderer/store';
+import {
+    useIsSyncHost,
+    useSyncActions,
+    useSyncConnected,
+    useSyncStore,
+} from '/@/renderer/store/sync.store';
+import { Song } from '/@/shared/types/domain-types';
+import { SyncTransport } from '/@/shared/types/sync-types';
+import { PlayerStatus } from '/@/shared/types/types';
+
+const DRIFT_THRESHOLD_SEC = 0.25;
+
+async function resolveSongsByIds(serverId: string, ids: string[]): Promise<Song[]> {
+    if (!serverId || ids.length === 0) return [];
+    const results = await Promise.all(
+        ids.map((id) =>
+            api.controller
+                .getSongDetail({ apiClientProps: { serverId }, query: { id } })
+                .catch(() => undefined),
+        ),
+    );
+    return results.filter((s): s is Song => !!s);
+}
+
+export const useSyncSession = (): void => {
+    const isHost = useIsSyncHost();
+    const connected = useSyncConnected();
+    const seq = useSyncStore((s) => s.seq);
+    const { sendTransport } = useSyncActions();
+    const serverId = useCurrentServerId();
+
+    const actions = usePlayerActions();
+    const queue = usePlayerQueue();
+    const playerData = usePlayerData();
+
+    const actionsRef = useRef(actions);
+    actionsRef.current = actions;
+    const queueRef = useRef(queue);
+    queueRef.current = queue;
+    const playerDataRef = useRef(playerData);
+    playerDataRef.current = playerData;
+    const serverIdRef = useRef(serverId);
+    serverIdRef.current = serverId;
+
+    const applyingRemoteRef = useRef(false);
+    const lastAppliedSeqRef = useRef(-1);
+
+    // ---- Followers: apply inbound roomState ----
+    useEffect(() => {
+        if (isHost) return;
+        if (seq < 0 || seq <= lastAppliedSeqRef.current) return;
+        const transport = useSyncStore.getState().lastTransport;
+        if (!transport) return;
+        lastAppliedSeqRef.current = seq;
+
+        const apply = async (t: SyncTransport) => {
+            applyingRemoteRef.current = true;
+            try {
+                const a = actionsRef.current;
+                const offset = useSyncStore.getState().clockOffsetMs;
+                const expectedMs = t.playing
+                    ? t.positionMs + (Date.now() + offset - t.serverTimeMs)
+                    : t.positionMs;
+                const expectedSec = Math.max(0, expectedMs / 1000);
+
+                const currentId = playerDataRef.current.currentSong?.id;
+                if (t.trackId && t.trackId !== currentId) {
+                    const songs = await resolveSongsByIds(serverIdRef.current, t.queue);
+                    if (songs.length) {
+                        const index = Math.max(0, t.queueIndex);
+                        a.setQueue(songs, index, expectedSec);
+                        a.mediaPlayByIndex(index);
+                    }
+                } else {
+                    const currentSec = useTimestampStoreBase.getState().timestamp;
+                    if (Math.abs(currentSec - expectedSec) > DRIFT_THRESHOLD_SEC) {
+                        a.mediaSeekToTimestamp(expectedSec);
+                    }
+                }
+
+                // mediaPlay/mediaPause are idempotent, so enforce unconditionally.
+                if (t.playing) a.mediaPlay();
+                else a.mediaPause();
+            } finally {
+                // Release the guard after the store settles so our own programmatic
+                // changes don't bounce back out as a host transport.
+                setTimeout(() => {
+                    applyingRemoteRef.current = false;
+                }, 50);
+            }
+        };
+
+        void apply(transport);
+    }, [seq, isHost]);
+
+    // ---- Host: emit transport on local playback changes ----
+    useEffect(() => {
+        if (!connected || !isHost) return;
+
+        const emit = () => {
+            if (applyingRemoteRef.current) return;
+            const data = playerDataRef.current;
+            const queueIds = queueRef.current.map((s) => s.id);
+            const positionMs = Math.round(useTimestampStoreBase.getState().timestamp * 1000);
+            sendTransport({
+                playing: data.status === PlayerStatus.PLAYING,
+                positionMs,
+                queue: queueIds,
+                queueIndex: data.index,
+                trackId: data.currentSong?.id ?? '',
+            });
+        };
+
+        const debounced = debounce(emit, 150);
+        const unsubscribers = [
+            subscribePlayerStatus(() => debounced()),
+            subscribePlayerSeekToTimestamp(() => debounced()),
+            subscribeCurrentTrack(() => debounced()),
+            subscribePlayerQueue(() => debounced()),
+        ];
+        emit(); // push current state immediately on becoming host
+
+        return () => {
+            debounced.cancel();
+            unsubscribers.forEach((unsub) => unsub?.());
+        };
+    }, [connected, isHost, sendTransport]);
+};
+
+// Mountable wrapper, following Feishin's hook-as-component convention
+// (e.g. RemoteHook in features/remote/hooks/use-remote.tsx).
+export const SyncSessionHook = () => {
+    useSyncSession();
+    return null;
+};

--- a/src/renderer/features/sync/use-sync-session.tsx
+++ b/src/renderer/features/sync/use-sync-session.tsx
@@ -154,6 +154,9 @@ export const useSyncSession = (): void => {
 
         // Re-send the full queue on the first emit after becoming host.
         lastSentQueueRef.current = [];
+        // Becoming host clears any "detached" follow-state, so if control is later
+        // handed back we resume following instead of staying silently detached.
+        useSyncStore.getState().actions.setFollowing(true);
 
         const emit = () => {
             if (applyingRemoteRef.current) return;

--- a/src/renderer/features/sync/use-sync-session.tsx
+++ b/src/renderer/features/sync/use-sync-session.tsx
@@ -33,6 +33,11 @@ import { PlayerStatus } from '/@/shared/types/types';
 
 const DRIFT_THRESHOLD_SEC = 0.25;
 
+// After applying remote state we hold the echo guard briefly so the player-store
+// mutations we just made have settled before this client could (if it becomes
+// host via pass-control) emit them back out as a fresh transport.
+const ECHO_GUARD_RELEASE_MS = 100;
+
 async function resolveSongsByIds(serverId: string, ids: string[]): Promise<Song[]> {
     if (!serverId || ids.length === 0) return [];
     const results = await Promise.all(
@@ -88,11 +93,23 @@ export const useSyncSession = (): void => {
 
                 const currentId = playerDataRef.current.currentSong?.id;
                 if (t.trackId && t.trackId !== currentId) {
-                    const songs = await resolveSongsByIds(serverIdRef.current, t.queue);
-                    if (songs.length) {
-                        const index = Math.max(0, t.queueIndex);
-                        a.setQueue(songs, index, expectedSec);
+                    const index = Math.max(0, t.queueIndex);
+                    const loadedIds = queueRef.current.map((s) => s.id);
+                    const sameQueue =
+                        loadedIds.length === t.queue.length &&
+                        loadedIds.every((id, i) => id === t.queue[i]);
+                    if (sameQueue) {
+                        // Queue is already loaded (e.g. the host skipped within the
+                        // shared queue): just switch track + seek, no need to
+                        // re-resolve every song's metadata.
                         a.mediaPlayByIndex(index);
+                        a.mediaSeekToTimestamp(expectedSec);
+                    } else {
+                        const songs = await resolveSongsByIds(serverIdRef.current, t.queue);
+                        if (songs.length) {
+                            a.setQueue(songs, index, expectedSec);
+                            a.mediaPlayByIndex(index);
+                        }
                     }
                 } else {
                     const currentSec = useTimestampStoreBase.getState().timestamp;
@@ -109,7 +126,7 @@ export const useSyncSession = (): void => {
                 // changes don't bounce back out as a host transport.
                 setTimeout(() => {
                     applyingRemoteRef.current = false;
-                }, 50);
+                }, ECHO_GUARD_RELEASE_MS);
             }
         };
 

--- a/src/renderer/features/sync/use-sync-session.tsx
+++ b/src/renderer/features/sync/use-sync-session.tsx
@@ -25,6 +25,7 @@ import {
     useIsSyncHost,
     useSyncActions,
     useSyncConnected,
+    useSyncFollowing,
     useSyncStore,
 } from '/@/renderer/store/sync.store';
 import { Song } from '/@/shared/types/domain-types';
@@ -53,6 +54,7 @@ async function resolveSongsByIds(serverId: string, ids: string[]): Promise<Song[
 export const useSyncSession = (): void => {
     const isHost = useIsSyncHost();
     const connected = useSyncConnected();
+    const following = useSyncFollowing();
     const seq = useSyncStore((s) => s.seq);
     const { sendTransport } = useSyncActions();
     const serverId = useCurrentServerId();
@@ -72,11 +74,20 @@ export const useSyncSession = (): void => {
 
     const applyingRemoteRef = useRef(false);
     const lastAppliedSeqRef = useRef(-1);
+    const prevFollowingRef = useRef(true);
 
     // ---- Followers: apply inbound roomState ----
     useEffect(() => {
         if (isHost) return;
-        if (seq < 0 || seq <= lastAppliedSeqRef.current) return;
+
+        // Detect a detach→resume transition so re-enabling "follow" re-applies the
+        // latest transport even when seq hasn't advanced since we detached.
+        const justResumed = following && !prevFollowingRef.current;
+        prevFollowingRef.current = following;
+
+        if (!following) return;
+        if (seq < 0) return;
+        if (!justResumed && seq <= lastAppliedSeqRef.current) return;
         const transport = useSyncStore.getState().lastTransport;
         if (!transport) return;
         lastAppliedSeqRef.current = seq;
@@ -111,8 +122,12 @@ export const useSyncSession = (): void => {
                             a.mediaPlayByIndex(index);
                         }
                     }
+                    // We just (re)seeked to the host's position, so report ~0 drift.
+                    useSyncStore.getState().actions.reportDrift(0);
                 } else {
                     const currentSec = useTimestampStoreBase.getState().timestamp;
+                    const driftMs = Math.round((currentSec - expectedSec) * 1000);
+                    useSyncStore.getState().actions.reportDrift(driftMs);
                     if (Math.abs(currentSec - expectedSec) > DRIFT_THRESHOLD_SEC) {
                         a.mediaSeekToTimestamp(expectedSec);
                     }
@@ -131,7 +146,7 @@ export const useSyncSession = (): void => {
         };
 
         void apply(transport);
-    }, [seq, isHost]);
+    }, [seq, isHost, following]);
 
     // ---- Host: emit transport on local playback changes ----
     useEffect(() => {

--- a/src/renderer/features/sync/use-sync-session.tsx
+++ b/src/renderer/features/sync/use-sync-session.tsx
@@ -35,10 +35,38 @@ import { PlayerStatus } from '/@/shared/types/types';
 
 const DRIFT_THRESHOLD_SEC = 0.25;
 
+// After switching track we must let the new source load before seeking, or the
+// seek races the load and is lost (the same reason use-queue-restore defers its
+// post-setQueue seek). Only correct the position when the host is meaningfully
+// into the track — a freshly-changed track already starts at ~0.
+const TRACK_LOAD_SEEK_DELAY_MS = 150;
+const TRACK_CHANGE_SEEK_MIN_SEC = 0.5;
+
 // After applying remote state we hold the echo guard briefly so the player-store
 // mutations we just made have settled before this client could (if it becomes
 // host via pass-control) emit them back out as a fresh transport.
 const ECHO_GUARD_RELEASE_MS = 100;
+
+// While following, a follower periodically re-snaps to the host's authoritative
+// state. This (a) lands the correct position once a slow-to-load track (e.g. a
+// large FLAC) finally becomes seekable — recomputed live, so we jump to where the
+// host is *now*, not where it was at join — and (b) makes the follower read-only:
+// any local play/pause/seek/skip is reverted so the session stays in sync.
+// Detach via "Follow host" to regain manual control.
+const RECONCILE_INTERVAL_MS = 500;
+// Only the periodic loop uses this larger threshold so steady-state clock jitter
+// doesn't trigger constant micro-seeks; it still catches interactions and slow
+// loads (both produce large gaps).
+const RECONCILE_DRIFT_SEC = 1.5;
+
+// Live expected playback position (seconds) for a transport, projecting forward
+// from the server-stamped time using the measured clock offset while playing.
+function expectedPositionSec(t: SyncTransport, clockOffsetMs: number): number {
+    const ms = t.playing
+        ? t.positionMs + (Date.now() + clockOffsetMs - t.serverTimeMs)
+        : t.positionMs;
+    return Math.max(0, ms / 1000);
+}
 
 async function resolveSongsByIds(serverId: string, ids: string[]): Promise<Song[]> {
     if (!serverId || ids.length === 0) return [];
@@ -98,10 +126,7 @@ export const useSyncSession = (): void => {
             try {
                 const a = actionsRef.current;
                 const offset = useSyncStore.getState().clockOffsetMs;
-                const expectedMs = t.playing
-                    ? t.positionMs + (Date.now() + offset - t.serverTimeMs)
-                    : t.positionMs;
-                const expectedSec = Math.max(0, expectedMs / 1000);
+                const expectedSec = expectedPositionSec(t, offset);
 
                 const currentId = playerDataRef.current.currentSong?.id;
                 if (t.trackId && t.trackId !== currentId) {
@@ -110,18 +135,29 @@ export const useSyncSession = (): void => {
                     const sameQueue = idsEqual(loadedIds, t.queue);
                     if (sameQueue) {
                         // Queue is already loaded (e.g. the host skipped within the
-                        // shared queue): just switch track + seek, no need to
-                        // re-resolve every song's metadata.
+                        // shared queue): just switch track, no need to re-resolve
+                        // every song's metadata. Don't seek immediately — that races
+                        // the new track's load and the seek is lost; defer it, and
+                        // only when the host is actually into the track.
                         a.mediaPlayByIndex(index);
-                        a.mediaSeekToTimestamp(expectedSec);
+                        if (expectedSec > TRACK_CHANGE_SEEK_MIN_SEC) {
+                            const target = expectedSec;
+                            setTimeout(
+                                () => actionsRef.current.mediaSeekToTimestamp(target),
+                                TRACK_LOAD_SEEK_DELAY_MS,
+                            );
+                        }
                     } else {
                         const songs = await resolveSongsByIds(serverIdRef.current, t.queue);
                         if (songs.length) {
+                            // setQueue carries the position; use-queue-restore applies
+                            // it on QUEUE_RESTORED after the track loads (deferred), so
+                            // no immediate seek is needed here.
                             a.setQueue(songs, index, expectedSec);
                             a.mediaPlayByIndex(index);
                         }
                     }
-                    // We just (re)seeked to the host's position, so report ~0 drift.
+                    // We just (re)positioned to the host's track, so report ~0 drift.
                     useSyncStore.getState().actions.reportDrift(0);
                 } else {
                     const currentSec = useTimestampStoreBase.getState().timestamp;
@@ -190,6 +226,58 @@ export const useSyncSession = (): void => {
             unsubscribers.forEach((unsub) => unsub?.());
         };
     }, [connected, isHost, sendTransport]);
+
+    // ---- Followers: periodic reconciliation (catch-up + read-only lock) ----
+    // Keeps the follower pinned to the host's authoritative state between inbound
+    // transports: lands the right position once a slow track becomes seekable, and
+    // reverts any local play/pause/seek/skip so a follower can't desync the room.
+    useEffect(() => {
+        if (isHost || !connected || !following) return;
+
+        const reconcile = () => {
+            if (applyingRemoteRef.current) return; // a full apply is in flight
+            const t = useSyncStore.getState().lastTransport;
+            if (!t || !t.trackId) return;
+
+            const a = actionsRef.current;
+            const data = playerDataRef.current;
+
+            // Wrong track: switch back to the host's. The follower already has the
+            // shared queue loaded, so map the id to its index and play it; the
+            // position converges on a later tick once the new track is seekable.
+            if (data.currentSong?.id !== t.trackId) {
+                const idx = queueRef.current.findIndex((s) => s.id === t.trackId);
+                if (idx < 0) return; // queue not loaded yet; the apply effect handles it
+                applyingRemoteRef.current = true;
+                a.mediaPlayByIndex(idx);
+                setTimeout(() => {
+                    applyingRemoteRef.current = false;
+                }, ECHO_GUARD_RELEASE_MS);
+                return;
+            }
+
+            // Wrong play/pause state: revert to the host's.
+            const isPlaying = data.status === PlayerStatus.PLAYING;
+            if (t.playing && !isPlaying) a.mediaPlay();
+            else if (!t.playing && isPlaying) a.mediaPause();
+
+            // Position drift (local seek, or a slow load that started at 0): snap to
+            // the host's live position. Larger threshold than on-receipt correction
+            // so steady-state jitter doesn't cause constant micro-seeks.
+            if (t.playing) {
+                const expected = expectedPositionSec(t, useSyncStore.getState().clockOffsetMs);
+                const actual = useTimestampStoreBase.getState().timestamp;
+                const driftMs = Math.round((actual - expected) * 1000);
+                useSyncStore.getState().actions.reportDrift(driftMs);
+                if (Math.abs(actual - expected) > RECONCILE_DRIFT_SEC) {
+                    a.mediaSeekToTimestamp(expected);
+                }
+            }
+        };
+
+        const id = setInterval(reconcile, RECONCILE_INTERVAL_MS);
+        return () => clearInterval(id);
+    }, [isHost, connected, following]);
 };
 
 // Mountable wrapper, following Feishin's hook-as-component convention

--- a/src/renderer/store/player.store.ts
+++ b/src/renderer/store/player.store.ts
@@ -1154,6 +1154,10 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
 
                     // If timestamp is greater than 10 seconds, restart current song
                     if (currentTimestamp > 10) {
+                        // Update the timestamp store right away (as mediaSeekToTimestamp and
+                        // mediaSkipBackward do) so readers don't see the stale pre-restart
+                        // position until the ~500ms engine poll catches up.
+                        setTimestampStore(0);
                         set((state) => {
                             state.player.seekToTimestamp = uniqueSeekToTimestamp(0);
                         });

--- a/src/renderer/store/sync.store.ts
+++ b/src/renderer/store/sync.store.ts
@@ -1,0 +1,176 @@
+// sync.store.ts — session state for "Listen Together".
+//
+// Only { enabled, sidecarUrl } is persisted; everything else is runtime. The
+// live SyncSocket is kept in a module variable (not in the store) so it never
+// gets serialized by `persist`. The hook in features/sync/use-sync-session.ts
+// applies inbound transport to the player and emits the host's transport.
+
+import { devtools, persist } from 'zustand/middleware';
+import { immer } from 'zustand/middleware/immer';
+import { shallow } from 'zustand/shallow';
+import { createWithEqualityFn } from 'zustand/traditional';
+
+import { SyncSocket } from '/@/renderer/api/sync/sync-client';
+import { useAuthStore } from '/@/renderer/store/auth.store';
+import { toast } from '/@/shared/components/toast/toast';
+import {
+    SyncMember,
+    SyncRoomState,
+    SyncTransport,
+    SyncTransportInput,
+} from '/@/shared/types/sync-types';
+
+let socket: SyncSocket | undefined;
+
+export interface SyncSlice extends SyncState {
+    actions: {
+        connect: () => void;
+        createRoom: () => void;
+        disconnect: () => void;
+        joinRoom: (roomId: string) => void;
+        leaveRoom: () => void;
+        passControl: (toMemberId: string) => void;
+        requestControl: () => void;
+        sendTransport: (input: SyncTransportInput) => void;
+        setEnabled: (enabled: boolean) => void;
+        setSidecarUrl: (url: string) => void;
+    };
+}
+
+interface SyncState {
+    clockOffsetMs: number;
+    connected: boolean;
+    enabled: boolean;
+    hostMemberId: string;
+    lastTransport: null | SyncTransport;
+    memberId: string;
+    members: SyncMember[];
+    roomId: string;
+    seq: number;
+    sidecarUrl: string;
+}
+
+const initialState: SyncState = {
+    clockOffsetMs: 0,
+    connected: false,
+    enabled: false,
+    hostMemberId: '',
+    lastTransport: null,
+    memberId: '',
+    members: [],
+    roomId: '',
+    seq: -1,
+    sidecarUrl: '',
+};
+
+export const useSyncStore = createWithEqualityFn<SyncSlice>()(
+    persist(
+        devtools(
+            immer((set, get) => ({
+                actions: {
+                    connect: () => {
+                        if (socket) return;
+                        const server = useAuthStore.getState().currentServer;
+                        const url = get().sidecarUrl.trim();
+                        if (!server || !url) {
+                            toast.error({ message: 'Set a sidecar URL and select a server first' });
+                            return;
+                        }
+                        const wsUrl = url.replace(/^http/, 'ws').replace(/\/$/, '') + '/ws';
+                        socket = new SyncSocket(
+                            wsUrl,
+                            { credential: server.credential, serverUrl: server.url },
+                            {
+                                onAuthenticated: (memberId) => set({ memberId }),
+                                onClockOffset: (clockOffsetMs) => set({ clockOffsetMs }),
+                                onConnectedChange: (connected) => set({ connected }),
+                                onControlRequested: (_id, username) =>
+                                    toast.info({
+                                        message: `${username} requested control`,
+                                        title: 'Listen Together',
+                                    }),
+                                onError: (message) =>
+                                    toast.error({ message, title: 'Listen Together' }),
+                                onRoomState: (rs: SyncRoomState) => {
+                                    set({
+                                        hostMemberId: rs.hostMemberId,
+                                        lastTransport: rs.transport,
+                                        members: rs.members,
+                                        roomId: rs.roomId,
+                                        seq: rs.seq,
+                                    });
+                                },
+                            },
+                        );
+                        socket.connect();
+                    },
+                    createRoom: () => {
+                        get().actions.connect();
+                        socket?.createRoom();
+                    },
+                    disconnect: () => {
+                        socket?.close();
+                        socket = undefined;
+                        set({
+                            ...initialState,
+                            enabled: get().enabled,
+                            sidecarUrl: get().sidecarUrl,
+                        });
+                    },
+                    joinRoom: (roomId: string) => {
+                        get().actions.connect();
+                        socket?.joinRoom(roomId.trim().toUpperCase());
+                    },
+                    leaveRoom: () => {
+                        socket?.leaveRoom();
+                        set({
+                            hostMemberId: '',
+                            lastTransport: null,
+                            members: [],
+                            roomId: '',
+                            seq: -1,
+                        });
+                    },
+                    passControl: (toMemberId: string) => socket?.passControl(toMemberId),
+                    requestControl: () => socket?.requestControl(),
+                    sendTransport: (input: SyncTransportInput) => socket?.sendTransport(input),
+                    setEnabled: (enabled: boolean) => {
+                        set({ enabled });
+                        if (!enabled) get().actions.disconnect();
+                    },
+                    setSidecarUrl: (sidecarUrl: string) => set({ sidecarUrl }),
+                },
+                ...initialState,
+            })),
+            { name: 'store_sync' },
+        ),
+        {
+            name: 'store_sync',
+            partialize: (state) => ({ enabled: state.enabled, sidecarUrl: state.sidecarUrl }),
+            version: 1,
+        },
+    ),
+);
+
+export const useSyncActions = () => useSyncStore((state) => state.actions);
+
+export const useSyncConnected = () => useSyncStore((state) => state.connected);
+
+export const useSyncRoom = () =>
+    useSyncStore(
+        (state) => ({
+            connected: state.connected,
+            hostMemberId: state.hostMemberId,
+            isHost: !!state.memberId && state.memberId === state.hostMemberId,
+            memberId: state.memberId,
+            members: state.members,
+            roomId: state.roomId,
+        }),
+        shallow,
+    );
+
+export const useSyncSettings = () =>
+    useSyncStore((state) => ({ enabled: state.enabled, sidecarUrl: state.sidecarUrl }), shallow);
+
+export const useIsSyncHost = () =>
+    useSyncStore((state) => !!state.memberId && state.memberId === state.hostMemberId);

--- a/src/renderer/store/sync.store.ts
+++ b/src/renderer/store/sync.store.ts
@@ -5,6 +5,7 @@
 // gets serialized by `persist`. The hook in features/sync/use-sync-session.ts
 // applies inbound transport to the player and emits the host's transport.
 
+import { t } from 'i18next';
 import { devtools, persist } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
 import { shallow } from 'zustand/shallow';
@@ -83,7 +84,7 @@ export const useSyncStore = createWithEqualityFn<SyncSlice>()(
                         const server = useAuthStore.getState().currentServer;
                         const url = get().sidecarUrl.trim();
                         if (!server || !url) {
-                            toast.error({ message: 'Set a sidecar URL and select a server first' });
+                            toast.error({ message: t('listenTogether.setUrlFirst') });
                             return;
                         }
                         const wsUrl = url.replace(/^http/, 'ws').replace(/\/$/, '') + '/ws';
@@ -96,11 +97,11 @@ export const useSyncStore = createWithEqualityFn<SyncSlice>()(
                                 onConnectedChange: (connected) => set({ connected }),
                                 onControlRequested: (_id, username) =>
                                     toast.info({
-                                        message: `${username} requested control`,
-                                        title: 'Listen Together',
+                                        message: t('listenTogether.controlRequested', { username }),
+                                        title: t('listenTogether.title'),
                                     }),
                                 onError: (message) =>
-                                    toast.error({ message, title: 'Listen Together' }),
+                                    toast.error({ message, title: t('listenTogether.title') }),
                                 onRoomClosed: () =>
                                     set({
                                         following: true,

--- a/src/renderer/store/sync.store.ts
+++ b/src/renderer/store/sync.store.ts
@@ -30,9 +30,11 @@ export interface SyncSlice extends SyncState {
         joinRoom: (roomId: string) => void;
         leaveRoom: () => void;
         passControl: (toMemberId: string) => void;
+        reportDrift: (driftMs: number) => void;
         requestControl: () => void;
         sendTransport: (input: SyncTransportInput) => void;
         setEnabled: (enabled: boolean) => void;
+        setFollowing: (following: boolean) => void;
         setSidecarUrl: (url: string) => void;
     };
 }
@@ -41,7 +43,13 @@ interface SyncState {
     clockOffsetMs: number;
     connected: boolean;
     enabled: boolean;
+    // Whether this client applies the host's transport. Followers can toggle this
+    // off to detach temporarily (e.g. take a call) without leaving the room.
+    following: boolean;
     hostMemberId: string;
+    // Signed drift (ms) measured at the last applied sync; positive = we were
+    // ahead of the host. Surfaced as an in-sync/correcting indicator.
+    lastDriftMs: number;
     lastTransport: null | SyncTransport;
     memberId: string;
     members: SyncMember[];
@@ -54,7 +62,9 @@ const initialState: SyncState = {
     clockOffsetMs: 0,
     connected: false,
     enabled: false,
+    following: true,
     hostMemberId: '',
+    lastDriftMs: 0,
     lastTransport: null,
     memberId: '',
     members: [],
@@ -91,6 +101,16 @@ export const useSyncStore = createWithEqualityFn<SyncSlice>()(
                                     }),
                                 onError: (message) =>
                                     toast.error({ message, title: 'Listen Together' }),
+                                onRoomClosed: () =>
+                                    set({
+                                        following: true,
+                                        hostMemberId: '',
+                                        lastDriftMs: 0,
+                                        lastTransport: null,
+                                        members: [],
+                                        roomId: '',
+                                        seq: -1,
+                                    }),
                                 onRoomState: (rs: SyncRoomState) => {
                                     set({
                                         hostMemberId: rs.hostMemberId,
@@ -106,6 +126,7 @@ export const useSyncStore = createWithEqualityFn<SyncSlice>()(
                     },
                     createRoom: () => {
                         get().actions.connect();
+                        set({ following: true });
                         socket?.createRoom();
                     },
                     disconnect: () => {
@@ -119,12 +140,15 @@ export const useSyncStore = createWithEqualityFn<SyncSlice>()(
                     },
                     joinRoom: (roomId: string) => {
                         get().actions.connect();
+                        set({ following: true });
                         socket?.joinRoom(roomId.trim().toUpperCase());
                     },
                     leaveRoom: () => {
                         socket?.leaveRoom();
                         set({
+                            following: true,
                             hostMemberId: '',
+                            lastDriftMs: 0,
                             lastTransport: null,
                             members: [],
                             roomId: '',
@@ -132,12 +156,14 @@ export const useSyncStore = createWithEqualityFn<SyncSlice>()(
                         });
                     },
                     passControl: (toMemberId: string) => socket?.passControl(toMemberId),
+                    reportDrift: (driftMs: number) => set({ lastDriftMs: driftMs }),
                     requestControl: () => socket?.requestControl(),
                     sendTransport: (input: SyncTransportInput) => socket?.sendTransport(input),
                     setEnabled: (enabled: boolean) => {
                         set({ enabled });
                         if (!enabled) get().actions.disconnect();
                     },
+                    setFollowing: (following: boolean) => set({ following }),
                     setSidecarUrl: (sidecarUrl: string) => set({ sidecarUrl }),
                 },
                 ...initialState,
@@ -174,3 +200,11 @@ export const useSyncSettings = () =>
 
 export const useIsSyncHost = () =>
     useSyncStore((state) => !!state.memberId && state.memberId === state.hostMemberId);
+
+export const useSyncFollowing = () => useSyncStore((state) => state.following);
+
+export const useSyncHealth = () =>
+    useSyncStore(
+        (state) => ({ clockOffsetMs: state.clockOffsetMs, lastDriftMs: state.lastDriftMs }),
+        shallow,
+    );

--- a/src/renderer/store/sync.store.ts
+++ b/src/renderer/store/sync.store.ts
@@ -23,11 +23,21 @@ import {
 
 let socket: SyncSocket | undefined;
 
+// Hysteresis for the in-sync/correcting badge: enter "correcting" only past a
+// clear divergence, and return to "in sync" only once well back under it. Without
+// this the badge flips constantly, because the player's reported position updates
+// coarsely (rounded / ~500ms polled) so the measured drift jitters around any
+// single threshold.
+const SYNC_DIVERGE_MS = 1500;
+const SYNC_RECOVER_MS = 600;
+
 export interface SyncSlice extends SyncState {
     actions: {
+        approveControlRequest: () => void;
         connect: () => void;
         createRoom: () => void;
         disconnect: () => void;
+        dismissControlRequest: () => void;
         joinRoom: (roomId: string) => void;
         leaveRoom: () => void;
         passControl: (toMemberId: string) => void;
@@ -49,14 +59,18 @@ interface SyncState {
     following: boolean;
     hostMemberId: string;
     // Signed drift (ms) measured at the last applied sync; positive = we were
-    // ahead of the host. Surfaced as an in-sync/correcting indicator.
+    // ahead of the host. Drives the hysteretic `syncing` flag below.
     lastDriftMs: number;
     lastTransport: null | SyncTransport;
     memberId: string;
     members: SyncMember[];
+    // A follower's pending request to take control, awaiting the host's decision.
+    pendingControlRequest: null | { memberId: string; username: string };
     roomId: string;
     seq: number;
     sidecarUrl: string;
+    // Hysteretic "actively catching up" flag for the badge (see thresholds above).
+    syncing: boolean;
 }
 
 const initialState: SyncState = {
@@ -69,9 +83,11 @@ const initialState: SyncState = {
     lastTransport: null,
     memberId: '',
     members: [],
+    pendingControlRequest: null,
     roomId: '',
     seq: -1,
     sidecarUrl: '',
+    syncing: false,
 };
 
 export const useSyncStore = createWithEqualityFn<SyncSlice>()(
@@ -79,6 +95,11 @@ export const useSyncStore = createWithEqualityFn<SyncSlice>()(
         devtools(
             immer((set, get) => ({
                 actions: {
+                    approveControlRequest: () => {
+                        const req = get().pendingControlRequest;
+                        if (req) socket?.passControl(req.memberId);
+                        set({ pendingControlRequest: null });
+                    },
                     connect: () => {
                         if (socket) return;
                         const server = useAuthStore.getState().currentServer;
@@ -95,11 +116,8 @@ export const useSyncStore = createWithEqualityFn<SyncSlice>()(
                                 onAuthenticated: (memberId) => set({ memberId }),
                                 onClockOffset: (clockOffsetMs) => set({ clockOffsetMs }),
                                 onConnectedChange: (connected) => set({ connected }),
-                                onControlRequested: (_id, username) =>
-                                    toast.info({
-                                        message: t('listenTogether.controlRequested', { username }),
-                                        title: t('listenTogether.title'),
-                                    }),
+                                onControlRequested: (memberId, username) =>
+                                    set({ pendingControlRequest: { memberId, username } }),
                                 onError: (message) =>
                                     toast.error({ message, title: t('listenTogether.title') }),
                                 onRoomClosed: () =>
@@ -109,8 +127,10 @@ export const useSyncStore = createWithEqualityFn<SyncSlice>()(
                                         lastDriftMs: 0,
                                         lastTransport: null,
                                         members: [],
+                                        pendingControlRequest: null,
                                         roomId: '',
                                         seq: -1,
+                                        syncing: false,
                                     }),
                                 onRoomState: (rs: SyncRoomState) => {
                                     set({
@@ -139,6 +159,7 @@ export const useSyncStore = createWithEqualityFn<SyncSlice>()(
                             sidecarUrl: get().sidecarUrl,
                         });
                     },
+                    dismissControlRequest: () => set({ pendingControlRequest: null }),
                     joinRoom: (roomId: string) => {
                         get().actions.connect();
                         set({ following: true });
@@ -152,12 +173,21 @@ export const useSyncStore = createWithEqualityFn<SyncSlice>()(
                             lastDriftMs: 0,
                             lastTransport: null,
                             members: [],
+                            pendingControlRequest: null,
                             roomId: '',
                             seq: -1,
+                            syncing: false,
                         });
                     },
                     passControl: (toMemberId: string) => socket?.passControl(toMemberId),
-                    reportDrift: (driftMs: number) => set({ lastDriftMs: driftMs }),
+                    reportDrift: (driftMs: number) => {
+                        const mag = Math.abs(driftMs);
+                        // Hysteresis so the badge doesn't flip on coarse-position jitter.
+                        const syncing = get().syncing
+                            ? mag >= SYNC_RECOVER_MS
+                            : mag > SYNC_DIVERGE_MS;
+                        set({ lastDriftMs: driftMs, syncing });
+                    },
                     requestControl: () => socket?.requestControl(),
                     sendTransport: (input: SyncTransportInput) => socket?.sendTransport(input),
                     setEnabled: (enabled: boolean) => {
@@ -206,6 +236,8 @@ export const useSyncFollowing = () => useSyncStore((state) => state.following);
 
 export const useSyncHealth = () =>
     useSyncStore(
-        (state) => ({ clockOffsetMs: state.clockOffsetMs, lastDriftMs: state.lastDriftMs }),
+        (state) => ({ clockOffsetMs: state.clockOffsetMs, syncing: state.syncing }),
         shallow,
     );
+
+export const usePendingControlRequest = () => useSyncStore((state) => state.pendingControlRequest);

--- a/src/shared/types/sync-types.ts
+++ b/src/shared/types/sync-types.ts
@@ -60,7 +60,9 @@ export interface SyncTransportInput {
     clientTimeMs?: number;
     playing: boolean;
     positionMs: number;
-    queue: string[];
+    // Omitted when unchanged since the last send so play/pause/seek don't resend
+    // the full track-id list; the server then keeps the room's current queue.
+    queue?: string[];
     queueIndex: number;
     trackId: string;
 }

--- a/src/shared/types/sync-types.ts
+++ b/src/shared/types/sync-types.ts
@@ -1,0 +1,63 @@
+// Wire types for the listen-together sync server. These mirror the Go structs in
+// the listen-together `internal/protocol` package exactly. Every frame on the
+// wire is an envelope { event, data }.
+//
+// See: listen-together/docs/PROTOCOL.md
+
+// Client -> Server
+export type SyncClientEvent =
+    | { data: SyncTransportInput; event: 'transport' }
+    | {
+          data: {
+              password?: string;
+              salt?: string;
+              serverUrl: string;
+              token?: string;
+              username: string;
+          };
+          event: 'authenticate';
+      }
+    | { data: { roomId: string }; event: 'joinRoom' }
+    | { data: { t0: number }; event: 'ping' }
+    | { data: { toMemberId: string }; event: 'passControl' }
+    | { event: 'createRoom' }
+    | { event: 'leaveRoom' }
+    | { event: 'requestControl' };
+
+export interface SyncMember {
+    id: string;
+    username: string;
+}
+
+export interface SyncRoomState {
+    hostMemberId: string;
+    members: SyncMember[];
+    roomId: string;
+    seq: number;
+    transport: SyncTransport;
+}
+
+// Server -> Client
+export type SyncServerEvent =
+    | { data: SyncRoomState; event: 'roomState' }
+    | { data: { fromMemberId: string; fromUsername: string }; event: 'controlRequested' }
+    | { data: { memberId: string; username: string }; event: 'authenticated' }
+    | { data: { message: string }; event: 'error' }
+    | { data: { serverTimeMs: number; t0: number }; event: 'pong' };
+
+export interface SyncTransport {
+    playing: boolean;
+    positionMs: number;
+    queue: string[];
+    queueIndex: number;
+    serverTimeMs: number;
+    trackId: string;
+}
+
+export interface SyncTransportInput {
+    playing: boolean;
+    positionMs: number;
+    queue: string[];
+    queueIndex: number;
+    trackId: string;
+}

--- a/src/shared/types/sync-types.ts
+++ b/src/shared/types/sync-types.ts
@@ -55,6 +55,9 @@ export interface SyncTransport {
 }
 
 export interface SyncTransportInput {
+    // Monotonic logical clock stamped at send time; lets the server drop
+    // out-of-order transports. Filled in by SyncSocket.sendTransport.
+    clientTimeMs?: number;
     playing: boolean;
     positionMs: number;
     queue: string[];

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,21 @@
+import { resolve } from 'path';
+import { defineConfig } from 'vitest/config';
+
+// Minimal vitest setup for the listen-together sync unit tests. Mirrors the path
+// aliases from electron.vite.config.ts so `/@/...` imports resolve.
+export default defineConfig({
+    resolve: {
+        alias: {
+            '/@/i18n': resolve('src/i18n'),
+            '/@/main': resolve('src/main'),
+            '/@/preload': resolve('src/preload'),
+            '/@/remote': resolve('src/remote'),
+            '/@/renderer': resolve('src/renderer'),
+            '/@/shared': resolve('src/shared'),
+        },
+    },
+    test: {
+        environment: 'node',
+        include: ['src/**/*.test.ts'],
+    },
+});


### PR DESCRIPTION
## What

Adds an opt-in **Listen Together** feature: multiple Feishin clients join a room
and follow one host's playback (play / pause / seek / track / queue changes) in
near-real-time — a SyncPlay/SharePlay-style "listening party".

Coordination is handled by a small standalone open-source server,
[listen-together](https://git.alsogamer.com/alsog/listen-together), over a plain
WebSocket + JSON protocol. It is intentionally **not** a Navidrome plugin
(Navidrome plugins can only be outbound WebSocket clients and can't host a
coordinator), and authentication reuses each user's existing Subsonic
credentials — so it works with Navidrome and any Subsonic-compatible server.

## How

- `src/renderer/api/sync/sync-client.ts` — `SyncSocket`: connection lifecycle,
  Subsonic-credential auth, NTP-style clock sync, and reconnect with backoff.
  Modeled on the existing remote-control client (`src/remote/store/index.ts`).
- `src/renderer/store/sync.store.ts` — Zustand session store. Only the enable
  flag and server URL are persisted; the live socket is kept outside persisted
  state.
- `src/renderer/features/sync/use-sync-session.tsx` — applies inbound room state
  to the player through existing `player.store` actions (works for both the mpv
  and web engines) with clock-corrected drift handling, and emits the host's
  transport on local changes. Mounted as `<SyncSessionHook />` alongside the
  other player hooks in `audio-players.tsx`, mirroring `<RemoteHook />`.
- `src/renderer/features/sync/listen-together-control.tsx` — player-bar control
  (added to `right-controls.tsx`) to create/join rooms by code, view members,
  and hand off control. Uses the shared component wrappers.
- `src/shared/types/sync-types.ts` — wire types.

Single host holds transport authority with explicit pass-control; the host is
reassigned automatically if it leaves. Echo is prevented with an
applying-remote guard, and stale frames are dropped via a monotonic sequence
number.

## Privacy

Only track ids and position are synced — **stream URLs are never shared**. Each
client resolves songs and streams with its own credentials.

## Notes

- Fully opt-in: inert until enabled in the control, where the sync-server URL is
  also configured. No behavior changes for existing users.
- This PR is the client side only; the sync server is a separate project.
