### PR TITLE
feat(player): add autoplay on open

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1080,6 +1080,8 @@
         "preservePitch": "Preserve pitch",
         "audioFadeOnStatusChange": "Audio fade on status change",
         "audioFadeOnStatusChange_description": "Enables fade out and fade in when play/pause status changes",
+        "autoPlayOnOpen": "Autoplay on open",
+        "autoPlayOnOpen_description": "Continue playing when the application is reopened if playback was active when it was closed. Enabling this also enables Save play queue",
         "preventSleepOnPlayback_description": "Prevent the display from sleeping while music is playing",
         "preventSleepOnPlayback": "Prevent sleep on playback",
         "preventSuspendOnPlayback_description": "Prevent the application from suspending while music is playing",

--- a/src/renderer/features/analytics/hooks/use-app-tracker.ts
+++ b/src/renderer/features/analytics/hooks/use-app-tracker.ts
@@ -70,6 +70,7 @@ type SettingsProperties = {
     'settings.autoDJ': boolean;
     'settings.autoDJItemCount': number;
     'settings.autoDJTiming': number;
+    'settings.autoPlayOnOpen': boolean;
     'settings.customCss': boolean;
     'settings.disableAutoUpdate': boolean;
     'settings.discord': boolean;
@@ -143,6 +144,7 @@ const getSettingsProperties = (): SettingsProperties => {
         'settings.autoDJ': settings.autoDJ.enabled,
         'settings.autoDJItemCount': settings.autoDJ.itemCount,
         'settings.autoDJTiming': settings.autoDJ.timing,
+        'settings.autoPlayOnOpen': settings.general.autoPlayOnOpen,
         'settings.customCss': settings.css.enabled,
         'settings.disableAutoUpdate': ignoreWeb(settings.window.disableAutoUpdate),
         'settings.discord': ignoreWeb(settings.discord.enabled),

--- a/src/renderer/features/settings/components/general/application-settings.tsx
+++ b/src/renderer/features/settings/components/general/application-settings.tsx
@@ -345,7 +345,8 @@ export const ApplicationSettings = memo(() => {
         {
             control: (
                 <Switch
-                    defaultChecked={settings.resume}
+                    checked={settings.resume || settings.autoPlayOnOpen}
+                    disabled={settings.autoPlayOnOpen}
                     onChange={(e) => {
                         localSettings?.set('resume', e.target.checked);
                         setSettings({
@@ -362,6 +363,34 @@ export const ApplicationSettings = memo(() => {
             }),
             isHidden: !isElectron(),
             title: t('setting.savePlayQueue'),
+        },
+        {
+            control: (
+                <Switch
+                    checked={settings.autoPlayOnOpen}
+                    onChange={(e) => {
+                        const autoPlayOnOpen = e.currentTarget.checked;
+                        const resume = autoPlayOnOpen ? true : settings.resume;
+
+                        if (autoPlayOnOpen) {
+                            localSettings?.set('resume', true);
+                        }
+
+                        setSettings({
+                            general: {
+                                ...settings,
+                                autoPlayOnOpen,
+                                resume,
+                            },
+                        });
+                    }}
+                />
+            ),
+            description: t('setting.autoPlayOnOpen', {
+                context: 'description',
+            }),
+            isHidden: !isElectron(),
+            title: t('setting.autoPlayOnOpen'),
         },
         {
             control: (

--- a/src/renderer/store/player.store.ts
+++ b/src/renderer/store/player.store.ts
@@ -1719,18 +1719,21 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                 usePlayerStoreBase.setState({ hydrated: true });
             },
             partialize: (state) => {
-                const shouldRestorePlayQueue = useSettingsStore.getState().general.resume;
+                const { autoPlayOnOpen, resume } = useSettingsStore.getState().general;
+                const shouldRestorePlayQueue = resume || autoPlayOnOpen;
 
                 // Exclude playerNum and seekToTimestamp from the stored player object.
-                // The status is persisted with the queue so an active session can continue
-                // playing when the app is opened again.
                 // Note: timestamp is now in a separate store and doesn't need to be excluded here
                 const excludedPlayerKeys = ['playerNum', 'seekToTimestamp'];
+
+                if (!autoPlayOnOpen) {
+                    excludedPlayerKeys.push('status');
+                }
 
                 // If we're not restoring the play queue, the index and status are meaningless
                 // without a song to play and must remain at their initial values on startup.
                 if (!shouldRestorePlayQueue) {
-                    excludedPlayerKeys.push('index', 'status');
+                    excludedPlayerKeys.push('index');
                 }
 
                 const player = Object.fromEntries(

--- a/src/renderer/store/player.store.ts
+++ b/src/renderer/store/player.store.ts
@@ -1721,15 +1721,16 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
             partialize: (state) => {
                 const shouldRestorePlayQueue = useSettingsStore.getState().general.resume;
 
-                // Exclude playerNum, seekToTimestamp, and status from stored player object
-                // These are not needed to be stored since they are ephemeral properties
+                // Exclude playerNum and seekToTimestamp from the stored player object.
+                // The status is persisted with the queue so an active session can continue
+                // playing when the app is opened again.
                 // Note: timestamp is now in a separate store and doesn't need to be excluded here
-                const excludedPlayerKeys = ['playerNum', 'seekToTimestamp', 'status'];
+                const excludedPlayerKeys = ['playerNum', 'seekToTimestamp'];
 
-                // If we're not restoring the play queue, we don't need the index property
-                // (it is meaningless without the queue)
+                // If we're not restoring the play queue, the index and status are meaningless
+                // without a song to play and must remain at their initial values on startup.
                 if (!shouldRestorePlayQueue) {
-                    excludedPlayerKeys.push('index');
+                    excludedPlayerKeys.push('index', 'status');
                 }
 
                 const player = Object.fromEntries(

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -497,6 +497,7 @@ export const GeneralSettingsSchema = z.object({
     artistItems: z.array(SortableItemSchema(ArtistItemSchema)),
     artistRadioCount: z.number(),
     artistReleaseTypeItems: z.array(SortableItemSchema(ArtistReleaseTypeItemSchema)),
+    autoPlayOnOpen: z.boolean(),
     autoSave: AutoSaveSchema,
     blurExplicitImages: z.boolean(),
     buttonSize: z.number(),
@@ -1223,6 +1224,7 @@ const initialState: SettingsState = {
         artistItems,
         artistRadioCount: 20,
         artistReleaseTypeItems,
+        autoPlayOnOpen: false,
         autoSave: {
             count: 10,
             enabled: false,
@@ -2620,10 +2622,14 @@ export const useSettingsStore = createWithEqualityFn<SettingsSlice>()(
                     }
                 }
 
+                if (version < 32) {
+                    state.general.autoPlayOnOpen = false;
+                }
+
                 return persistedState;
             },
             name: 'store_settings',
-            version: 31,
+            version: 32,
         },
     ),
 );


### PR DESCRIPTION
## Summary

- add an opt-in **Autoplay on open** setting under General → Application
- persist the playing state only when autoplay on open is enabled
- automatically enable and lock **Save play queue** while autoplay on open is enabled
- keep paused and stopped sessions idle after reopening

Closes #2241
