### PR TITLE
fix: lyrics export issue when furigana is enabled

### DIFF
--- a/src/renderer/features/lyrics/components/lyrics-export-form.tsx
+++ b/src/renderer/features/lyrics/components/lyrics-export-form.tsx
@@ -20,16 +20,6 @@ interface LyricsExportFormProps {
     synced: boolean;
 }
 
-const stripLyricsMarkup = (text: string) => {
-    if (!text.includes('<')) return text;
-
-    const template = document.createElement('template');
-    template.innerHTML = text;
-    template.content.querySelectorAll('rt, rp').forEach((node) => node.remove());
-
-    return template.content.textContent ?? text;
-};
-
 export const LyricsExportForm = ({ lyrics, offsetMs, synced }: LyricsExportFormProps) => {
     const { t } = useTranslation();
 
@@ -45,7 +35,7 @@ export const LyricsExportForm = ({ lyrics, offsetMs, synced }: LyricsExportFormP
             const contents = lyrics.lyrics
                 .map(
                     (lyric) =>
-                        `[${formatDuration(lyric[0], { leading: true, ms: true })}]${stripLyricsMarkup(lyric[1])}`,
+                        `[${formatDuration(lyric[0], { leading: true, ms: true })}]${lyric[1]}`,
                 )
                 .join('\n');
 
@@ -56,9 +46,9 @@ ${contents}
 `;
         } else {
             if (Array.isArray(lyrics.lyrics)) {
-                return lyrics.lyrics.map((lyric) => stripLyricsMarkup(lyric[1])).join('\n') + '\n';
+                return lyrics.lyrics.map((lyric) => lyric[1]).join('\n') + '\n';
             }
-            return stripLyricsMarkup(lyrics.lyrics);
+            return lyrics.lyrics;
         }
     }, [
         form.values.offsetMs,

--- a/src/renderer/features/lyrics/components/lyrics-export-form.tsx
+++ b/src/renderer/features/lyrics/components/lyrics-export-form.tsx
@@ -20,6 +20,16 @@ interface LyricsExportFormProps {
     synced: boolean;
 }
 
+const stripLyricsMarkup = (text: string) => {
+    if (!text.includes('<')) return text;
+
+    const template = document.createElement('template');
+    template.innerHTML = text;
+    template.content.querySelectorAll('rt, rp').forEach((node) => node.remove());
+
+    return template.content.textContent ?? text;
+};
+
 export const LyricsExportForm = ({ lyrics, offsetMs, synced }: LyricsExportFormProps) => {
     const { t } = useTranslation();
 
@@ -35,7 +45,7 @@ export const LyricsExportForm = ({ lyrics, offsetMs, synced }: LyricsExportFormP
             const contents = lyrics.lyrics
                 .map(
                     (lyric) =>
-                        `[${formatDuration(lyric[0], { leading: true, ms: true })}]${lyric[1]}`,
+                        `[${formatDuration(lyric[0], { leading: true, ms: true })}]${stripLyricsMarkup(lyric[1])}`,
                 )
                 .join('\n');
 
@@ -46,9 +56,9 @@ ${contents}
 `;
         } else {
             if (Array.isArray(lyrics.lyrics)) {
-                return lyrics.lyrics.map((lyric) => lyric[1]).join('\n') + '\n';
+                return lyrics.lyrics.map((lyric) => stripLyricsMarkup(lyric[1])).join('\n') + '\n';
             }
-            return lyrics.lyrics;
+            return stripLyricsMarkup(lyrics.lyrics);
         }
     }, [
         form.values.offsetMs,

--- a/src/renderer/features/lyrics/lyrics.tsx
+++ b/src/renderer/features/lyrics/lyrics.tsx
@@ -293,10 +293,10 @@ export const Lyrics = ({ fadeOutNoLyricsMessage = true, settingsKey = 'default' 
     }, [isLoadingLyrics, hasNoLyrics, fadeOutNoLyricsMessage]);
 
     const handleExportLyrics = useCallback(() => {
-        if (displayLyrics) {
-            openLyricsExportModal({ lyrics: displayLyrics, offsetMs: currentOffsetMs, synced });
+        if (lyrics && !isLyricsDisabled) {
+            openLyricsExportModal({ lyrics, offsetMs: currentOffsetMs, synced });
         }
-    }, [currentOffsetMs, displayLyrics, synced]);
+    }, [currentOffsetMs, isLyricsDisabled, lyrics, synced]);
 
     const handleOpenSettings = () => {
         openLyricsSettingsModal(settingsKey);


### PR DESCRIPTION
## Problem
The Japanese Furigana support introduced in #2161 broke the in-app lyrics export feature: when Furigana is enabled, the raw HTML tags and readings are accidentally included in the exported text.

### Example of the issue in lyrics export
```
[00:01.180]<ruby>考<rp>(</rp><rt>かんが</rt><rp>)</rp></ruby>えたってわからないし
[00:02.890]<ruby>青空<rp>(</rp><rt>あおぞら</rt><rp>)</rp></ruby>の<ruby>下<rp>(</rp><rt>した</rt><rp>)</rp></ruby>、<ruby>君<rp>(</rp><rt>きみ</rt><rp>)</rp></ruby>を<ruby>待<rp>(</rp><rt>ま</rt><rp>)</rp></ruby>った
``` 

## Changes
The formatter now removes `rt` and `rp` nodes before extracting text, so `<ruby>考<rt>かんが</rt></ruby>え` becomes `考え` instead of carrying readings into the file.