### PR TITLE
feat: support furigana and romaji generation on web

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,4 +1,4 @@
-import { externalizeDepsPlugin, UserConfig } from 'electron-vite';
+import { defineConfig, externalizeDepsPlugin, UserConfig } from 'electron-vite';
 import { resolve } from 'path';
 import conditionalImportPlugin from 'vite-plugin-conditional-import';
 import dynamicImportPlugin from 'vite-plugin-dynamic-import';
@@ -10,7 +10,7 @@ import { createReactPlugin } from './vite.react-plugin';
 const currentOSEnv = process.platform;
 const electronRendererTarget = 'chrome87';
 
-const config: UserConfig = {
+const createConfig = (isDevelopment: boolean): UserConfig => ({
     main: {
         build: {
             rollupOptions: {
@@ -68,20 +68,24 @@ const config: UserConfig = {
         },
         plugins: [
             createReactPlugin(),
-            kuromojiDictionaryPlugin({ emitDictionary: false }),
+            ...(isDevelopment ? [kuromojiDictionaryPlugin({ emitDictionary: false })] : []),
             ViteEjsPlugin({ web: false }),
         ],
         resolve: {
             alias: {
                 '/@/i18n': resolve('src/i18n'),
-                '/@/main': resolve('src/main'),
+                '/@/lyrics-conversion-api': resolve(
+                    isDevelopment
+                        ? 'src/renderer/features/lyrics/api/development-lyrics-conversion-api.ts'
+                        : 'src/renderer/features/lyrics/api/electron-lyrics-conversion-api.ts',
+                ),
                 '/@/remote': resolve('src/remote'),
                 '/@/renderer': resolve('src/renderer'),
                 '/@/shared': resolve('src/shared'),
-                path: resolve('src/renderer/shims/path.ts'),
+                ...(isDevelopment ? { path: resolve('src/renderer/shims/path.ts') } : {}),
             },
         },
     },
-};
+});
 
-export default config;
+export default defineConfig(({ command }) => createConfig(command === 'serve'));

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -4,6 +4,7 @@ import conditionalImportPlugin from 'vite-plugin-conditional-import';
 import dynamicImportPlugin from 'vite-plugin-dynamic-import';
 import { ViteEjsPlugin } from 'vite-plugin-ejs';
 
+import { kuromojiDictionaryPlugin } from './vite.kuromoji-plugin';
 import { createReactPlugin } from './vite.react-plugin';
 
 const currentOSEnv = process.platform;
@@ -65,13 +66,19 @@ const config: UserConfig = {
                 localsConvention: 'camelCase',
             },
         },
-        plugins: [createReactPlugin(), ViteEjsPlugin({ web: false })],
+        plugins: [
+            createReactPlugin(),
+            kuromojiDictionaryPlugin({ emitDictionary: false }),
+            ViteEjsPlugin({ web: false }),
+        ],
         resolve: {
             alias: {
                 '/@/i18n': resolve('src/i18n'),
+                '/@/main': resolve('src/main'),
                 '/@/remote': resolve('src/remote'),
                 '/@/renderer': resolve('src/renderer'),
                 '/@/shared': resolve('src/shared'),
+                path: resolve('src/renderer/shims/path.ts'),
             },
         },
     },

