### PR TITLE
fix(web-player): unlock AudioContext on first user gesture

### DIFF
--- a/src/renderer/features/player/components/audio-players.tsx
+++ b/src/renderer/features/player/components/audio-players.tsx
@@ -264,6 +264,24 @@ const AudioPlayersContent = ({
     }, []);
 
     useEffect(() => {
+        if (!audioContext?.context) return undefined;
+        const ctx = audioContext.context;
+        if (ctx.state === 'running') return undefined;
+
+        const unlock = () => {
+            ctx.resume().catch(() => {});
+        };
+
+        document.addEventListener('pointerdown', unlock, { capture: true, once: true });
+        document.addEventListener('keydown', unlock, { capture: true, once: true });
+
+        return () => {
+            document.removeEventListener('pointerdown', unlock, { capture: true });
+            document.removeEventListener('keydown', unlock, { capture: true });
+        };
+    }, [audioContext]);
+
+    useEffect(() => {
         // Not standard, just used in chromium-based browsers. See
         // https://developer.chrome.com/blog/audiocontext-setsinkid/.
 


### PR DESCRIPTION
## Problem
On the web build, playback would silently produce no audio: the progress bar advances and `Now Playing` fires, but nothing comes out of the speakers. Desktop (MPV backend) is unaffected.

## Root cause
The `AudioContext` is created in a mount-time `useEffect` (`audio-players.tsx`), not inside a click handler, so Chrome creates it in a `suspended` state. The existing `resume()` call in `web-player.tsx` only runs inside the async player-start callback, which fires after the original click's transient user-activation window has already expired. Chrome silently rejects the resume in that case, so the underlying `<audio>` element keeps advancing while the Web Audio graph never outputs sound.

## Fix
Add a one-time `pointerdown`/`keydown` listener that resumes the context synchronously on the very first user gesture anywhere on the page, instead of relying on the later async resume call.

## Testing
Reproduced reliably on Chrome/macOS against a self-hosted Navidrome server (web build served via the official Dockerfile). Confirmed the fix resolves it across repeated attempts.