### PR TITLE
fix: recover mpv playback after the OS resumes from sleep

### DIFF
--- a/src/main/features/core/player/index.ts
+++ b/src/main/features/core/player/index.ts
@@ -1,5 +1,5 @@
 import console from 'console';
-import { app, ipcMain } from 'electron';
+import { app, ipcMain, powerMonitor } from 'electron';
 import { access, rm } from 'fs/promises';
 import uniq from 'lodash/uniq';
 import MpvAPI from 'node-mpv';
@@ -83,6 +83,19 @@ const DEFAULT_MPV_PARAMETERS = (extraParameters?: string[]) => {
 
     if (!extraParameters?.some((param) => prefetchPlaylistParams.includes(param))) {
         parameters.push('--prefetch-playlist=yes');
+    }
+
+    // Without these, mpv/ffmpeg will block indefinitely on a dead TCP connection
+    // instead of failing or reconnecting. This commonly happens when the OS network
+    // adapter resets after the system wakes from sleep while a stream is open.
+    if (!extraParameters?.some((param) => param.startsWith('--network-timeout'))) {
+        parameters.push('--network-timeout=10');
+    }
+
+    if (!extraParameters?.some((param) => param.startsWith('--stream-lavf-o'))) {
+        parameters.push(
+            '--stream-lavf-o=reconnect=1,reconnect_streamed=1,reconnect_at_eof=1,reconnect_delay_max=5',
+        );
     }
 
     return parameters;
@@ -191,21 +204,44 @@ export const getMpvInstance = () => {
     return mpvInstance;
 };
 
+const QUIT_TIMEOUT_MS = 3000;
+
+const killMpvProcess = (mpv: MpvAPI) => {
+    const mpvProcess = (mpv as any).process || (mpv as any).mpvProcess;
+    if (mpvProcess && typeof mpvProcess.kill === 'function') {
+        try {
+            mpvProcess.kill('SIGTERM');
+        } catch (killErr) {
+            mpvLog({ action: 'Failed to kill mpv process' }, killErr as NodeMpvError);
+        }
+    }
+};
+
 const quit = async (instance?: MpvAPI | null) => {
     const mpv = instance || getMpvInstance();
     if (mpv) {
         try {
-            await mpv.quit();
+            // mpv.quit() resolves only when mpv replies over IPC. If mpv's command queue
+            // is wedged (e.g. blocked on a dead network stream after the system resumes
+            // from sleep), that reply never arrives, so this must not be allowed to hang
+            // forever - fall back to killing the process directly.
+            let timedOut = false;
+            await Promise.race([
+                mpv.quit(),
+                new Promise((resolve) => {
+                    setTimeout(() => {
+                        timedOut = true;
+                        resolve(undefined);
+                    }, QUIT_TIMEOUT_MS);
+                }),
+            ]);
+
+            if (timedOut) {
+                killMpvProcess(mpv);
+            }
         } catch {
             // If quit() fails, try to kill the process directly
-            const mpvProcess = (mpv as any).process || (mpv as any).mpvProcess;
-            if (mpvProcess && typeof mpvProcess.kill === 'function') {
-                try {
-                    mpvProcess.kill('SIGTERM');
-                } catch (killErr) {
-                    mpvLog({ action: 'Failed to kill mpv process' }, killErr as NodeMpvError);
-                }
-            }
+            killMpvProcess(mpv);
         }
         if (!isWindows()) {
             try {
@@ -665,6 +701,17 @@ const cleanupMpv = async (force = false) => {
         }
     }
 };
+
+// When the OS resumes from sleep, any network stream mpv had open is likely dead
+// (the connection silently dropped while the network adapter was suspended). Tell
+// the renderer to reload mpv so it reconnects with a fresh stream instead of staying
+// stuck on the old, now-dead connection until the app is manually restarted.
+powerMonitor.on('resume', () => {
+    if (getMpvInstance()) {
+        mpvLog({ action: 'System resumed from sleep, reloading mpv' });
+        getMainWindow()?.webContents.send('renderer-mpv-reconnect');
+    }
+});
 
 app.on('before-quit', async (event) => {
     switch (mpvState) {

--- a/src/preload/mpv-player.ts
+++ b/src/preload/mpv-player.ts
@@ -174,6 +174,10 @@ const rendererPlayerFallback = (cb: (data: boolean) => void) => {
     ipcRenderer.on('renderer-player-fallback', (_, data) => cb(data));
 };
 
+const rendererMpvReconnect = (cb: () => void) => {
+    ipcRenderer.on('renderer-mpv-reconnect', () => cb());
+};
+
 export const mpvPlayer = {
     autoNext,
     cleanup,
@@ -205,6 +209,7 @@ export const mpvPlayerListener = {
     rendererAutoNext,
     rendererCurrentTime,
     rendererError,
+    rendererMpvReconnect,
     rendererNext,
     rendererPause,
     rendererPlay,

--- a/src/renderer/features/player/audio-player/engine/mpv-player-engine.tsx
+++ b/src/renderer/features/player/audio-player/engine/mpv-player-engine.tsx
@@ -68,9 +68,13 @@ export const MpvPlayerEngine = (props: MpvPlayerEngineProps) => {
         };
 
         eventEmitter.on('MPV_RELOAD', handleMpvReload);
+        // The main process notifies us after the OS resumes from sleep, since the
+        // stream mpv had open is likely on a now-dead connection.
+        mpvPlayerListener?.rendererMpvReconnect(handleMpvReload);
 
         return () => {
             eventEmitter.off('MPV_RELOAD', handleMpvReload);
+            ipc?.removeAllListeners('renderer-mpv-reconnect');
         };
     }, []);
 


### PR DESCRIPTION
## Problem

After Windows wakes from sleep/hibernate, Feishin can't play any track on the mpv engine — neither resuming a paused track nor starting a new one. The only fix is to fully restart Feishin (not Windows). See #2171 for the original report, including server-side investigation that ruled out Navidrome/ffmpeg/ffprobe as the cause (server logs clean, ffmpeg+ffprobe present, already past the unrelated fix in #1923).

There's also prior art in #187 (2023, against a Jellyfin server) with the same symptom — a request "stuck waiting for server response" — which went stale without resolution and is now locked.

## Root cause

Traced the mpv engine path (`src/main/features/core/player/index.ts`) and the underlying `node-mpv` fork it depends on (`jeffvli/Node-MPV`, pinned at commit `32b4d64`):

1. mpv is launched with no `--network-timeout` and no ffmpeg reconnect options (`DEFAULT_MPV_PARAMETERS`). A stream left open across a sleep/hibernate cycle sits on a TCP connection the OS silently drops; without these flags, mpv/ffmpeg blocks indefinitely on the dead socket instead of failing or reconnecting.
2. That hang isn't contained to the stream. Node-MPV's IPC layer makes every command — including `quit()` — a promise that only resolves when mpv sends a matching reply over the socket, with no timeout anywhere in that path:
   - `quit()` just `await`s `this.command("quit")` and nothing else: https://github.com/jeffvli/Node-MPV/blob/32b4d64395289ad710c41d481d2707a7acfc228f/lib/mpv/_startStop.js#L242-L253
   - the request wrapper backing every command resolves/rejects only from an IPC reply, with no timeout fallback: https://github.com/jeffvli/Node-MPV/blob/32b4d64395289ad710c41d481d2707a7acfc228f/lib/ipcInterface/ipcRequest.js#L11-L41

   So once mpv's command queue is wedged on the dead network read, `quit()` — and therefore Feishin's existing "restart mpv" path — can also hang forever. The only way out is killing the whole app, which matches the reports.
3. Electron's `powerMonitor` is only used in Feishin today to *prevent* sleep during playback (`powerSaveBlocker`). Nothing listens for *resume* to recover playback afterward.

## Fix

- Add `--network-timeout=10` and `--stream-lavf-o=reconnect=1,reconnect_streamed=1,reconnect_at_eof=1,reconnect_delay_max=5` to mpv's default parameters (skipped if the user already set either via the existing extra-parameters setting), so a stalled stream fails fast or reconnects instead of hanging forever.
- Make the existing `quit()` helper resilient to a wedged mpv process: race it against a 3s timeout and fall back to force-killing the process, so both manual and automatic recovery can't hang even if mpv itself is stuck.
- Listen for `powerMonitor`'s `resume` event in the main process and tell the renderer to reload mpv (reusing the existing `MPV_RELOAD` mechanism already used when playback settings change), so playback recovers automatically after sleep/wake instead of requiring a manual app restart.

## Testing

I want to be upfront: **I have not yet been able to verify this fix against a real Windows sleep/wake cycle.**

What's been verified:
- `pnpm run lint` (typecheck + eslint + stylelint — the exact CI check) passes clean.
- Manually traced the code paths above against the actual `node-mpv` source to confirm this targets the root cause rather than papering over the symptom.

Why conclusive testing will take a bit longer:
- I can only reproduce this after hibernating overnight and waking up later — an immediate manual sleep/wake from my desk doesn't reproduce it.
- A wake that *doesn't* fail isn't conclusive by itself (the original report is ~90%, not 100%, reproducible), so I'd want a few overnight hibernation cycles before calling it solid either way.

I'm continuing to test this in parallel on my own machine and will report back results. If you're comfortable reviewing the code and merging on that basis given how narrowly scoped the change is (default mpv parameters + a timeout fallback + a resume listener, no behavior change on the happy path), I'm fine with that — but didn't want this to merge under the assumption it was already verified end-to-end.

Closes #2171