### PR TITLE
fix: table row playback controls glitch

### DIFF
--- a/src/renderer/components/item-list/item-table-list/columns/row-play-control-cell.tsx
+++ b/src/renderer/components/item-list/item-table-list/columns/row-play-control-cell.tsx
@@ -110,7 +110,7 @@ export const RowPlayControlCell = (
 
     return (
         <TableColumnTextContainer {...props} className={styles.fullSizeContent}>
-            <HoverCard openDelay={300} position="top" withArrow withinPortal={false}>
+            <HoverCard openDelay={300} position="top" withArrow withinPortal={true}>
                 <HoverCard.Target>
                     <Flex className={styles.indexContent} justify="center" w="100%">
                         {getIndexDisplay(false)}


### PR DESCRIPTION
Small fix on a glitch on the table row playback controls position.

Glitch on the first rows (interactions on the playback controls are impossible) :

<img width="413" height="171" alt="Capture d’écran 2026-07-29 à 10 08 37" src="https://github.com/user-attachments/assets/0513913f-4da9-4dcf-870d-81fecef49c64" />

When the popover is in `up` position, the bug disappears (interactions with playback controls are possible):

<img width="412" height="154" alt="Capture d’écran 2026-07-29 à 10 08 45" src="https://github.com/user-attachments/assets/3d2ea6d1-8392-4109-9246-43d0c6ca0e0a" />

The fix aims to render the popover within the Portal, as the default value is `true` on the `MantineHoverCard` but it may be tweaked in any future development, so I thought it was better to keep it exposed.