### PR TITLE
feat: add setting for static window title

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1175,6 +1175,8 @@
         "webAudio": "Use web audio",
         "windowBarStyle_description": "Select the style of the window bar",
         "windowBarStyle": "Window bar style",
+        "windowBarTrackinfo": "Track info in Window Title",
+        "windowBarTrackinfo_description": "Show current track's title and artist, queue position, and Playing/Paused state in the Window's Title.",
         "zoom_description": "Sets the zoom percentage for the application",
         "zoom": "Zoom percentage",
         "queryBuilder": "Query builder",

--- a/src/renderer/features/settings/components/window/window-settings.tsx
+++ b/src/renderer/features/settings/components/window/window-settings.tsx
@@ -66,6 +66,30 @@ export const WindowSettings = memo(() => {
         {
             control: (
                 <Switch
+                    aria-label="Toggle track info in Window Bar"
+                    defaultChecked={settings.windowBarTrackinfo}
+                    onChange={(e) => {
+                        if (!e) return;
+                        setSettings({
+                            window: {
+                                windowBarTrackinfo: e.currentTarget.checked,
+                            },
+                        });
+                    }}
+                />
+            ),
+            description: t('setting.windowBarTrackinfo', {
+                context: 'description',
+            }),
+            // tab is hidden entirely right now
+            // but if it was shown we would want to show this option
+            // as it also controls the tab title in web
+            isHidden: false,
+            title: t('setting.windowBarTrackinfo'),
+        },
+        {
+            control: (
+                <Switch
                     aria-label="toggle hiding tray"
                     defaultChecked={settings.tray}
                     disabled={!isElectron()}

--- a/src/renderer/layouts/window-bar.tsx
+++ b/src/renderer/layouts/window-bar.tsx
@@ -14,7 +14,13 @@ import macMin from './assets/min-mac.png';
 import styles from './window-bar.module.css';
 
 import { useRadioPlayer } from '/@/renderer/features/radio/hooks/use-radio-player';
-import { useAppStore, usePlayerData, usePlayerStatus, useWindowSettings } from '/@/renderer/store';
+import {
+    useAppStore,
+    usePlayerData,
+    usePlayerStatus,
+    useWindowBarTrackinfo,
+    useWindowSettings,
+} from '/@/renderer/store';
 import { Text } from '/@/shared/components/text/text';
 import { Platform, PlayerStatus } from '/@/shared/types/types';
 
@@ -130,6 +136,8 @@ const MacOsControls = ({ controls, title }: WindowBarControlsProps) => {
 export const WindowBar = () => {
     const { t } = useTranslation();
     const { windowBarStyle } = useWindowSettings();
+    const windowBarTrackinfo = useWindowBarTrackinfo();
+
     const playerStatus = usePlayerStatus();
     const privateMode = useAppStore((state) => state.privateMode);
     const handleMinimize = () => minimize();
@@ -152,6 +160,10 @@ export const WindowBar = () => {
 
     const title = useMemo(() => {
         const privateModeString = privateMode ? t('page.windowBar.privateMode') : '';
+
+        if (!windowBarTrackinfo) {
+            return `Feishin${privateMode ? ` ${privateModeString}` : ''}`;
+        }
 
         // Show radio information if radio is active
         if (isRadioActive) {
@@ -194,6 +206,7 @@ export const WindowBar = () => {
         queueLength,
         stationName,
         t,
+        windowBarTrackinfo,
     ]);
 
     useEffect(() => {

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -678,6 +678,7 @@ const WindowSettingsSchema = z.object({
     startMinimized: z.boolean(),
     tray: z.boolean(),
     windowBarStyle: z.nativeEnum(Platform),
+    windowBarTrackinfo: z.boolean(),
 });
 
 const QueryValueInputTypeSchema = z.enum([
@@ -2014,6 +2015,7 @@ const initialState: SettingsState = {
         startMinimized: false,
         tray: true,
         windowBarStyle: platformDefaultWindowBarStyle,
+        windowBarTrackinfo: true,
     },
 };
 
@@ -2559,6 +2561,9 @@ export const useWindowSettings = () => useSettingsStore((state) => state.window,
 
 export const useWindowBarStyle = () =>
     useSettingsStore((state) => state.window.windowBarStyle, shallow);
+
+export const useWindowBarTrackinfo = () =>
+    useSettingsStore((state) => state.window.windowBarTrackinfo, shallow);
 
 export const useHotkeySettings = () => useSettingsStore((state) => state.hotkeys, shallow);
 


### PR DESCRIPTION
### Description
Adds a setting whether or not to show the track info in the Window title. Defaults to true (i.e. current state).

### Motivation and Context
For one, I don't really look at the Window title anyway, so the track information conveyed there is of no use.

However, the motivation for this change is that I'm occasionally window capturing Feishin in OBS Studio (but the same applies to other software). Window capture is matched by the Window title, so having it change all the time means the capture is also lost after an application restart, which means having to set it up again.

### How Has This Been Tested?
- checked the window title stays static during playback
- checked that Private Mode is still appended to window title, which (intentionally) still breaks capture

Only tested on Linux. Screen capture on Plasma via xdg-desktop-portal. Have no system to test on Windows or Mac.