--- a/src/main/features/core/lyrics/furigana.ts
+++ b/src/main/features/core/lyrics/furigana.ts
@@ -17,6 +17,14 @@ export type RomajiToken = LyricTextToken & {
 let kuroshiroInstance: any = null;
 let initPromise: null | Promise<void> = null;
 
+const getDictionaryPath = (): string | undefined => {
+    if (typeof document === 'undefined') {
+        return undefined;
+    }
+
+    return new URL('./assets/kuromoji/', document.baseURI).href;
+};
+
 const getKuroshiro = async () => {
     if (initPromise) {
         await initPromise;
@@ -26,8 +34,13 @@ const getKuroshiro = async () => {
     if (kuroshiroInstance) return kuroshiroInstance;
 
     const KuroshiroClass = (Kuroshiro as any).default || Kuroshiro;
+    const dictionaryPath = getDictionaryPath();
+    const analyzer = dictionaryPath
+        ? new KuromojiAnalyzer({ dictPath: dictionaryPath })
+        : new KuromojiAnalyzer();
+
     kuroshiroInstance = new KuroshiroClass();
-    initPromise = kuroshiroInstance.init(new KuromojiAnalyzer());
+    initPromise = kuroshiroInstance.init(analyzer);
     await initPromise;
 
     initPromise = null;

--- a/src/renderer/features/lyrics/api/development-lyrics-conversion-api.ts
+++ b/src/renderer/features/lyrics/api/development-lyrics-conversion-api.ts
@@ -1,0 +1,13 @@
+import isElectron from 'is-electron';
+
+import * as browserLyricsApi from '../../../../main/features/core/lyrics/furigana';
+
+const lyricsApi = isElectron() ? window.api.lyrics : browserLyricsApi;
+
+export const {
+    convertFurigana,
+    convertFuriganaFragment,
+    convertRomaji,
+    convertRomajiTokens,
+    parseLyricsTextTokens,
+} = lyricsApi;

--- a/src/renderer/features/lyrics/api/electron-lyrics-conversion-api.ts
+++ b/src/renderer/features/lyrics/api/electron-lyrics-conversion-api.ts
@@ -1,0 +1,7 @@
+export const {
+    convertFurigana,
+    convertFuriganaFragment,
+    convertRomaji,
+    convertRomajiTokens,
+    parseLyricsTextTokens,
+} = window.api.lyrics;

--- a/src/renderer/features/lyrics/components/lyrics-settings-form.tsx
+++ b/src/renderer/features/lyrics/components/lyrics-settings-form.tsx
@@ -372,7 +372,6 @@ export const LyricsSettingsForm = ({ settingsKey }: LyricsSettingsFormProps) => 
             description: t('setting.enableFurigana', {
                 context: 'description',
             }),
-            isHidden: !isElectron(),
             title: t('setting.enableFurigana'),
         },
         {
@@ -386,7 +385,6 @@ export const LyricsSettingsForm = ({ settingsKey }: LyricsSettingsFormProps) => 
             description: t('setting.enableRomaji', {
                 context: 'description',
             }),
-            isHidden: !isElectron(),
             title: t('setting.enableRomaji'),
         },
         {

--- a/src/renderer/features/lyrics/hooks/use-furigana-lyrics.ts
+++ b/src/renderer/features/lyrics/hooks/use-furigana-lyrics.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import isElectron from 'is-electron';
 
+import * as browserLyricsApi from '/@/main/features/core/lyrics/furigana';
 import {
     alignFuriganaToWordCues,
     alignRomajiTokensToWordCues,
@@ -10,15 +11,11 @@ import {
 import { normalizeLyrics } from '/@/renderer/features/lyrics/api/lyrics-utils';
 import { LyricsResponse, SyncedCueLine, SynchronizedLyrics } from '/@/shared/types/domain-types';
 
-const lyricsApi = isElectron() ? window.api.lyrics : null;
+const lyricsApi = isElectron() ? window.api.lyrics : browserLyricsApi;
 
 const convertSyncedLyricsFurigana = async (
     lyrics: SynchronizedLyrics,
 ): Promise<SynchronizedLyrics> => {
-    if (!lyricsApi) {
-        return lyrics;
-    }
-
     return Promise.all(
         normalizeLyrics(lyrics).map(async (line) => ({
             ...line,
@@ -76,9 +73,9 @@ const convertSyncedLyricsRomaji = async (
 
 export const useFuriganaLyrics = (lyrics: LyricsResponse | null | undefined, enabled: boolean) => {
     return useQuery({
-        enabled: enabled && !!lyrics && !!lyricsApi,
+        enabled: enabled && !!lyrics,
         queryFn: async () => {
-            if (!lyrics || !lyricsApi || !enabled) return lyrics;
+            if (!lyrics || !enabled) return lyrics;
 
             if (typeof lyrics === 'string') {
                 return await lyricsApi.convertFurigana(lyrics);
@@ -97,9 +94,9 @@ export const useFuriganaLyrics = (lyrics: LyricsResponse | null | undefined, ena
 
 export const useRomajiLyrics = (lyrics: LyricsResponse | null | undefined, enabled: boolean) => {
     return useQuery({
-        enabled: enabled && !!lyrics && !!lyricsApi,
+        enabled: enabled && !!lyrics,
         queryFn: async () => {
-            if (!lyrics || !lyricsApi || !enabled) return lyrics;
+            if (!lyrics || !enabled) return lyrics;
 
             if (typeof lyrics === 'string') {
                 return await lyricsApi.convertRomaji(lyrics);
@@ -129,10 +126,6 @@ const buildSyncedRomajiLine = async (
             continue;
         }
 
-        if (!lyricsApi) {
-            return cueLines.map(() => null);
-        }
-
         const tokens = (await lyricsApi.convertRomajiTokens(cueLine.value)) as RomajiToken[];
         if (!tokens.length) {
             romajiCueLines.push(null);
@@ -160,9 +153,9 @@ export const useSyncedRomajiLyrics = (
     enabled: boolean,
 ) => {
     return useQuery({
-        enabled: enabled && !!lyrics && !!lyricsApi,
+        enabled: enabled && !!lyrics,
         queryFn: async (): Promise<null | SyncedRomajiLyrics> => {
-            if (!lyrics || !lyricsApi || !enabled) {
+            if (!lyrics || !enabled) {
                 return null;
             }
 

--- a/src/renderer/features/lyrics/hooks/use-furigana-lyrics.ts
+++ b/src/renderer/features/lyrics/hooks/use-furigana-lyrics.ts
@@ -1,7 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
-import isElectron from 'is-electron';
 
-import * as browserLyricsApi from '/@/main/features/core/lyrics/furigana';
+import * as lyricsApi from '/@/lyrics-conversion-api';
 import {
     alignFuriganaToWordCues,
     alignRomajiTokensToWordCues,
@@ -10,8 +9,6 @@ import {
 } from '/@/renderer/features/lyrics/api/lyric-conversion';
 import { normalizeLyrics } from '/@/renderer/features/lyrics/api/lyrics-utils';
 import { LyricsResponse, SyncedCueLine, SynchronizedLyrics } from '/@/shared/types/domain-types';
-
-const lyricsApi = isElectron() ? window.api.lyrics : browserLyricsApi;
 
 const convertSyncedLyricsFurigana = async (
     lyrics: SynchronizedLyrics,

--- a/src/renderer/features/settings/components/general/lyric-settings.tsx
+++ b/src/renderer/features/settings/components/general/lyric-settings.tsx
@@ -104,7 +104,6 @@ export const LyricSettings = memo(() => {
             description: t('setting.enableFurigana', {
                 context: 'description',
             }),
-            isHidden: !isElectron(),
             title: t('setting.enableFurigana'),
         },
         {
@@ -118,7 +117,6 @@ export const LyricSettings = memo(() => {
             description: t('setting.enableRomaji', {
                 context: 'description',
             }),
-            isHidden: !isElectron(),
             title: t('setting.enableRomaji'),
         },
         {

--- a/src/renderer/shims/path.ts
+++ b/src/renderer/shims/path.ts
@@ -1,0 +1,9 @@
+export const join = (...parts: string[]): string =>
+    parts
+        .filter(Boolean)
+        .map((part, index) =>
+            index === 0 ? part.replace(/\/+$/u, '') : part.replace(/^\/+|\/+$/gu, ''),
+        )
+        .join('/');
+
+export default { join };

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -2,6 +2,7 @@
   "extends": "@electron-toolkit/tsconfig/tsconfig.node.json",
   "include": [
     "electron.vite.config.*",
+    "vite.kuromoji-plugin.ts",
     "vite.react-plugin.ts",
     "src/main/**/*",
     "src/preload/**/*",

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -6,6 +6,7 @@
     "src/renderer/**/*.tsx",
     "src/preload/*.d.ts",
     "src/i18n/**/*",
+    "src/main/features/core/lyrics/furigana.ts",
     "src/shared/**/*",
     "src/remote/**/*",
     "package.json"
@@ -17,6 +18,9 @@
     "paths": {
       "/@/renderer/*": [
         "src/renderer/*"
+      ],
+      "/@/main/*": [
+        "src/main/*"
       ],
       "/@/shared/*": [
         "src/shared/*"

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -19,8 +19,8 @@
       "/@/renderer/*": [
         "src/renderer/*"
       ],
-      "/@/main/*": [
-        "src/main/*"
+      "/@/lyrics-conversion-api": [
+        "src/main/features/core/lyrics/furigana.ts"
       ],
       "/@/shared/*": [
         "src/shared/*"

--- a/vite.kuromoji-plugin.ts
+++ b/vite.kuromoji-plugin.ts
@@ -1,0 +1,54 @@
+import type { Connect, Plugin } from 'vite';
+
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+const analyzerRequire = createRequire(require.resolve('kuroshiro-analyzer-kuromoji/package.json'));
+const dictionaryDirectory = path.join(
+    path.dirname(analyzerRequire.resolve('kuromoji/package.json')),
+    'dict',
+);
+const dictionaryFiles = fs
+    .readdirSync(dictionaryDirectory)
+    .filter((fileName) => fileName.endsWith('.dat.gz'));
+
+const serveDictionary: Connect.NextHandleFunction = (request, response, next) => {
+    const fileName = path.basename(new URL(request.url ?? '/', 'http://localhost').pathname);
+
+    if (!dictionaryFiles.includes(fileName)) {
+        next();
+        return;
+    }
+
+    response.setHeader('Content-Type', 'application/gzip');
+    fs.createReadStream(path.join(dictionaryDirectory, fileName)).pipe(response);
+};
+
+type KuromojiDictionaryPluginOptions = {
+    emitDictionary?: boolean;
+};
+
+export const kuromojiDictionaryPlugin = ({
+    emitDictionary = true,
+}: KuromojiDictionaryPluginOptions = {}): Plugin => ({
+    configurePreviewServer(server) {
+        server.middlewares.use('/assets/kuromoji', serveDictionary);
+    },
+    configureServer(server) {
+        server.middlewares.use('/assets/kuromoji', serveDictionary);
+    },
+    generateBundle() {
+        if (!emitDictionary) return;
+
+        for (const fileName of dictionaryFiles) {
+            this.emitFile({
+                fileName: `assets/kuromoji/${fileName}`,
+                source: fs.readFileSync(path.join(dictionaryDirectory, fileName)),
+                type: 'asset',
+            });
+        }
+    },
+    name: 'kuromoji-dictionary',
+});

--- a/web.vite.config.ts
+++ b/web.vite.config.ts
@@ -3,6 +3,7 @@ import { defineConfig, normalizePath } from 'vite';
 import { ViteEjsPlugin } from 'vite-plugin-ejs';
 import { VitePWA } from 'vite-plugin-pwa';
 
+import { kuromojiDictionaryPlugin } from './vite.kuromoji-plugin';
 import { createReactPlugin } from './vite.react-plugin';
 
 export default defineConfig({
@@ -65,6 +66,7 @@ export default defineConfig({
     },
     plugins: [
         createReactPlugin(),
+        kuromojiDictionaryPlugin(),
         ViteEjsPlugin({
             root: normalizePath(path.resolve(__dirname, './src/renderer')),
             web: true,
@@ -134,6 +136,7 @@ export default defineConfig({
             workbox: {
                 cleanupOutdatedCaches: true,
                 clientsClaim: true,
+                globIgnores: ['**/kuromoji/**'],
                 maximumFileSizeToCacheInBytes: 1000000 * 5, // 5 MB
                 skipWaiting: true,
             },
@@ -142,9 +145,11 @@ export default defineConfig({
     resolve: {
         alias: {
             '/@/i18n': path.resolve(__dirname, './src/i18n'),
+            '/@/main': path.resolve(__dirname, './src/main'),
             '/@/remote': path.resolve(__dirname, './src/remote'),
             '/@/renderer': path.resolve(__dirname, './src/renderer'),
             '/@/shared': path.resolve(__dirname, './src/shared'),
+            path: path.resolve(__dirname, './src/renderer/shims/path.ts'),
         },
     },
     root: path.resolve(__dirname, './src/renderer'),

--- a/web.vite.config.ts
+++ b/web.vite.config.ts
@@ -145,7 +145,10 @@ export default defineConfig({
     resolve: {
         alias: {
             '/@/i18n': path.resolve(__dirname, './src/i18n'),
-            '/@/main': path.resolve(__dirname, './src/main'),
+            '/@/lyrics-conversion-api': path.resolve(
+                __dirname,
+                './src/main/features/core/lyrics/furigana.ts',
+            ),
             '/@/remote': path.resolve(__dirname, './src/remote'),
             '/@/renderer': path.resolve(__dirname, './src/renderer'),
             '/@/shared': path.resolve(__dirname, './src/shared'),


### PR DESCRIPTION
As mentioned in #2219 (https://github.com/jeffvli/feishin/pull/2219#issuecomment-4972108136), this PR enables the existing furigana and romaji settings in the web app and runs Kuroshiro directly in the browser.

The web build now includes the required Kuromoji dictionaries, while Vite serves them during development and preview. Electron continues to use the existing IPC implementation.

Tested locally with both the dev server and a production web build.

<img width="2032" height="1110" alt="CleanShot 2026-07-15 at 15 10 09" src="https://github.com/user-attachments/assets/80a39a76-81fd-4a72-b272-7c7e8de88e68" />

<img width="2032" height="1110" alt="CleanShot 2026-07-15 at 15 10 26" src="https://github.com/user-attachments/assets/18b4dae4-a2e9-4f75-8c08-6d968b0c23f1" />
