### PR TITLE
feat: musical speed controls

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1183,7 +1183,9 @@
         "queryBuilderCustomFields_inputLabel": "Label",
         "queryBuilderCustomFields_inputTag": "Tag",
         "queryBuilderCustomFields": "Custom fields",
-        "queryBuilderCustomFields_description": "Add custom fields to use in query builders"
+        "queryBuilderCustomFields_description": "Add custom fields to use in query builders",
+        "microtonalPitchControls": "Microtonal pitch controls",
+        "microtonalPitchControls_description": "Add more pitch controls to go between semi-tones"
     },
     "table": {
         "column": {

--- a/src/renderer/features/player/components/player-config.tsx
+++ b/src/renderer/features/player/components/player-config.tsx
@@ -97,8 +97,8 @@ export const PlayerConfig = () => {
                 id: 'playbackSpeed',
                 label: t('player.playbackSpeed'),
             },
-            !preservePitch && {
-                component: <PitchControls />,
+            {
+                component: !preservePitch && <PitchControls />,
                 id: 'pitchControls',
             },
             {
@@ -445,7 +445,7 @@ export const PitchControls = () => {
                     -10ct
                 </Button>
             )}
-            <Text size="xs" style={{ fontFamily: 'monospace' }} ta="center">
+            <Text size="xs" style={{ fontFamily: 'monospace' }} ta="center" w="60px">
                 {speed.toFixed(2)}% {speedToPitch(speed) > 0 && '+'}
                 {speedToPitch(speed) == 0 && '±'}
                 {speedToPitch(speed).toFixed(2)}st

--- a/src/renderer/features/player/components/player-config.tsx
+++ b/src/renderer/features/player/components/player-config.tsx
@@ -3,6 +3,7 @@ import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useAudioDevices } from '/@/renderer/features/settings/components/playback/audio-settings';
+import { useMicrotonalPitchControls } from '/@/renderer/store/settings.store';
 import { ListConfigTable } from '/@/renderer/features/shared/components/list-config-menu';
 import {
     usePlaybackType,
@@ -21,11 +22,14 @@ import {
     useShowVisualizerInSidebar,
 } from '/@/renderer/store/settings.store';
 import { ActionIcon } from '/@/shared/components/action-icon/action-icon';
+import { Button } from '/@/shared/components/button/button';
+import { Group } from '/@/shared/components/group/group';
 import { Popover } from '/@/shared/components/popover/popover';
 import { SegmentedControl } from '/@/shared/components/segmented-control/segmented-control';
 import { Select } from '/@/shared/components/select/select';
 import { Slider } from '/@/shared/components/slider/slider';
 import { Switch } from '/@/shared/components/switch/switch';
+import { Text } from '/@/shared/components/text/text';
 import { CrossfadeStyle, PlayerStatus, PlayerStyle, PlayerType } from '/@/shared/types/types';
 
 const ipc = isElectron() ? window.api.ipc : null;
@@ -92,6 +96,10 @@ export const PlayerConfig = () => {
                 component: <PlaybackSpeedSlider />,
                 id: 'playbackSpeed',
                 label: t('player.playbackSpeed'),
+            },
+            {
+                component: <PitchControls />,
+                id: 'pitchControls',
             },
             {
                 component: (
@@ -364,16 +372,15 @@ export const PlaybackSpeedSlider = () => {
         () => (value: number) => {
             const bpmValue = Number(bpm);
             if (bpmValue > 0) {
-                return `${value} x / ${(bpmValue * value).toFixed(1)} BPM`;
+                return `${value.toFixed(2)} x / ${(bpmValue * value).toFixed(1)} BPM`;
             }
-            return `${value} x`;
+            return `${value.toFixed(2)} x`;
         },
         [bpm],
     );
 
     return (
         <Slider
-            defaultValue={speed}
             label={formatPlaybackSpeedSliderLabel}
             marks={[
                 { label: '0.5', value: 0.5 },
@@ -386,14 +393,83 @@ export const PlaybackSpeedSlider = () => {
             ]}
             max={2}
             min={0.5}
-            onChangeEnd={setSpeed}
+            onChange={setSpeed}
             onDoubleClick={() => setSpeed(1)}
             step={0.01}
             styles={{
                 markLabel: {},
                 root: {},
             }}
+            value={speed}
             w="100%"
         />
+    );
+};
+
+export const PitchControls = () => {
+    const microtonal = useMicrotonalPitchControls();
+    const speed = usePlayerSpeed();
+    const { setSpeed } = usePlayerActions();
+
+    // get current semitone value
+
+    const speedToPitch = (speed: number) => {
+        return 12 * Math.log2(speed);
+    };
+
+    const pitchToSpeed = (pitch: number) => {
+        return 2 ** (pitch / 12);
+    };
+
+    const adjustMusicalSpeed = (adjustment: number) => {
+        const curPitch = speedToPitch(speed);
+        const newSpeed = pitchToSpeed(curPitch + adjustment);
+        setSpeed(newSpeed);
+    };
+
+    return (
+        <Group gap="xs" my="sm" w="100%" wrap="nowrap">
+            <Button
+                aria-label="-1 semitone"
+                fullWidth
+                onClick={() => adjustMusicalSpeed(-1)}
+                size="compact-xs"
+            >
+                -1st
+            </Button>
+            {microtonal && (
+                <Button
+                    aria-label="-10 cents"
+                    fullWidth
+                    onClick={() => adjustMusicalSpeed(-0.1)}
+                    size="compact-xs"
+                >
+                    -10ct
+                </Button>
+            )}
+            <Text size="xs" style={{ fontFamily: 'monospace' }} ta="center">
+                {speed.toFixed(2)}% {speedToPitch(speed) > 0 && '+'}
+                {speedToPitch(speed) == 0 && '±'}
+                {speedToPitch(speed).toFixed(2)}st
+            </Text>
+            {microtonal && (
+                <Button
+                    aria-label="+10 cents"
+                    fullWidth
+                    onClick={() => adjustMusicalSpeed(0.1)}
+                    size="compact-xs"
+                >
+                    +10ct
+                </Button>
+            )}
+            <Button
+                aria-label="+1 semitone"
+                fullWidth
+                onClick={() => adjustMusicalSpeed(1)}
+                size="compact-xs"
+            >
+                +1st
+            </Button>
+        </Group>
     );
 };

--- a/src/renderer/features/player/components/player-config.tsx
+++ b/src/renderer/features/player/components/player-config.tsx
@@ -3,7 +3,6 @@ import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useAudioDevices } from '/@/renderer/features/settings/components/playback/audio-settings';
-import { useMicrotonalPitchControls } from '/@/renderer/store/settings.store';
 import { ListConfigTable } from '/@/renderer/features/shared/components/list-config-menu';
 import {
     usePlaybackType,
@@ -15,6 +14,7 @@ import {
 } from '/@/renderer/store';
 import {
     useCombinedLyricsAndVisualizer,
+    useMicrotonalPitchControls,
     usePlaybackSettings,
     useSettingsStore,
     useSettingsStoreActions,
@@ -97,7 +97,7 @@ export const PlayerConfig = () => {
                 id: 'playbackSpeed',
                 label: t('player.playbackSpeed'),
             },
-            {
+            !preservePitch && {
                 component: <PitchControls />,
                 id: 'pitchControls',
             },
@@ -410,8 +410,6 @@ export const PitchControls = () => {
     const microtonal = useMicrotonalPitchControls();
     const speed = usePlayerSpeed();
     const { setSpeed } = usePlayerActions();
-
-    // get current semitone value
 
     const speedToPitch = (speed: number) => {
         return 12 * Math.log2(speed);

--- a/src/renderer/features/player/components/player-config.tsx
+++ b/src/renderer/features/player/components/player-config.tsx
@@ -428,7 +428,7 @@ export const PitchControls = () => {
     };
 
     return (
-        <Group gap="xs" my="sm" w="100%" wrap="nowrap">
+        <Group gap={microtonal ? 'xs' : 'md'} my="sm" w="100%" wrap="nowrap">
             <Button
                 aria-label="-1 semitone"
                 fullWidth

--- a/src/renderer/features/player/components/player-config.tsx
+++ b/src/renderer/features/player/components/player-config.tsx
@@ -98,8 +98,9 @@ export const PlayerConfig = () => {
                 label: t('player.playbackSpeed'),
             },
             {
-                component: !preservePitch && <PitchControls />,
+                component: !preservePitch ? <PitchControls /> : <></>,
                 id: 'pitchControls',
+                label: '',
             },
             {
                 component: (

--- a/src/renderer/features/settings/components/general/control-settings.tsx
+++ b/src/renderer/features/settings/components/general/control-settings.tsx
@@ -501,6 +501,26 @@ export const ControlSettings = memo(() => {
                   },
               ]
             : []),
+        {
+            control: (
+                <Switch
+                    defaultChecked={settings.microtonalPitchControls}
+                    onChange={(e) =>
+                        setSettings({
+                            general: {
+                                ...settings,
+                                microtonalPitchControls: e.currentTarget.checked,
+                            },
+                        })
+                    }
+                />
+            ),
+            description: t('setting.microtonalPitchControls', {
+                context: 'description',
+            }),
+            isHidden: false,
+            title: t('setting.microtonalPitchControls'),
+        },
     ];
 
     return <SettingsSection options={controlOptions} title={t('page.setting.controls')} />;

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -505,6 +505,7 @@ export const GeneralSettingsSchema = z.object({
     lastFM: z.boolean(),
     lastfmApiKey: z.string(),
     listenBrainz: z.boolean(),
+    microtonalPitchControls: z.boolean(),
     musicBrainz: z.boolean(),
     nativeAspectRatio: z.boolean(),
     nativeSpotify: z.boolean(),
@@ -1201,6 +1202,7 @@ const initialState: SettingsState = {
         lastFM: true,
         lastfmApiKey: '',
         listenBrainz: true,
+        microtonalPitchControls: false,
         musicBrainz: true,
         nativeAspectRatio: false,
         nativeSpotify: false,
@@ -2830,3 +2832,6 @@ export const useButterchurnSettings = () => {
         };
     }, shallow);
 };
+
+export const useMicrotonalPitchControls = () =>
+    useSettingsStore((state) => state.general.microtonalPitchControls, shallow);


### PR DESCRIPTION
this pr adds a new way to adjust the player speed: musical controls!

when "Preserve pitch" is disabled, buttons to control the playback speed via semitones will appear
<img width="506" height="159" alt="image" src="https://github.com/user-attachments/assets/531f8260-deca-4ceb-86b5-9ec891731c43" />


there's also a new setting to enable more pitch control buttons for those who like listening between keys
<img width="925" height="85" alt="image" src="https://github.com/user-attachments/assets/da833bde-1346-4ffc-9172-6e08135515b5" />
<img width="502" height="108" alt="image" src="https://github.com/user-attachments/assets/71150a9d-1472-4f65-896f-f1c294fd2b19" />

demo:
https://github.com/user-attachments/assets/3fdd2f2f-8ef0-47b0-8c0d-3a1819f74cd6

this closes https://github.com/jeffvli/feishin/issues/2165
