### PR TITLE
perf: use crypto.getRandomValues() for higher-quality shuffle in music player

### DIFF
--- a/src/renderer/utils/shuffle.ts
+++ b/src/renderer/utils/shuffle.ts
@@ -1,22 +1,22 @@
 export function shuffle<T>(array: T[]): T[] {
-    // Create a copy of the array to avoid mutating the original
     const shuffled = [...array];
-
-    // Loop through the array from the last element to the first
     for (let i = shuffled.length - 1; i > 0; i--) {
-        // Generate a random index from 0 to i
-        const j = Math.floor(Math.random() * (i + 1));
-        // Swap elements at positions i and j
+        const j = Math.floor(cryptoRandom() * (i + 1));
         [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
     }
-
     return shuffled;
 }
 
 export function shuffleInPlace<T>(array: T[]): T[] {
     for (let i = array.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
+        const j = Math.floor(cryptoRandom() * (i + 1));
         [array[i], array[j]] = [array[j], array[i]];
     }
     return array;
+}
+
+function cryptoRandom(): number {
+    const buf = new Uint32Array(1);
+    crypto.getRandomValues(buf);
+    return buf[0] / 0x100000000; // Normalize to [0, 1], same contract as Math.random()
 }

--- a/src/renderer/utils/shuffle.ts
+++ b/src/renderer/utils/shuffle.ts
@@ -1,10 +1,5 @@
 export function shuffle<T>(array: T[]): T[] {
-    const shuffled = [...array];
-    for (let i = shuffled.length - 1; i > 0; i--) {
-        const j = Math.floor(cryptoRandom() * (i + 1));
-        [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
-    }
-    return shuffled;
+    return shuffleInPlace(array.slice());
 }
 
 export function shuffleInPlace<T>(array: T[]): T[] {
@@ -15,8 +10,13 @@ export function shuffleInPlace<T>(array: T[]): T[] {
     return array;
 }
 
+const randomBuffer = new Uint32Array(1);
+
+/**
+ * Returns a cryptographically secure random float in [0, 1),
+ * matching the contract of Math.random().
+ */
 function cryptoRandom(): number {
-    const buf = new Uint32Array(1);
-    crypto.getRandomValues(buf);
-    return buf[0] / 0x100000000; // Normalize to [0, 1], same contract as Math.random()
+    crypto.getRandomValues(randomBuffer);
+    return randomBuffer[0] / 0x100000000;
 }


### PR DESCRIPTION
This update improves shuffle randomness for the music player by using crypto-based randomness instead of Math.random.