### PR TITLE
Improve Jellyfin playlist loading and modification performance times

### DIFF
--- a/src/renderer/api/controller.ts
+++ b/src/renderer/api/controller.ts
@@ -546,6 +546,18 @@ export const controller: GeneralController = {
             server.type,
         )?.(addContext({ ...args, apiClientProps: { ...args.apiClientProps, server } }));
     },
+    getPlaylistSongIds(args) {
+        const server = getServerById(args.apiClientProps.serverId);
+
+        if (!server) {
+            throw new Error(`${i18n.t('error.apiRouteError')}: getPlaylistSongIds`);
+        }
+
+        return apiController(
+            'getPlaylistSongIds',
+            server.type,
+        )?.(addContext({ ...args, apiClientProps: { ...args.apiClientProps, server } }));
+    },
     getPlaylistSongList(args) {
         const server = getServerById(args.apiClientProps.serverId);
 

--- a/src/renderer/api/jellyfin/jellyfin-controller.ts
+++ b/src/renderer/api/jellyfin/jellyfin-controller.ts
@@ -1056,6 +1056,35 @@ export const JellyfinController: InternalControllerEndpoint = {
             apiClientProps,
             query: { ...query, limit: 1, startIndex: 0 },
         }).then((result) => result!.totalRecordCount!),
