### PR TITLE
fix: fixed height for fullscreen image

### DIFF
--- a/src/renderer/features/shared/components/library-header.tsx
+++ b/src/renderer/features/shared/components/library-header.tsx
@@ -114,7 +114,7 @@ export const LibraryHeader = forwardRef(
                         onClick={() => closeAllModals()}
                         style={{
                             cursor: 'pointer',
-                            height: 'calc(100vh - 80px)',
+                            height: 'calc(100vh - 72px - 10px - 12px - 12px)', // 72px header, 10px outer modal border, 12px padding bottom image, 12px scrollbar bottom
                             width: '100%',
                         }}
                     >


### PR DESCRIPTION
This change fixes #2261 
I changed the height calculation to include a detailed list and sources of numbers instead of just 80px
The result is 
- 72px for the header that includes the close button
- 10px for the outermost modal padding/margin
- 12px for the padding/margin of the modal content (the image) itself
- 12px for the bottom scrollbar

Closes #2261 