### PR TITLE
fix: startup resume-seek cancelled when shuffle is enabled

### DIFF
--- a/src/renderer/features/player/hooks/use-queue-restore.ts
+++ b/src/renderer/features/player/hooks/use-queue-restore.ts
@@ -78,9 +78,7 @@ export const useInitialTimestampRestore = () => {
         }
 
         const targetUniqueId = startupSeekTargetUniqueIdRef.current;
-        const currentUniqueId = usePlayerStore.getState().getQueue().items[
-            usePlayerStore.getState().player.index
-        ]?._uniqueId;
+        const currentUniqueId = usePlayerStore.getState().getCurrentSong()?._uniqueId;
 
         if (targetUniqueId && currentUniqueId !== targetUniqueId) {
             cancelStartupSeek();


### PR DESCRIPTION
Fixes #2202

With shuffle enabled, the startup resume-seek is silently cancelled and the saved playback position is lost as soon as playback starts.

`applyStartupSeek()` in `use-queue-restore.ts` verifies that the current song still matches the one the seek was armed for (guard added for #2094), but it looks the song up with the raw index:

```ts
usePlayerStore.getState().getQueue().items[usePlayerStore.getState().player.index]
```

`player.index` is a position in the shuffled order while `getQueue().items` is always the default order, so with shuffle on this resolves to the wrong song, the uniqueId comparison fails, and the seek is cancelled. The track then plays from 0:00 and the progress poller overwrites the persisted timestamp, so the position is gone for good.

This PR switches the lookup to `getCurrentSong()`, which maps the index through `queue.shuffled` — the same accessor the arming side uses, and the same pattern already used throughout `use-scrobble.ts`.

Verified on Linux (web player, Jellyfin, 559-track shuffled queue): before the change, pressing play after an app restart produced no `seeking` event and the position reset to 0:00; after the change, playback seeks to the saved position (`seeking` → `seeked` at the persisted timestamp) and shuffle-off behaviour is unchanged. The #2094 guard still works, since `getCurrentSong()` identifies the actually-current track in both shuffle modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
