### PR TITLE
fix: show system default audio device in the device select when unset

### DIFF
--- a/src/renderer/features/player/components/player-config.tsx
+++ b/src/renderer/features/player/components/player-config.tsx
@@ -2,7 +2,10 @@ import isElectron from 'is-electron';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { useAudioDevices } from '/@/renderer/features/settings/components/playback/audio-settings';
+import {
+    getDefaultAudioDevice,
+    useAudioDevices,
+} from '/@/renderer/features/settings/components/playback/audio-settings';
 import { ListConfigTable } from '/@/renderer/features/shared/components/list-config-menu';
 import {
     usePlaybackType,
@@ -253,7 +256,6 @@ const AudioDeviceConfig = () => {
             clearable
             comboboxProps={{ withinPortal: false }}
             data={audioDevices}
-            defaultValue={audioDeviceId}
             disabled={status === PlayerStatus.PLAYING}
             onChange={(e) => {
                 setSettings({
@@ -265,6 +267,7 @@ const AudioDeviceConfig = () => {
                     },
                 });
             }}
+            value={audioDeviceId ?? getDefaultAudioDevice(audioDevices, playbackType)}
             width="100%"
         />
     );

--- a/src/renderer/features/settings/components/playback/audio-settings.tsx
+++ b/src/renderer/features/settings/components/playback/audio-settings.tsx
@@ -39,6 +39,14 @@ const getMpvAudioDevices = async () => {
 
 export type AudioDeviceOption = { label: string; value: string };
 
+export const getDefaultAudioDevice = (
+    devices: AudioDeviceOption[],
+    playbackType: PlayerType,
+): null | string => {
+    const defaultId = playbackType === PlayerType.LOCAL ? 'auto' : 'default';
+    return devices.find((d) => d.value === defaultId)?.value ?? devices[0]?.value ?? null;
+};
+
 export const useAudioDevices = (playbackType: PlayerType) => {
     const [audioDevices, setAudioDevices] = useState<AudioDeviceOption[]>([]);
 
@@ -137,7 +145,6 @@ export const AudioSettings = memo(() => {
                 <Select
                     clearable
                     data={audioDevices}
-                    defaultValue={audioDeviceId}
                     disabled={!isElectron()}
                     onChange={(e) =>
                         setSettings({
@@ -147,6 +154,7 @@ export const AudioSettings = memo(() => {
                                     : { audioDeviceId: e },
                         })
                     }
+                    value={audioDeviceId ?? getDefaultAudioDevice(audioDevices, playbackType)}
                 />
             ),
             description: t('setting.audioDevice', { context: 'description' }),


### PR DESCRIPTION
## Problem

On a fresh install (or after clearing the selection), the **Audio device** dropdown in the player settings popover and in Settings → Playback renders blank. An unset device id actually means "follow the system default" , `setSinkId` is skipped for the web player and mpv uses `audio-device=auto` , but the UI doesn't communicate that, so it looks like no output device is configured.

## Fix

- Added a `getDefaultAudioDevice()` helper next to `useAudioDevices` that resolves the enumerated default entry (browser `default` / mpv `auto`, falling back to the first device).
- Made both device selects controlled (`value` instead of `defaultValue` - the device list loads asynchronously, so an uncontrolled default could never resolve), displaying the default entry whenever no device id is stored.
- Nothing is persisted by the fallback: the stored setting stays unset, so playback keeps following the OS default until a device is explicitly chosen. Clearing the select returns to the default entry instead of going blank. This matches the existing "System default" semantics of the volume-button context menu.

## Screenshots

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/anbarsaleem/feishin/pr-assets/audio-device-before.png) | ![after](https://raw.githubusercontent.com/anbarsaleem/feishin/pr-assets/audio-device-after.png) |

## Testing

- Verified in the Electron app: fresh state shows "Default" pre-selected in both the popover and the settings page; selecting a device pins it; clearing falls back to the default entry.
- `lint-code` and `lint-styles` pass; the two pre-existing typecheck errors on `development` (album-group files) are unrelated to this change.
