### PR TITLE
fix: romaji duplicate lines for non-Japanese lyrics

### DIFF
--- a/src/main/features/core/lyrics/furigana.ts
+++ b/src/main/features/core/lyrics/furigana.ts
@@ -42,13 +42,13 @@ export const convertFurigana = async (text: string): Promise<string> => {
 export const convertRomaji = async (text: string): Promise<string> => {
     const KuroshiroClass = (Kuroshiro as any).default || Kuroshiro;
 
-    if (!KuroshiroClass.Util.hasKana(text)) return text;
+    if (!KuroshiroClass.Util.hasKana(text)) return '';
 
     try {
         const kuroshiro = await getKuroshiro();
         return await kuroshiro.convert(text, { mode: 'spaced', to: 'romaji' });
     } catch (e) {
         console.error('Romaji conversion error: ', e);
-        return text;
+        return '';
     }
 };

--- a/src/renderer/features/lyrics/hooks/use-furigana-lyrics.ts
+++ b/src/renderer/features/lyrics/hooks/use-furigana-lyrics.ts
@@ -43,7 +43,7 @@ export const useRomajiLyrics = (lyrics: LyricsResponse | null | undefined, enabl
                 const convertedLines = converted.split('\n');
                 return lyrics.map(([time], i) => [
                     time,
-                    convertedLines[i] ?? lyrics[i][1],
+                    convertedLines[i] ?? '',
                 ]) as SynchronizedLyricsArray;
             }
             return lyrics;


### PR DESCRIPTION
## Problem

When a line didn’t need romaji conversion, the conversion would return the original lyric text. So non-Japanese lines ended up being shown again as the romaji line, which caused the duplicate lyrics.

## The fix

Return blank romaji output for lyrics/lines without Japanese kana.

#### No duplicate lyrics now
<img width="778" height="203" alt="CleanShot 2026-06-30 at 09 57 41" src="https://github.com/user-attachments/assets/f2238813-d9e3-4ad4-917b-9df755eebb14" />