### PR TITLE
fix furigana and romaji issues

### DIFF
--- a/src/main/features/core/lyrics/furigana.ts
+++ b/src/main/features/core/lyrics/furigana.ts
@@ -35,6 +35,10 @@ const getKuroshiro = async () => {
 };
 
 export const convertFurigana = async (text: string): Promise<string> => {
+    if (typeof text !== 'string' || !text) {
+        return text;
+    }
+
     const KuroshiroClass = (Kuroshiro as any).default || Kuroshiro;
 
     // check if the text contains any Japanese kana (to distinguish Japanese from Chinese text, which shares Kanji)
@@ -51,7 +55,11 @@ export const convertFurigana = async (text: string): Promise<string> => {
 };
 
 export const convertFuriganaFragment = async (text: string): Promise<string> => {
-    if (!text || !hasJapanese(text)) {
+    if (typeof text !== 'string' || !text) {
+        return text;
+    }
+
+    if (!hasJapanese(text)) {
         return text;
     }
 
@@ -65,6 +73,10 @@ export const convertFuriganaFragment = async (text: string): Promise<string> => 
 };
 
 export const convertRomaji = async (text: string): Promise<string> => {
+    if (typeof text !== 'string' || !text) {
+        return text;
+    }
+
     const KuroshiroClass = (Kuroshiro as any).default || Kuroshiro;
 
     if (!KuroshiroClass.Util.hasKana(text)) return '';
@@ -79,7 +91,7 @@ export const convertRomaji = async (text: string): Promise<string> => {
 };
 
 export const parseLyricsTextTokens = async (text: string): Promise<LyricTextToken[]> => {
-    if (!text || !hasJapanese(text)) {
+    if (typeof text !== 'string' || !text || !hasJapanese(text)) {
         return [];
     }
 
@@ -108,6 +120,10 @@ export const parseLyricsTextTokens = async (text: string): Promise<LyricTextToke
 };
 
 export const convertRomajiTokens = async (text: string): Promise<RomajiToken[]> => {
+    if (typeof text !== 'string' || !text) {
+        return [];
+    }
+
     const KuroshiroClass = (Kuroshiro as any).default || Kuroshiro;
 
     if (!KuroshiroClass.Util.hasKana(text)) {

--- a/src/renderer/features/lyrics/components/lyrics-export-form.tsx
+++ b/src/renderer/features/lyrics/components/lyrics-export-form.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import i18n from '/@/i18n/i18n';
+import { normalizeLyrics } from '/@/renderer/features/lyrics/api/lyrics-utils';
 import { Button } from '/@/shared/components/button/button';
 import { Checkbox } from '/@/shared/components/checkbox/checkbox';
 import { Code } from '/@/shared/components/code/code';
@@ -31,8 +32,14 @@ export const LyricsExportForm = ({ lyrics, offsetMs, synced }: LyricsExportFormP
     });
 
     const displayedLyrics = useMemo(() => {
-        if (form.values.synced && Array.isArray(lyrics.lyrics)) {
-            const contents = lyrics.lyrics
+        if (Array.isArray(lyrics.lyrics)) {
+            const normalizedLyrics = normalizeLyrics(lyrics.lyrics);
+
+            if (!form.values.synced) {
+                return normalizedLyrics.map((lyric) => lyric.text).join('\n') + '\n';
+            }
+
+            const contents = normalizedLyrics
                 .map(
                     (lyric) =>
                         `[${formatDuration(lyric.startMs, { leading: true, ms: true })}]${lyric.text}`,
@@ -44,12 +51,9 @@ export const LyricsExportForm = ({ lyrics, offsetMs, synced }: LyricsExportFormP
 [offset:${form.values.offsetMs + (lyrics.offsetMs ?? 0)}]
 ${contents}
 `;
-        } else {
-            if (Array.isArray(lyrics.lyrics)) {
-                return lyrics.lyrics.map((lyric) => lyric.text).join('\n') + '\n';
-            }
-            return lyrics.lyrics;
         }
+
+        return lyrics.lyrics;
     }, [
         form.values.offsetMs,
         form.values.synced,

--- a/src/renderer/features/lyrics/hooks/use-furigana-lyrics.ts
+++ b/src/renderer/features/lyrics/hooks/use-furigana-lyrics.ts
@@ -7,6 +7,7 @@ import {
     LyricTextToken,
     RomajiToken,
 } from '/@/renderer/features/lyrics/api/lyric-conversion';
+import { normalizeLyrics } from '/@/renderer/features/lyrics/api/lyrics-utils';
 import { LyricsResponse, SyncedCueLine, SynchronizedLyrics } from '/@/shared/types/domain-types';
 
 const lyricsApi = isElectron() ? window.api.lyrics : null;
@@ -19,7 +20,7 @@ const convertSyncedLyricsFurigana = async (
     }
 
     return Promise.all(
-        lyrics.map(async (line) => ({
+        normalizeLyrics(lyrics).map(async (line) => ({
             ...line,
             cueLines: line.cueLines
                 ? await Promise.all(
@@ -53,7 +54,7 @@ const convertSyncedLyricsRomaji = async (
     convert: (text: string) => Promise<string>,
 ): Promise<SynchronizedLyrics> =>
     Promise.all(
-        lyrics.map(async (line) => ({
+        normalizeLyrics(lyrics).map(async (line) => ({
             ...line,
             cueLines: line.cueLines
                 ? await Promise.all(


### PR DESCRIPTION
## Problem

1. When furigana/romaji generation is enabled, it will not show and error in console like:

```
Error occurred in handler for 'lyric-convert-furigana': TypeError: Cannot read properties of undefined (reading 'length')
    at Object.hasKana (/Users/york/Documents/code/feishin-development/node_modules/.pnpm/kuroshiro@1.2.0/node_modules/kuroshiro/lib/util.js:126:27)
    at convertFurigana (/Users/york/Documents/code/feishin-development/out/main/index.js:3591:28)
    at /Users/york/Documents/code/feishin-development/out/main/index.js:4139:16
    at Session.<anonymous> (node:electron/js2c/browser_init:2:116372)
    at Session.emit (node:events:509:28)
Error occurred in handler for 'lyric-convert-romaji': TypeError: Cannot read properties of undefined (reading 'length')
    at Object.hasKana (/Users/york/Documents/code/feishin-development/node_modules/.pnpm/kuroshiro@1.2.0/node_modules/kuroshiro/lib/util.js:126:27)
    at convertRomaji (/Users/york/Documents/code/feishin-development/out/main/index.js:3614:28)
    at /Users/york/Documents/code/feishin-development/out/main/index.js:4148:16
    at Session.<anonymous> (node:electron/js2c/browser_init:2:116372)
    at Session.emit (node:events:509:28)
```

2. The export lyrics form will crash the app when furigana/romaji generation is enabled.

## Fix

- Normalize synced lyrics before furigana and romaji conversion so generated lyric structures display correctly.
- Normalize synced lyrics before export so generated synced lyrics can be exported without crashing.
- Harden furigana/romaji helpers to safely handle empty or non-string input.