### PR TITLE
fix: unify scrobbling behavior across subsonic servers

### DIFF
--- a/src/renderer/api/subsonic/subsonic-controller.ts
+++ b/src/renderer/api/subsonic/subsonic-controller.ts
@@ -2213,24 +2213,24 @@ export const SubsonicController: InternalControllerEndpoint = {
     scrobble: async (args) => {
         const { apiClientProps, query } = args;
 
-        if (hasFeature(apiClientProps.server, ServerFeature.REPORT_PLAYBACK)) {
-            if (query.submission || query.event === 'start') {
-                const res = await ssApiClient(apiClientProps).scrobble({
-                    query: {
-                        id: query.id,
-                        submission: query.submission,
-                    },
-                });
+        if (query.submission || query.event === 'start') {
+            const res = await ssApiClient(apiClientProps).scrobble({
+                query: {
+                    id: query.id,
+                    submission: query.submission,
+                },
+            });
 
-                if (res.status !== 200) {
-                    throw new Error('Failed to scrobble');
-                }
-
-                if (query.submission) {
-                    return null;
-                }
+            if (res.status !== 200) {
+                throw new Error('Failed to scrobble');
             }
 
+            if (query.submission) {
+                return null;
+            }
+        }
+
+        if (hasFeature(apiClientProps.server, ServerFeature.REPORT_PLAYBACK)) {
             const defaultParams = {
                 ignoreScrobble: true,
                 mediaId: query.id,
@@ -2277,17 +2277,6 @@ export const SubsonicController: InternalControllerEndpoint = {
             }
 
             return null;
-        }
-
-        const res = await ssApiClient(apiClientProps).scrobble({
-            query: {
-                id: query.id,
-                submission: query.submission,
-            },
-        });
-
-        if (res.status !== 200) {
-            throw new Error('Failed to scrobble');
         }
 
         return null;


### PR DESCRIPTION
Small change that modifies the subsonic `scrobble` controller method to always limit sending a `scrobble` payload to the subsonic backend to cases where a scrobble is being submitted or a new song is being started.

This is the current behavior for subsonic backends which support the `reportPlayback` backend (e.g., Navidrome). This change only modifies the behavior for other backends, which would receive `scrobble` notifications whenever a song changed for both the stopped song and the newly-started song.

After this change, all subsonic backends now only receive a `scrobble` when a new song is started or when feishin is attempting to submit a scrobble. This prevents issues where some backends would receive a non-submission scrobble for the previous, stopped song after receiving one for the currently playing song, resulting in the server tracking plays (or now playing information) incorrectly.