### PR TITLE
feat: implemented random button in the playlist view

### DIFF
--- a/src/renderer/features/playlists/components/playlist-detail-album-view.tsx
+++ b/src/renderer/features/playlists/components/playlist-detail-album-view.tsx
@@ -57,7 +57,7 @@ export const PlaylistDetailAlbumView = ({
     const sortBy = (query.sortBy as SongListSort) ?? SongListSort.ID;
     // only re-randomize when the sort is actually random
     const randomRefreshRevision = sortBy === SongListSort.RANDOM ? refreshRevision : null;
-    const randomCacheRef = useRef<{ revision: boolean | null; songs: Song[] }>();
+    const randomCacheRef = useRef<{ revision: boolean | null; songs: Song[] }>(undefined);
 
     const filteredAndSortedSongs = useMemo(() => {
         const raw = data?.items ?? [];

--- a/src/renderer/features/playlists/components/playlist-detail-album-view.tsx
+++ b/src/renderer/features/playlists/components/playlist-detail-album-view.tsx
@@ -1,3 +1,4 @@
+import shuffle from 'lodash/shuffle';
 import { useEffect, useMemo } from 'react';
 
 import { useGridRows } from '/@/renderer/components/item-list/helpers/use-grid-rows';
@@ -36,7 +37,13 @@ import {
     TableColumn,
 } from '/@/shared/types/types';
 
-export const PlaylistDetailAlbumView = ({ data }: { data: PlaylistSongListResponse }) => {
+export const PlaylistDetailAlbumView = ({
+    data,
+    refreshRevision,
+}: {
+    data: PlaylistSongListResponse;
+    refreshRevision: boolean;
+}) => {
     const player = usePlayer();
     const { setItemCount, setListData } = useListContext();
     const { detail, display, grid, itemsPerPage, pagination, table } = useListSettings(
@@ -59,12 +66,29 @@ export const PlaylistDetailAlbumView = ({ data }: { data: PlaylistSongListRespon
             return searched;
         }
 
-        return sortSongList(
-            searched,
-            (query.sortBy as SongListSort) ?? SongListSort.ID,
-            (query.sortOrder as SortOrder) ?? SortOrder.ASC,
-        );
-    }, [data?.items, query, searchTerm]);
+        const sortBy = (query.sortBy as SongListSort) ?? SongListSort.ID;
+        const sortOrder = (query.sortOrder as SortOrder) ?? SortOrder.ASC;
+
+        if (sortBy === SongListSort.RANDOM) {
+            const songsByAlbum = new Map<string, Song[]>();
+
+            searched.forEach((song) => {
+                const albumSongs = songsByAlbum.get(song.albumId);
+                if (albumSongs) {
+                    albumSongs.push(song);
+                } else {
+                    songsByAlbum.set(song.albumId, [song]);
+                }
+            });
+
+            return shuffle(Array.from(songsByAlbum.values())).flatMap((albumSongs) =>
+                sortSongList(albumSongs, SongListSort.ALBUM, SortOrder.ASC),
+            );
+        }
+
+        return sortSongList(searched, sortBy, sortOrder);
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- refreshRevision intentionally triggers a new random order
+    }, [data?.items, query, searchTerm, refreshRevision]);
 
     const sortedAlbums = useMemo(
         () => playlistSongsToAlbums(filteredAndSortedSongs),

--- a/src/renderer/features/playlists/components/playlist-detail-album-view.tsx
+++ b/src/renderer/features/playlists/components/playlist-detail-album-view.tsx
@@ -54,6 +54,10 @@ export const PlaylistDetailAlbumView = ({
     const { searchTerm } = useSearchTermFilter();
     const { query } = usePlaylistSongListFilters();
 
+    const sortBy = (query.sortBy as SongListSort) ?? SongListSort.ID;
+    // only re-randomize when the sort is actually random
+    const randomRefreshRevision = sortBy === SongListSort.RANDOM ? refreshRevision : null;
+
     const filteredAndSortedSongs = useMemo(() => {
         const raw = data?.items ?? [];
         const filtered = applyClientSideSongFilters(raw, query as Record<string, unknown>);
@@ -66,7 +70,6 @@ export const PlaylistDetailAlbumView = ({
             return searched;
         }
 
-        const sortBy = (query.sortBy as SongListSort) ?? SongListSort.ID;
         const sortOrder = (query.sortOrder as SortOrder) ?? SortOrder.ASC;
 
         if (sortBy === SongListSort.RANDOM) {
@@ -87,8 +90,7 @@ export const PlaylistDetailAlbumView = ({
         }
 
         return sortSongList(searched, sortBy, sortOrder);
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- refreshRevision intentionally triggers a new random order
-    }, [data?.items, query, searchTerm, refreshRevision]);
+    }, [data?.items, query, searchTerm, sortBy, randomRefreshRevision]);
 
     const sortedAlbums = useMemo(
         () => playlistSongsToAlbums(filteredAndSortedSongs),

--- a/src/renderer/features/playlists/components/playlist-detail-album-view.tsx
+++ b/src/renderer/features/playlists/components/playlist-detail-album-view.tsx
@@ -1,5 +1,5 @@
 import shuffle from 'lodash/shuffle';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
 import { useGridRows } from '/@/renderer/components/item-list/helpers/use-grid-rows';
 import { useItemListColumnReorder } from '/@/renderer/components/item-list/helpers/use-item-list-column-reorder';
@@ -57,6 +57,7 @@ export const PlaylistDetailAlbumView = ({
     const sortBy = (query.sortBy as SongListSort) ?? SongListSort.ID;
     // only re-randomize when the sort is actually random
     const randomRefreshRevision = sortBy === SongListSort.RANDOM ? refreshRevision : null;
+    const randomCacheRef = useRef<{ revision: boolean | null; songs: Song[] }>();
 
     const filteredAndSortedSongs = useMemo(() => {
         const raw = data?.items ?? [];
@@ -73,6 +74,11 @@ export const PlaylistDetailAlbumView = ({
         const sortOrder = (query.sortOrder as SortOrder) ?? SortOrder.ASC;
 
         if (sortBy === SongListSort.RANDOM) {
+            const cached = randomCacheRef.current;
+            if (cached && cached.revision === randomRefreshRevision) {
+                return cached.songs;
+            }
+
             const songsByAlbum = new Map<string, Song[]>();
 
             searched.forEach((song) => {
@@ -84,9 +90,11 @@ export const PlaylistDetailAlbumView = ({
                 }
             });
 
-            return shuffle(Array.from(songsByAlbum.values())).flatMap((albumSongs) =>
+            const shuffled = shuffle(Array.from(songsByAlbum.values())).flatMap((albumSongs) =>
                 sortSongList(albumSongs, SongListSort.ALBUM, SortOrder.ASC),
             );
+            randomCacheRef.current = { revision: randomRefreshRevision, songs: shuffled };
+            return shuffled;
         }
 
         return sortSongList(searched, sortBy, sortOrder);

--- a/src/renderer/features/playlists/components/playlist-detail-song-list-content.tsx
+++ b/src/renderer/features/playlists/components/playlist-detail-song-list-content.tsx
@@ -49,6 +49,7 @@ const PlaylistDetailSongListGrid = lazy(() =>
 );
 
 export const PlaylistDetailSongListContent = () => {
+    const [refreshRevision, setRefreshRevision] = useState(true);
     const { playlistId } = useParams() as { playlistId: string };
     const server = useCurrentServer();
     const queryClient = useQueryClient();
@@ -71,6 +72,8 @@ export const PlaylistDetailSongListContent = () => {
                 return;
             }
 
+            setRefreshRevision((prev) => !prev);
+
             const queryKey = playlistsQueries.songList({
                 query: {
                     id: playlistId,
@@ -91,7 +94,10 @@ export const PlaylistDetailSongListContent = () => {
 
     return (
         <Suspense fallback={<Spinner container />}>
-            <PlaylistDetailSongList data={playlistSongsQuery.data} />
+            <PlaylistDetailSongList
+                data={playlistSongsQuery.data}
+                refreshRevision={refreshRevision}
+            />
         </Suspense>
     );
 };
@@ -282,31 +288,49 @@ export const PlaylistDetailSongListEdit = ({ data }: { data: PlaylistSongListRes
     }
 };
 
-const PlaylistDetailTrackView = ({ data }: { data: PlaylistSongListResponse }) => {
+const PlaylistDetailTrackView = ({
+    data,
+    refreshRevision,
+}: {
+    data: PlaylistSongListResponse;
+    refreshRevision: boolean;
+}) => {
     const { isSmartPlaylist, mode } = useListContext();
 
     if (isSmartPlaylist) {
-        return <PlaylistDetailTrackViewContent data={data} />;
+        return <PlaylistDetailTrackViewContent data={data} refreshRevision={refreshRevision} />;
     }
 
     if (mode === 'edit') {
         return <PlaylistDetailSongListEdit data={data} />;
     }
 
-    return <PlaylistDetailTrackViewContent data={data} />;
+    return <PlaylistDetailTrackViewContent data={data} refreshRevision={refreshRevision} />;
 };
 
-const PlaylistDetailTrackViewContent = ({ data }: { data: PlaylistSongListResponse }) => {
-    const { sortedAndFilteredSongs } = usePlaylistTrackList(data);
+const PlaylistDetailTrackViewContent = ({
+    data,
+    refreshRevision,
+}: {
+    data: PlaylistSongListResponse;
+    refreshRevision: boolean;
+}) => {
+    const { sortedAndFilteredSongs } = usePlaylistTrackList(data, refreshRevision);
     return <PlaylistDetailSongListView data={data} items={sortedAndFilteredSongs} />;
 };
 
-const PlaylistDetailSongList = ({ data }: { data: PlaylistSongListResponse }) => {
+const PlaylistDetailSongList = ({
+    data,
+    refreshRevision,
+}: {
+    data: PlaylistSongListResponse;
+    refreshRevision: boolean;
+}) => {
     const { displayMode, mode } = useListContext();
 
     if (mode !== 'edit' && displayMode === LibraryItem.ALBUM) {
-        return <PlaylistDetailAlbumView data={data} />;
+        return <PlaylistDetailAlbumView data={data} refreshRevision={refreshRevision} />;
     }
 
-    return <PlaylistDetailTrackView data={data} />;
+    return <PlaylistDetailTrackView data={data} refreshRevision={refreshRevision} />;
 };

--- a/src/renderer/features/playlists/hooks/use-playlist-track-list.ts
+++ b/src/renderer/features/playlists/hooks/use-playlist-track-list.ts
@@ -100,7 +100,7 @@ export function usePlaylistTrackList(
     const sortBy = (query.sortBy as SongListSort) ?? SongListSort.ID;
     // only re-randomize when the sort is actually random
     const randomRefreshRevision = sortBy === SongListSort.RANDOM ? refreshRevision : null;
-    const randomCacheRef = useRef<{ revision: boolean | null; songs: Song[] }>();
+    const randomCacheRef = useRef<{ revision: boolean | null; songs: Song[] }>(undefined);
 
     const sortedAndFilteredSongs = useMemo(() => {
         const raw = data?.items ?? [];

--- a/src/renderer/features/playlists/hooks/use-playlist-track-list.ts
+++ b/src/renderer/features/playlists/hooks/use-playlist-track-list.ts
@@ -97,17 +97,19 @@ export function usePlaylistTrackList(
     const { searchTerm } = useSearchTermFilter();
     const { query } = usePlaylistSongListFilters();
 
+    const sortBy = (query.sortBy as SongListSort) ?? SongListSort.ID;
+    // only re-randomize when the sort is actually random
+    const randomRefreshRevision = sortBy === SongListSort.RANDOM ? refreshRevision : null;
+
     const sortedAndFilteredSongs = useMemo(() => {
         const raw = data?.items ?? [];
         const filtered = applyClientSideSongFilters(raw, query as Record<string, unknown>);
         if (searchTerm?.trim()) {
             return searchLibraryItems(filtered, searchTerm, LibraryItem.SONG);
         }
-        const sortBy = (query.sortBy as SongListSort) ?? SongListSort.ID;
         const sortOrder = (query.sortOrder as SortOrder) ?? SortOrder.ASC;
         return sortSongList(filtered, sortBy, sortOrder);
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- refreshRevision intentionally triggers a new random order
-    }, [data?.items, query, searchTerm, refreshRevision]);
+    }, [data?.items, query, searchTerm, sortBy, randomRefreshRevision]);
 
     const totalCount = sortedAndFilteredSongs.length;
 

--- a/src/renderer/features/playlists/hooks/use-playlist-track-list.ts
+++ b/src/renderer/features/playlists/hooks/use-playlist-track-list.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
 import { useListContext } from '/@/renderer/context/list-context';
 import { usePlaylistSongListFilters } from '/@/renderer/features/playlists/hooks/use-playlist-song-list-filters';
@@ -100,6 +100,7 @@ export function usePlaylistTrackList(
     const sortBy = (query.sortBy as SongListSort) ?? SongListSort.ID;
     // only re-randomize when the sort is actually random
     const randomRefreshRevision = sortBy === SongListSort.RANDOM ? refreshRevision : null;
+    const randomCacheRef = useRef<{ revision: boolean | null; songs: Song[] }>();
 
     const sortedAndFilteredSongs = useMemo(() => {
         const raw = data?.items ?? [];
@@ -108,6 +109,17 @@ export function usePlaylistTrackList(
             return searchLibraryItems(filtered, searchTerm, LibraryItem.SONG);
         }
         const sortOrder = (query.sortOrder as SortOrder) ?? SortOrder.ASC;
+
+        if (sortBy === SongListSort.RANDOM) {
+            const cached = randomCacheRef.current;
+            if (cached && cached.revision === randomRefreshRevision) {
+                return cached.songs;
+            }
+            const shuffled = sortSongList(filtered, sortBy, sortOrder);
+            randomCacheRef.current = { revision: randomRefreshRevision, songs: shuffled };
+            return shuffled;
+        }
+
         return sortSongList(filtered, sortBy, sortOrder);
     }, [data?.items, query, searchTerm, sortBy, randomRefreshRevision]);
 

--- a/src/renderer/features/playlists/hooks/use-playlist-track-list.ts
+++ b/src/renderer/features/playlists/hooks/use-playlist-track-list.ts
@@ -86,7 +86,10 @@ export function applyClientSideSongFilters(songs: Song[], query: Record<string, 
     return result;
 }
 
-export function usePlaylistTrackList(data: PlaylistSongListResponse | undefined): {
+export function usePlaylistTrackList(
+    data: PlaylistSongListResponse | undefined,
+    refreshRevision: boolean,
+): {
     sortedAndFilteredSongs: Song[];
     totalCount: number;
 } {
@@ -103,7 +106,8 @@ export function usePlaylistTrackList(data: PlaylistSongListResponse | undefined)
         const sortBy = (query.sortBy as SongListSort) ?? SongListSort.ID;
         const sortOrder = (query.sortOrder as SortOrder) ?? SortOrder.ASC;
         return sortSongList(filtered, sortBy, sortOrder);
-    }, [data?.items, query, searchTerm]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- refreshRevision intentionally triggers a new random order
+    }, [data?.items, query, searchTerm, refreshRevision]);
 
     const totalCount = sortedAndFilteredSongs.length;
 

--- a/src/renderer/features/shared/components/list-sort-by-dropdown.tsx
+++ b/src/renderer/features/shared/components/list-sort-by-dropdown.tsx
@@ -197,6 +197,11 @@ export const CLIENT_SIDE_SONG_FILTERS = [
         value: SongListSort.PLAY_COUNT,
     },
     {
+        defaultOrder: SortOrder.ASC,
+        name: i18n.t('filter.random'),
+        value: SongListSort.RANDOM,
+    },
+    {
         defaultOrder: SortOrder.DESC,
         name: i18n.t('filter.rating'),
         value: SongListSort.RATING,


### PR DESCRIPTION
This is an implementation that fixes #2270.
Having a random function in many places in the app already, only lead me to the conclusion that it makes sense to implement it in the playlist view as well.
Therefore my changes include
- Random sort order in playlist view for tracks and albums
- Addition of some logic to allow refresh to re-randomize the list

Closes #2270 