### PR TITLE
fix: use compilation release type label on album details

### DIFF
--- a/src/renderer/features/albums/components/album-detail-content.tsx
+++ b/src/renderer/features/albums/components/album-detail-content.tsx
@@ -105,7 +105,17 @@ const AlbumMetadataTags = ({ album }: AlbumMetadataTagsProps) => {
     const defaultTagItems = useMemo(() => {
         if (!album) return [];
 
-        const releaseTypes = normalizeReleaseTypes(album.releaseTypes ?? [], t).map((type) => ({
+        const releaseTypes = [...(album.releaseTypes ?? [])];
+
+        const hasCompilationReleaseType = releaseTypes.some(
+            (type) => type.toLowerCase() === 'compilation',
+        );
+
+        if (album.isCompilation && !hasCompilationReleaseType) {
+            releaseTypes.push('compilation');
+        }
+
+        const releaseTypeItems = normalizeReleaseTypes(releaseTypes, t).map((type) => ({
             id: type,
             value: titleCase(type),
         }));
@@ -124,24 +134,15 @@ const AlbumMetadataTags = ({ album }: AlbumMetadataTagsProps) => {
 
         const items: Array<{ id: string; value: ReactNode | string | undefined }> = [];
 
-        items.push(
-            ...releaseTypes,
-            {
-                id: 'isCompilation',
-                value: album?.isCompilation ? t('filter.isCompilation') : undefined,
-            },
-            ...releaseCountries,
-            ...releaseStatuses,
-            {
-                id: 'explicitStatus',
-                value:
-                    album.explicitStatus === ExplicitStatus.EXPLICIT
-                        ? t('common.explicit')
-                        : album.explicitStatus === ExplicitStatus.CLEAN
-                          ? t('common.clean')
-                          : undefined,
-            },
-        );
+        items.push(...releaseTypeItems, ...releaseCountries, ...releaseStatuses, {
+            id: 'explicitStatus',
+            value:
+                album.explicitStatus === ExplicitStatus.EXPLICIT
+                    ? t('common.explicit')
+                    : album.explicitStatus === ExplicitStatus.CLEAN
+                      ? t('common.clean')
+                      : undefined,
+        });
 
         return items.filter((item) => item.value);
     }, [album, t]);


### PR DESCRIPTION
The `filter.isCompilation` string is also used as a metadata pill on the album detail page.

This works for filters, but can be grammatically awkward as a display label in some languages.

This change treats `album.isCompilation` as a fallback for the `compilation` release type:

- If `releaseTypes` already contains `compilation`, no extra pill is added.
- If it does not, but `isCompilation` is true, `compilation` is added before normalization.
- The existing release type translation is reused.
- Duplicate compilation pills are avoided.

Related Weblate discussion:
https://hosted.weblate.org/translate/feishin/translation/zh_Hant/?checksum=2923f4fe61ccbba3

| Before | After |
| --- | --- |
| <img width="536" alt="Before: the album page shows the filter label as a metadata pill" src="https://github.com/user-attachments/assets/771c99c4-aa7c-4134-b812-36af3ee9773e" /> | <img width="413" alt="After: the album page uses the compilation release type label" src="https://github.com/user-attachments/assets/3acb5157-a000-4af7-8e9c-599a8676551d" /> |