### PR TITLE
fix: keep a seek control when the waveform fails to load

### DIFF
--- a/src/renderer/features/player/components/playerbar-waveform.tsx
+++ b/src/renderer/features/player/components/playerbar-waveform.tsx
@@ -27,6 +27,7 @@ export const PlayerbarWaveform = () => {
     const audioElementRef = useRef<HTMLAudioElement>(document.createElement('audio'));
     const { mediaSeekToTimestamp } = usePlayer();
     const [isLoading, setIsLoading] = useState(true);
+    const [hasError, setHasError] = useState(false);
     const [isDragging, setIsDragging] = useState(false);
     const [tooltipPosition, setTooltipPosition] = useState<null | { x: number; y: number }>(null);
     const [tooltipValue, setTooltipValue] = useState(0);
@@ -77,14 +78,27 @@ export const PlayerbarWaveform = () => {
     // Reset loading state when stream URL changes and ensure media is muted
     useEffect(() => {
         setIsLoading(true);
+        setHasError(false);
     }, [streamUrl]);
 
     // Handle waveform ready state
     useEffect(() => {
         if (!wavesurfer || !streamUrl) return;
 
+        // The wavesurfer instance is shared across stream URLs, and this
+        // effect subscribes before its (delayed) load actually starts. Guard
+        // against events that do not belong to this effect's own load:
+        // `cancelled` rejects events after the URL has moved on, and
+        // `loadStarted` rejects a still-in-flight previous load's `ready`
+        // (which would otherwise clear the loading state for the wrong
+        // track and hide the seek bar over an empty/stale waveform).
+        let cancelled = false;
+        let loadStarted = false;
+
         const handleReady = () => {
+            if (cancelled || !loadStarted) return;
             setIsLoading(false);
+            setHasError(false);
             const mediaElement = wavesurfer.getMediaElement();
             if (mediaElement) {
                 mediaElement.muted = true;
@@ -92,17 +106,40 @@ export const PlayerbarWaveform = () => {
             }
         };
 
+        // A load failure previously left the waveform canvas empty with no
+        // seek control (the fallback slider only showed while loading), so
+        // the progress bar disappeared until the app was restarted. Surface
+        // real failures so the fallback slider is rendered again. AbortError
+        // is the expected outcome of a superseded load and is ignored.
+        const handleError = (error?: unknown) => {
+            if (cancelled || !loadStarted) return;
+            if (error instanceof Error && error.name === 'AbortError') return;
+            setIsLoading(false);
+            setHasError(true);
+        };
+
         wavesurfer.on('ready', handleReady);
+        wavesurfer.on('error', handleError);
 
         const waveformTimeout = setTimeout(
             () => {
-                wavesurfer.load(streamUrl);
+                if (cancelled) return;
+                loadStarted = true;
+                wavesurfer.load(streamUrl).catch((error: unknown) => {
+                    if (cancelled || (error instanceof Error && error.name === 'AbortError')) {
+                        return;
+                    }
+                    setIsLoading(false);
+                    setHasError(true);
+                });
             },
             playerbarSlider?.loadingDelay ? playerbarSlider.loadingDelay * 1000 : 2000,
         );
 
         return () => {
+            cancelled = true;
             wavesurfer.un('ready', handleReady);
+            wavesurfer.un('error', handleError);
             clearTimeout(waveformTimeout);
         };
     }, [wavesurfer, streamUrl, playerbarSlider.loadingDelay]);
@@ -349,14 +386,14 @@ export const PlayerbarWaveform = () => {
             style={{ position: 'relative' }}
         >
             <motion.div
-                animate={{ opacity: isLoading ? 0 : 1 }}
+                animate={{ opacity: isLoading || hasError ? 0 : 1 }}
                 className={styles.waveform}
                 initial={{ opacity: 0 }}
                 ref={containerRef}
                 transition={{ duration: 0.2 }}
             />
             <AnimatePresence>
-                {isLoading && (
+                {(isLoading || hasError) && (
                     <motion.div
                         animate={{ opacity: 1 }}
                         exit={{ opacity: 0 }}


### PR DESCRIPTION
## Summary

Fixes #2193: the playerbar seek/progress bar can disappear entirely after switching tracks, with the only recovery being a full app restart. This makes the waveform component always keep a working seek control, even when the waveform itself fails to load.

## Background

`PlayerbarWaveform` renders the standard `PlayerbarSeekSlider` as a fallback *only* while `isLoading` is true, and clears `isLoading` on any wavesurfer `ready` event. It has no failure handling: `wavesurfer.load(streamUrl)` is called with no `.catch()`, and there is no `error` listener. So when a load fails, or when a stale `ready` from a superseded load clears the loading flag for the wrong track, the component is left with an empty waveform canvas and no seek slider. The reporter described it as "trying to switch to a waveform view, but fails," and it was confirmed by a contributor across Linux (X11/Wayland) and Windows 11, which points at a logic gap in the component rather than a platform issue. There is no reliable reproduction, but the symptom maps directly to this unhandled-failure path.

## Fix

- Add an explicit `hasError` state and render the fallback `PlayerbarSeekSlider` whenever the waveform `isLoading || hasError`, hiding the empty canvas in that case. This guarantees a seek control is always present.
- Add a `wavesurfer.on('error', ...)` listener and a `.catch()` on `load()` that ignore `AbortError` (the expected result of a rapid track switch) and surface only genuine failures into `hasError`.
- Add a per-load `loadStarted` guard alongside the existing effect cleanup so `ready`/`error` events from a previous, superseded load are ignored and cannot clear the loading state for the wrong track. `hasError` resets on stream-URL change and on a successful `ready`.

The happy path is unchanged: when a load succeeds and `ready` fires, the waveform shows and the fallback hides exactly as before.

## Testing

`pnpm run typecheck` and `eslint` on the changed file both pass. This repository's CI (`test.yml`) runs only `pnpm run lint` (typecheck + eslint + stylelint) and has no unit-test harness, so verification is lint/typecheck plus manual reasoning about the load/ready/error state transitions; the change is scoped to a single component and preserves existing behavior for successful loads.

Closes #2193

AI was used for assistance.
