### PR TITLE
fix: add close window button to macOS menu

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -104,14 +104,14 @@ export default class MenuBuilder {
                     click: () => {
                         this.mainWindow.webContents.send('renderer-open-settings');
                     },
-                    label: 'Settings',
+                    label: 'Settings...',
                 },
                 { type: 'separator' },
                 {
                     click: () => {
                         this.mainWindow.webContents.send('renderer-open-manage-servers');
                     },
-                    label: 'Manage Servers',
+                    label: 'Manage Servers...',
                 },
                 {
                     checked: privateMode,
@@ -141,6 +141,8 @@ export default class MenuBuilder {
                     },
                     label: 'Create Playlist...',
                 },
+                { type: 'separator' },
+                { role: 'close' },
             ],
         };
         const subMenuEdit: MenuItemConstructorOptions = { role: 'editMenu' };


### PR DESCRIPTION
Add the `close` role (Close Window button) to the File menu so Cmd + W can close the window.

<img width="177" height="94" alt="CleanShot 2026-07-19 at 10 13 46" src="https://github.com/user-attachments/assets/3b6706fd-3f23-4638-a845-f4c2a5d2ecf4" />

Also add `...` suffixes to Settings and Manage Servers to indicate that they open dialogs.

Sorry for forgetting to include these changes in #2242.