+    getPlaylistSongIds: async (args) => {
+        const { apiClientProps, query } = args;
+
+        if (!apiClientProps.server?.userId) {
+            throw new Error('No userId found');
+        }
+
+        const res = await jfApiClient(apiClientProps).getPlaylistSongList({
+            params: {
+                id: query.id,
+            },
+            query: {
+                // XXX: No fields are required for only IDs, which saves processing time between
+                // the Jellyfin server query, network (MBs vs KBs), and in-app parsing.
+                IncludeItemTypes: 'Audio',
+                UserId: apiClientProps.server?.userId,
+            },
+        });
+
+        if (res.status !== 200) {
+            throw new Error('Failed to get playlist song list IDs');
+        }
+
+        return {
+            items: res.body.Items.map((item) => item.Id),
+            startIndex: 0,
+            totalRecordCount: res.body.TotalRecordCount,
+        };
+    },
     getPlaylistSongList: async (args) => {
         const { apiClientProps, query } = args;
 

--- a/src/renderer/api/jellyfin/jellyfin-controller.ts
+++ b/src/renderer/api/jellyfin/jellyfin-controller.ts
@@ -1068,7 +1068,7 @@ export const JellyfinController: InternalControllerEndpoint = {
                 id: query.id,
             },
             query: {
-                Fields: JF_FIELDS.SONG,
+                Fields: JF_FIELDS.PLAYLIST_DETAIL,
                 IncludeItemTypes: 'Audio',
                 UserId: apiClientProps.server?.userId,
             },

--- a/src/renderer/api/jellyfin/jellyfin-controller.ts
+++ b/src/renderer/api/jellyfin/jellyfin-controller.ts
@@ -197,8 +197,8 @@ const JF_FIELDS = {
         'SortName',
         'ProviderIds',
     ],
-    ALBUM_DETAIL: ['Genres', 'DateCreated', 'ChildCount', 'People', 'Tags', 'ProviderIds'],
-    ALBUM_LIST: ['People', 'Tags', 'Studios', 'SortName', 'ProviderIds', 'ChildCount'],
+    ALBUM_DETAIL: ['Genres', 'DateCreated', 'ChildCount', 'Tags', 'ProviderIds'],
+    ALBUM_LIST: ['Tags', 'Studios', 'SortName', 'ProviderIds', 'ChildCount'],
     FOLDER: ['Genres', 'DateCreated', 'MediaSources', 'ParentId'],
     GENRE: ['ItemCounts'],
     PLAYLIST_DETAIL: [
@@ -210,16 +210,7 @@ const JF_FIELDS = {
         'SortName',
     ],
     PLAYLIST_LIST: ['ChildCount', 'Genres', 'DateCreated', 'ParentId', 'Overview'],
-    SONG: [
-        'Genres',
-        'DateCreated',
-        'MediaSources',
-        'ParentId',
-        'People',
-        'Tags',
-        'SortName',
-        'ProviderIds',
-    ],
+    SONG: ['Genres', 'DateCreated', 'MediaSources', 'ParentId', 'Tags', 'SortName', 'ProviderIds'],
 } as const;
 
 export const JellyfinController: InternalControllerEndpoint = {

--- a/src/renderer/api/navidrome/navidrome-controller.ts
+++ b/src/renderer/api/navidrome/navidrome-controller.ts
@@ -683,6 +683,11 @@ export const NavidromeController: InternalControllerEndpoint = {
             apiClientProps,
             query: { ...query, limit: 1, startIndex: 0 },
         }).then((result) => result!.totalRecordCount!),
+    getPlaylistSongIds: async (args) =>
+        NavidromeController.getPlaylistSongList(args).then((result) => ({
+            ...result,
+            items: result.items.map((song) => song.id),
+        })),
     getPlaylistSongList: async (args: PlaylistSongListArgs): Promise<PlaylistSongListResponse> => {
         const { apiClientProps, query } = args;
 

--- a/src/renderer/api/query-keys.ts
+++ b/src/renderer/api/query-keys.ts
@@ -338,6 +338,9 @@ export const queryKeys: Record<
 
             return [serverId, 'playlists', 'songList'] as const;
         },
+        songListIds: (serverId: string, id: string) => {
+            return [serverId, 'playlists', 'songListIds', id] as const;
+        },
     },
     radio: {
         list: (serverId: string) => [serverId, 'radio', 'list'] as const,

--- a/src/renderer/api/subsonic/subsonic-controller.ts
+++ b/src/renderer/api/subsonic/subsonic-controller.ts
@@ -1223,6 +1223,11 @@ export const SubsonicController: InternalControllerEndpoint = {
 
         return results.length;
     },
+    getPlaylistSongIds: async (args) =>
+        SubsonicController.getPlaylistSongList(args).then((result) => ({
+            ...result,
+            items: result.items.map((song) => song.id),
+        })),
     getPlaylistSongList: async ({ apiClientProps, query }) => {
         const res = await ssApiClient(apiClientProps).getPlaylist({
             query: {

--- a/src/renderer/features/context-menu/actions/add-to-playlist-action.tsx
+++ b/src/renderer/features/context-menu/actions/add-to-playlist-action.tsx
@@ -211,11 +211,11 @@ export const AddToPlaylistAction = ({ items, itemType }: AddToPlaylistActionProp
                 let songsToAdd: string[] = allSongIds;
 
                 if (skipDuplicates) {
-                    const queryKey = queryKeys.playlists.songList(serverId, playlistId);
+                    const queryKey = queryKeys.playlists.songListIds(serverId, playlistId);
 
                     const playlistSongsRes = await queryClient.fetchQuery({
                         queryFn: ({ signal }) => {
-                            return api.controller.getPlaylistSongList({
+                            return api.controller.getPlaylistSongIds({
                                 apiClientProps: {
                                     serverId,
                                     signal,
@@ -228,7 +228,7 @@ export const AddToPlaylistAction = ({ items, itemType }: AddToPlaylistActionProp
                         queryKey,
                     });
 
-                    const playlistSongIds = playlistSongsRes?.items?.map((song) => song.id);
+                    const playlistSongIds = playlistSongsRes?.items;
                     const uniqueSongIds: string[] = [];
 
                     for (const songId of allSongIds) {

--- a/src/renderer/features/playlists/components/add-to-playlist-context-modal.tsx
+++ b/src/renderer/features/playlists/components/add-to-playlist-context-modal.tsx
@@ -231,11 +231,11 @@ export const AddToPlaylistContextModal = ({
                 const uniqueSongIds: string[] = [];
 
                 if (values.skipDuplicates) {
-                    const queryKey = queryKeys.playlists.songList(serverId, playlistId);
+                    const queryKey = queryKeys.playlists.songListIds(serverId, playlistId);
 
                     const playlistSongsRes = await queryClient.fetchQuery({
                         queryFn: ({ signal }) => {
-                            return api.controller.getPlaylistSongList({
+                            return api.controller.getPlaylistSongIds({
                                 apiClientProps: {
                                     serverId,
                                     signal,
@@ -248,7 +248,7 @@ export const AddToPlaylistContextModal = ({
                         queryKey,
                     });
 
-                    const playlistSongIds = playlistSongsRes?.items?.map((song) => song.id);
+                    const playlistSongIds = playlistSongsRes?.items;
 
                     for (const songId of allSongIds) {
                         if (!playlistSongIds?.includes(songId)) {

--- a/src/shared/api/jellyfin/jellyfin-normalize.ts
+++ b/src/shared/api/jellyfin/jellyfin-normalize.ts
@@ -10,7 +10,6 @@ import {
     LibraryItem,
     MusicFolder,
     Playlist,
-    RelatedArtist,
     Song,
 } from '/@/shared/types/domain-types';
 import { ServerListItem, ServerType } from '/@/shared/types/types';
@@ -18,42 +17,6 @@ import { ServerListItem, ServerType } from '/@/shared/types/types';
 const TICKS_PER_MS = 10000;
 
 type AlbumOrSong = z.infer<typeof jfType._response.album> | z.infer<typeof jfType._response.song>;
-
-const KEYS_TO_OMIT = new Set(['AlbumArtist', 'Artist']);
-
-const getPeople = (item: AlbumOrSong): null | Record<string, RelatedArtist[]> => {
-    if (item.People) {
-        const participants: Record<string, RelatedArtist[]> = {};
-
-        for (const person of item.People) {
-            const key = person.Type || '';
-            if (KEYS_TO_OMIT.has(key)) {
-                continue;
-            }
-
-            const item: RelatedArtist = {
-                // for other roles, we just want to display this and not filter.
-                // filtering (and links) would require a separate field, PersonIds
-                id: '',
-                imageId: null,
-                imageUrl: null,
-                name: person.Name,
-                userFavorite: false,
-                userRating: null,
-            };
-
-            if (key in participants) {
-                participants[key].push(item);
-            } else {
-                participants[key] = [item];
-            }
-        }
-
-        return participants;
-    }
-
-    return null;
-};
 
 const getTags = (item: AlbumOrSong): null | Record<string, string[]> => {
     if (item.Tags) {
@@ -106,39 +69,6 @@ const getPlaylistImageId = (item: z.infer<typeof jfType._response.playlist>): nu
     return null;
 };
 
-const getArtists = (
-    item: z.infer<typeof jfType._response.song>,
-    participants?: null | Record<string, RelatedArtist[]>,
-): RelatedArtist[] => {
-    if (!item?.ArtistItems?.length && !item.AlbumArtists && !participants) {
-        return [];
-    }
-
-    const result: RelatedArtist[] = [];
-
-    (item?.ArtistItems?.length ? item.ArtistItems : item.AlbumArtists)?.forEach((entry) => {
-        result.push({
-            id: entry.Id,
-            imageId: null,
-            imageUrl: null,
-            name: entry.Name,
-            userFavorite: false,
-            userRating: null,
-        });
-    });
-
-    if (participants?.['Remixer']) {
-        const existingIds = new Set(result.map((artist) => artist.id));
-        for (const participant of participants['Remixer']) {
-            if (!existingIds.has(participant.id)) {
-                result.push(participant);
-            }
-        }
-    }
-
-    return result;
-};
-
 const jellyfinPremiereFields = (item: {
     PremiereDate?: string;
     ProductionYear?: number;
@@ -189,9 +119,18 @@ const normalizeSong = (
         console.warn('Jellyfin song retrieved with no media sources', item);
     }
 
-    const participants = getPeople(item);
-
-    const artists = getArtists(item, participants);
+    const artists = (item?.ArtistItems?.length ? item.ArtistItems : item.AlbumArtists)?.map(
+        (entry) => {
+            return {
+                id: entry.Id,
+                imageId: null,
+                imageUrl: null,
+                name: entry.Name,
+                userFavorite: false,
+                userRating: null,
+            };
+        },
+    );
 
     const { releaseDate, releaseYear } = jellyfinPremiereFields(item);
 
@@ -253,7 +192,7 @@ const normalizeSong = (
         mbzRecordingId: null,
         mbzTrackId: item.ProviderIds?.MusicBrainzTrack || null,
         name: item.Name,
-        participants,
+        participants: null,
         path: path || '',
         peak: null,
         playCount: (item.UserData && item.UserData.PlayCount) || 0,
@@ -328,7 +267,7 @@ const normalizeAlbum = (
         name: item.Name,
         originalDate: releaseDate,
         originalYear,
-        participants: getPeople(item),
+        participants: null,
         playCount: item.UserData?.PlayCount || 0,
         recordLabels: item.Studios?.map((entry) => entry.Name) || [],
         releaseDate,

--- a/src/shared/api/jellyfin/jellyfin-normalize.ts
+++ b/src/shared/api/jellyfin/jellyfin-normalize.ts
@@ -119,19 +119,6 @@ const normalizeSong = (
         console.warn('Jellyfin song retrieved with no media sources', item);
     }
 
-    const artists = (item?.ArtistItems?.length ? item.ArtistItems : item.AlbumArtists)?.map(
-        (entry) => {
-            return {
-                id: entry.Id,
-                imageId: null,
-                imageUrl: null,
-                name: entry.Name,
-                userFavorite: false,
-                userRating: null,
-            };
-        },
-    );
-
     const { releaseDate, releaseYear } = jellyfinPremiereFields(item);
 
     return {
@@ -150,7 +137,16 @@ const normalizeSong = (
         })),
         albumId: item.AlbumId || `dummy/${item.Id}`,
         artistName: item?.ArtistItems?.map((entry) => entry.Name).join(', ') || '',
-        artists,
+        artists: (item?.ArtistItems?.length ? item.ArtistItems : item.AlbumArtists)?.map(
+            (entry) => ({
+                id: entry.Id,
+                imageId: null,
+                imageUrl: null,
+                name: entry.Name,
+                userFavorite: false,
+                userRating: null,
+            }),
+        ),
         bitDepth,
         bitRate,
         bpm: null,

--- a/src/shared/types/domain-types.ts
+++ b/src/shared/types/domain-types.ts
@@ -620,6 +620,8 @@ export type AlbumInfo = {
     notes: null | string;
 };
 
+export type SongIdListResponse = BasePaginatedResponse<string[]>;
+
 export type SongListArgs = BaseEndpointArgs & { query: SongListQuery };
 
 export type SongListCountArgs = BaseEndpointArgs & { query: ListCountQuery<SongListQuery> };
@@ -1506,6 +1508,7 @@ export type ControllerEndpoint = {
     getPlaylistDetail: (args: PlaylistDetailArgs) => Promise<PlaylistDetailResponse>;
     getPlaylistList: (args: PlaylistListArgs) => Promise<PlaylistListResponse>;
     getPlaylistListCount: (args: PlaylistListCountArgs) => Promise<number>;
+    getPlaylistSongIds: (args: PlaylistSongListArgs) => Promise<SongIdListResponse>;
     getPlaylistSongList: (args: PlaylistSongListArgs) => Promise<SongListResponse>;
     getPlayQueue: (args: GetQueueArgs) => Promise<GetQueueResponse>;
     getRandomSongList: (args: RandomSongListArgs) => Promise<SongListResponse>;
@@ -1660,6 +1663,9 @@ export type InternalControllerEndpoint = {
         args: ReplaceApiClientProps<PlaylistListArgs>,
     ) => Promise<PlaylistListResponse>;
     getPlaylistListCount: (args: ReplaceApiClientProps<PlaylistListCountArgs>) => Promise<number>;
+    getPlaylistSongIds: (
+        args: ReplaceApiClientProps<PlaylistSongListArgs>,
+    ) => Promise<SongIdListResponse>;
     getPlaylistSongList: (
         args: ReplaceApiClientProps<PlaylistSongListArgs>,
     ) => Promise<SongListResponse>;


### PR DESCRIPTION
I've been moving a bunch of playlist content into Jellyfin from another music service using Feishin this weekend. At some point though it became _unusably slow_ in edit -> view iterations. While looking into this I also tried updating to Jellyfin 12.0RC1 since the headline feature is a large number of performance improvements. But this didn't help much :(

After updating the Jellyfin WebUI _loading_ playlists was significantly faster then Feishin though so I started to look at how Feishin was making the same API requests. The two things:
- All playlist-related fetches were requesting `People` and did not seem to be using the response data.
    - Requesting `People` seems like an ongoing performance issue in Jellyfin (https://github.com/jellyfin/jellyfin/issues/15346) even when supposedly fixed in 12.0 :/
 - When modifying a playlist with duplicate detection enabled, each add fetched the whole playlist's contents and threw away every response property except the ID. Beyond `People` being unused and slow, these responses were just unnecessarily slow and large.

### People is slow

To attempt to reduce the `People` slowness I stripped it out of what `getPlaylistSongList` returns. This didn't appear to cause any issues locally. It seems like showing a song's composer (if you have that column property shown) might need it per the code but showing them doesn't look to be functional on `development` either?

<img width="1601" height="268" alt="composer_missing_in_playlist" src="https://github.com/user-attachments/assets/036d7e27-39a1-4698-8491-84b54c8e16e8" />

Without this query parameter loading a large playlist in Feishin goes from ~13s to ~3s so it does make quite a difference in day to day use.

Before:
<img width="410" height="51" alt="load_playlist_old" src="https://github.com/user-attachments/assets/0b9e7220-9318-4084-987f-5a3d8f3db50b" />

After:
<img width="421" height="79" alt="load_playlist" src="https://github.com/user-attachments/assets/ff192c18-84bb-4ebb-b099-b2e3481c1618" />


### Minimize playlist addition requests

The more obviously harmless improvement is just optimizing the API requests made for duplicate detection. The two handlers for playlist additions only used the IDs and it makes a large difference when needing to add multiple songs back-to-back into a playlist which otherwise can end up getting out of sync with multiple requests in flight at once.

Before:
<img width="476" height="67" alt="add_with_duplicate_detection_old" src="https://github.com/user-attachments/assets/d5b65353-cdd6-4021-a63e-72c28230844a" />

After:
<img width="410" height="89" alt="add_with_duplicate_detection" src="https://github.com/user-attachments/assets/bb8f2f9b-e970-4105-babb-406eb936981f" />
