### PR TITLE
feat(player): right-click volume icon to switch audio output device

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -783,6 +783,7 @@
         "artistConfiguration_description": "Configure what items are shown, and in what order, on the album artist page",
         "artistReleaseTypeConfiguration": "Artist release type configuration",
         "artistReleaseTypeConfiguration_description": "Configure what release types are shown, and in what order, on the album artist page",
+        "audioDeviceDefault": "System default",
         "audioDevice_description": "Select the audio device to use for playback",
         "audioDevice": "Audio device",
         "audioExclusiveMode_description": "Enable exclusive output mode. In this mode, the system is usually locked out, and only mpv will be able to output audio. Visualizer system audio capture will not work while this is enabled",

--- a/src/renderer/features/player/components/right-controls.tsx
+++ b/src/renderer/features/player/components/right-controls.tsx
@@ -590,6 +590,12 @@ const VolumeButton = () => {
         <>
             <ContextMenu>
                 <ContextMenu.Target>
+                    {/*
+                     * ActionIcon renders a Mantine Tooltip wrapper, which does not
+                     * forward the onContextMenu/ref that Radix injects via asChild to
+                     * the underlying button. Wrap in a real DOM node so right-click
+                     * reliably opens the menu.
+                     */}
                     <div style={{ alignItems: 'center', display: 'flex' }}>
                         <ActionIcon
                             icon={muted ? 'volumeMute' : volume > 50 ? 'volumeMax' : 'volumeNormal'}
@@ -612,7 +618,6 @@ const VolumeButton = () => {
                     </div>
                 </ContextMenu.Target>
                 <ContextMenu.Content>
-                    <ContextMenu.Label>{t('setting.audioDevice')}</ContextMenu.Label>
                     <ContextMenu.Item
                         isSelected={!currentAudioDeviceId}
                         onSelect={() => handleSelectAudioDevice(null)}

--- a/src/renderer/features/player/components/right-controls.tsx
+++ b/src/renderer/features/player/components/right-controls.tsx
@@ -7,6 +7,7 @@ import { PlayerConfig } from '/@/renderer/features/player/components/player-conf
 import { CustomPlayerbarSlider } from '/@/renderer/features/player/components/playerbar-slider';
 import { SleepTimerButton } from '/@/renderer/features/player/components/sleep-timer-button';
 import { usePlayer } from '/@/renderer/features/player/context/player-context';
+import { useAudioDevices } from '/@/renderer/features/settings/components/playback/audio-settings';
 import { useSetRating } from '/@/renderer/features/shared/hooks/use-set-rating';
 import { useCreateFavorite } from '/@/renderer/features/shared/mutations/create-favorite-mutation';
 import { useDeleteFavorite } from '/@/renderer/features/shared/mutations/delete-favorite-mutation';
@@ -21,6 +22,8 @@ import {
     useFullScreenPlayerStore,
     useGeneralSettings,
     useHotkeySettings,
+    usePlaybackSettings,
+    usePlaybackType,
     usePlayerData,
     usePlayerMuted,
     usePlayerSong,
@@ -35,6 +38,7 @@ import {
 import { useFullScreenPlayerStoreActions } from '/@/renderer/store/full-screen-player.store';
 import { ActionIcon } from '/@/shared/components/action-icon/action-icon';
 import { Button } from '/@/shared/components/button/button';
+import { ContextMenu } from '/@/shared/components/context-menu/context-menu';
 import { Flex } from '/@/shared/components/flex/flex';
 import { Group } from '/@/shared/components/group/group';
 import { NumberInput } from '/@/shared/components/number-input/number-input';
@@ -50,6 +54,7 @@ import { useMediaQuery } from '/@/shared/hooks/use-media-query';
 import { useThrottledCallback } from '/@/shared/hooks/use-throttled-callback';
 import { useThrottledValue } from '/@/shared/hooks/use-throttled-value';
 import { LibraryItem, QueueSong, ServerType } from '/@/shared/types/domain-types';
+import { PlayerType } from '/@/shared/types/types';
 
 const calculateVolumeUp = (volume: number, volumeWheelStep: number) => {
     let volumeToSet: number;
@@ -506,6 +511,28 @@ const VolumeButton = () => {
     const { decreaseVolume, increaseVolume, mediaToggleMute, setVolume } = usePlayer();
     const isMinWidth = useMediaQuery('(max-width: 480px)');
 
+    const playbackType = usePlaybackType();
+    const playbackSettings = usePlaybackSettings();
+    const { setSettings } = useSettingsStoreActions();
+    const audioDevices = useAudioDevices(playbackType);
+
+    const currentAudioDeviceId =
+        playbackType === PlayerType.LOCAL
+            ? playbackSettings.mpvAudioDeviceId
+            : playbackSettings.audioDeviceId;
+
+    const handleSelectAudioDevice = useCallback(
+        (deviceId: null | string) => {
+            setSettings({
+                playback:
+                    playbackType === PlayerType.LOCAL
+                        ? { mpvAudioDeviceId: deviceId }
+                        : { audioDeviceId: deviceId },
+            });
+        },
+        [playbackType, setSettings],
+    );
+
     const [sliderValue, setSliderValue] = useState(volume);
 
     const throttledVolume = useThrottledValue(sliderValue, 100);
@@ -561,24 +588,49 @@ const VolumeButton = () => {
 
     return (
         <>
-            <ActionIcon
-                icon={muted ? 'volumeMute' : volume > 50 ? 'volumeMax' : 'volumeNormal'}
-                iconProps={{
-                    color: muted ? 'muted' : undefined,
-                    size: 'xl',
-                }}
-                onClick={(e) => {
-                    e.stopPropagation();
-                    handleMute();
-                }}
-                onWheel={handleVolumeWheel}
-                size="sm"
-                tooltip={{
-                    label: muted ? t('player.muted') : volume,
-                    openDelay: 0,
-                }}
-                variant="subtle"
-            />
+            <ContextMenu>
+                <ContextMenu.Target>
+                    <div style={{ alignItems: 'center', display: 'flex' }}>
+                        <ActionIcon
+                            icon={muted ? 'volumeMute' : volume > 50 ? 'volumeMax' : 'volumeNormal'}
+                            iconProps={{
+                                color: muted ? 'muted' : undefined,
+                                size: 'xl',
+                            }}
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                handleMute();
+                            }}
+                            onWheel={handleVolumeWheel}
+                            size="sm"
+                            tooltip={{
+                                label: muted ? t('player.muted') : volume,
+                                openDelay: 0,
+                            }}
+                            variant="subtle"
+                        />
+                    </div>
+                </ContextMenu.Target>
+                <ContextMenu.Content>
+                    <ContextMenu.Label>{t('setting.audioDevice')}</ContextMenu.Label>
+                    <ContextMenu.Item
+                        isSelected={!currentAudioDeviceId}
+                        onSelect={() => handleSelectAudioDevice(null)}
+                    >
+                        {t('setting.audioDeviceDefault', { defaultValue: 'System default' })}
+                    </ContextMenu.Item>
+                    {audioDevices.length > 0 && <ContextMenu.Divider />}
+                    {audioDevices.map((device) => (
+                        <ContextMenu.Item
+                            isSelected={device.value === currentAudioDeviceId}
+                            key={device.value}
+                            onSelect={() => handleSelectAudioDevice(device.value)}
+                        >
+                            {device.label || device.value}
+                        </ContextMenu.Item>
+                    ))}
+                </ContextMenu.Content>
+            </ContextMenu>
             {!isMinWidth ? (
                 <CustomPlayerbarSlider
                     max={100}


### PR DESCRIPTION
## What

Adds a right-click context menu to the volume/speaker icon in the player bar for quickly switching the audio output device.

- Right-clicking the speaker icon opens a menu of available output devices.
- The currently active device is checkmarked; a **System default** entry resets the selection.
- Works for both the **Web** player (`audioDeviceId`) and the **MPV** player (`mpvAudioDeviceId`).

## Why

Changing the audio output previously required opening Settings → Playback. This puts it one right-click away from where you're already controlling volume. The selection is applied live and **persists across restarts** via the existing settings store, and — unlike the settings-page selector — the menu is **not disabled during playback**.

## Implementation notes

- Reuses the existing `useAudioDevices` hook and the `audioDeviceId` / `mpvAudioDeviceId` playback settings, so device application (web `setSinkId` effect, mpv `--audio-device` param) and persistence are already wired — no new plumbing.
- The icon is wrapped in a plain `<div>` trigger inside `ContextMenu.Target` so the `onContextMenu` handler reliably reaches a DOM element (the tooltip-wrapped `ActionIcon` is not itself a suitable `asChild` target). Left-click (mute) and scroll-to-adjust-volume are unchanged.
- Adds one new i18n string, `setting.audioDeviceDefault` ("System default"), to `en.json`.

## Known limitation

On the **Web** player type with the Web Audio pipeline turned *off*, output switching is currently only wired to the `AudioContext` (not the raw `<audio>` element) — so the choice persists but won't take audible effect until Web Audio is enabled or the MPV player is used. This is a pre-existing limitation of the current codebase, not introduced by this change.

## Testing

Manual: right-click the speaker icon, select a different output device, confirm audio routes to it and that the selection survives an app restart.

> Note: I was unable to run `typecheck`/`lint` in my environment (dependencies weren't installed locally). The change was written against the existing hook/component APIs; a maintainer CI run should confirm.
