### PR TITLE
fix: use the ID3 getArtistInfo2 endpoint for artist info

### DIFF
--- a/src/renderer/api/navidrome/navidrome-controller.ts
+++ b/src/renderer/api/navidrome/navidrome-controller.ts
@@ -289,7 +289,7 @@ export const NavidromeController: InternalControllerEndpoint = {
     getAlbumArtistInfo: async (args) => {
         const { apiClientProps, query } = args;
 
-        const artistInfoRes = await ssApiClient(apiClientProps).getArtistInfo({
+        const artistInfoRes = await ssApiClient(apiClientProps).getArtistInfo2({
             query: {
                 id: query.id,
                 ...(query.limit != null && { count: query.limit }),
@@ -300,7 +300,7 @@ export const NavidromeController: InternalControllerEndpoint = {
             return null;
         }
 
-        const artistInfo = artistInfoRes.body.artistInfo;
+        const artistInfo = artistInfoRes.body.artistInfo2;
         const imageUrl =
             artistInfo?.largeImageUrl ||
             artistInfo?.mediumImageUrl ||
@@ -312,8 +312,8 @@ export const NavidromeController: InternalControllerEndpoint = {
             imageUrl,
             similarArtists:
                 artistInfo?.similarArtist?.map((artist) => ({
-                    id: artist.id,
-                    imageId: artist.id,
+                    id: String(artist.id),
+                    imageId: String(artist.id),
                     imageUrl: null,
                     name: artist.name,
                     userFavorite: Boolean(artist.starred) || false,

--- a/src/renderer/api/subsonic/subsonic-api.ts
+++ b/src/renderer/api/subsonic/subsonic-api.ts
@@ -98,12 +98,12 @@ export const contract = c.router({
             200: ssType._response.getArtist,
         },
     },
-    getArtistInfo: {
+    getArtistInfo2: {
         method: 'GET',
-        path: 'getArtistInfo.view',
+        path: 'getArtistInfo2.view',
         query: ssType._parameters.artistInfo,
         responses: {
-            200: ssType._response.artistInfo,
+            200: ssType._response.artistInfo2,
         },
     },
     getArtists: {

--- a/src/renderer/api/subsonic/subsonic-controller.ts
+++ b/src/renderer/api/subsonic/subsonic-controller.ts
@@ -496,7 +496,7 @@ export const SubsonicController: InternalControllerEndpoint = {
     getAlbumArtistInfo: async (args) => {
         const { apiClientProps, query } = args;
 
-        const artistInfoRes = await ssApiClient(apiClientProps).getArtistInfo({
+        const artistInfoRes = await ssApiClient(apiClientProps).getArtistInfo2({
             query: {
                 id: query.id,
                 ...(query.limit != null && { count: query.limit }),
@@ -507,14 +507,14 @@ export const SubsonicController: InternalControllerEndpoint = {
             return null;
         }
 
-        const artistInfo = artistInfoRes.body.artistInfo;
+        const artistInfo = artistInfoRes.body.artistInfo2;
 
         return {
             biography: artistInfo?.biography || null,
             similarArtists:
                 artistInfo?.similarArtist?.map((artist) => ({
-                    id: artist.id,
-                    imageId: artist.coverArt ?? artist.id,
+                    id: String(artist.id),
+                    imageId: artist.coverArt ?? String(artist.id),
                     imageUrl: null,
                     name: artist.name,
                     userFavorite: Boolean(artist.starred) || false,

--- a/src/shared/api/navidrome/navidrome-normalize.ts
+++ b/src/shared/api/navidrome/navidrome-normalize.ts
@@ -392,7 +392,9 @@ const normalizeAlbum = (
 
 const normalizeAlbumArtist = (
     item: z.infer<typeof ndType._response.albumArtist> & {
-        similarArtists?: z.infer<typeof ssType._response.artistInfo>['artistInfo']['similarArtist'];
+        similarArtists?: NonNullable<
+            z.infer<typeof ssType._response.artistInfo2>['artistInfo2']
+        >['similarArtist'];
     },
     server?: null | ServerListItem,
 ): AlbumArtist => {
@@ -448,8 +450,8 @@ const normalizeAlbumArtist = (
         playCount: item.playCount || 0,
         similarArtists:
             item.similarArtists?.map((artist) => ({
-                id: artist.id,
-                imageId: artist.id,
+                id: String(artist.id),
+                imageId: String(artist.id),
                 imageUrl: null,
                 name: artist.name,
                 userFavorite: Boolean(artist.starred) || false,

--- a/src/shared/api/subsonic/subsonic-normalize.ts
+++ b/src/shared/api/subsonic/subsonic-normalize.ts
@@ -245,14 +245,14 @@ const normalizeSong = (
 const normalizeAlbumArtist = (
     item:
         | (z.infer<typeof ssType._response.albumArtist> & {
-              similarArtists?: z.infer<
-                  typeof ssType._response.artistInfo
-              >['artistInfo']['similarArtist'];
+              similarArtists?: NonNullable<
+                  z.infer<typeof ssType._response.artistInfo2>['artistInfo2']
+              >['similarArtist'];
           })
         | (z.infer<typeof ssType._response.artistListEntry> & {
-              similarArtists?: z.infer<
-                  typeof ssType._response.artistInfo
-              >['artistInfo']['similarArtist'];
+              similarArtists?: NonNullable<
+                  z.infer<typeof ssType._response.artistInfo2>['artistInfo2']
+              >['similarArtist'];
           }),
     server?: null | ServerListItemWithCredential,
 ): AlbumArtist => {
@@ -273,8 +273,8 @@ const normalizeAlbumArtist = (
         playCount: null,
         similarArtists:
             item.similarArtists?.map((artist) => ({
-                id: artist.id,
-                imageId: artist.coverArt ?? artist.id,
+                id: String(artist.id),
+                imageId: artist.coverArt ?? String(artist.id),
                 imageUrl: null,
                 name: artist.name,
                 userFavorite: Boolean(artist.starred) || false,

--- a/src/shared/api/subsonic/subsonic-types.ts
+++ b/src/shared/api/subsonic/subsonic-types.ts
@@ -304,26 +304,33 @@ const artistInfoParameters = z.object({
     includeNotPresent: z.boolean().optional(),
 });
 
-const artistInfo = z.object({
-    artistInfo: z.object({
-        biography: z.string().optional(),
-        largeImageUrl: z.string().optional(),
-        lastFmUrl: z.string().optional(),
-        mediumImageUrl: z.string().optional(),
-        musicBrainzId: z.string().optional(),
-        similarArtist: z.array(
-            z.object({
-                albumCount: z.string(),
-                artistImageUrl: z.string().optional(),
-                coverArt: z.string().optional(),
-                id: z.string(),
-                name: z.string(),
-                starred: z.string().optional(),
-                userRating: z.number().optional(),
-            }),
-        ),
-        smallImageUrl: z.string().optional(),
-    }),
+// Organizes music according to ID3 tags, and must be queried with an ID3 artist id
+// (as returned by getArtists/getArtist). The non-ID3 getArtistInfo resolves the id
+// against the folder browsing namespace, where the same id belongs to an unrelated item.
+const artistInfo2 = z.object({
+    artistInfo2: z
+        .object({
+            biography: z.string().optional(),
+            largeImageUrl: z.string().optional(),
+            lastFmUrl: z.string().optional(),
+            mediumImageUrl: z.string().optional(),
+            musicBrainzId: z.string().optional(),
+            similarArtist: z
+                .array(
+                    z.object({
+                        albumCount: z.number().or(z.string()).optional(),
+                        artistImageUrl: z.string().optional(),
+                        coverArt: z.string().optional(),
+                        id,
+                        name: z.string(),
+                        starred: z.string().optional(),
+                        userRating: z.number().optional(),
+                    }),
+                )
+                .optional(),
+            smallImageUrl: z.string().optional(),
+        })
+        .optional(),
 });
 
 const topSongsListParameters = z.object({
@@ -951,7 +958,7 @@ export const ssType = {
         albumInfo,
         albumList,
         albumListEntry,
-        artistInfo,
+        artistInfo2,
         artistListEntry,
         authenticate,
         baseResponse,


### PR DESCRIPTION
Closes #2308

## Problem

On the album artist detail page the "About" section and the "Related Artists" list belong to a completely different artist than the one the page is opened for. Albums, top songs and external links on the same page are correct.

## Cause

Album artists are loaded through the ID3 endpoints (`getArtists.view` / `getArtist.view`), but artist info was requested through the non-ID3 `getArtistInfo.view`. The two endpoints resolve the `id` parameter in two different id namespaces, and the namespaces overlap numerically, so the id is valid in both and no error is raised.

Airsonic-Advanced resolves the id against `media_file` in `getArtistInfo`:

https://github.com/airsonic-advanced/airsonic-advanced/blob/68d11bfbfe051b0acaca2770c3c1f47f8d59201c/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java#L434-L440

and against the `artist` table in `getArtistInfo2`:

https://github.com/airsonic-advanced/airsonic-advanced/blob/68d11bfbfe051b0acaca2770c3c1f47f8d59201c/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java#L470-L476

## Fix

`getAlbumArtistInfo` now calls `getArtistInfo2.view` in both the Subsonic and the Navidrome controller, and the response is typed by a new `artistInfo2` schema.

| Server | Before | After | Basis |
| --- | --- | --- | --- |
| Airsonic / Airsonic-Advanced | biography and similar artists of an unrelated artist | correct artist | tested |
| gonic | no biography at all — `getArtistInfo` returns an empty response there | correct artist | expected, from reading the sources |
| Navidrome | already correct — both endpoints are backed by the same handler | unchanged | expected, from reading the sources |
| Jellyfin | not affected — separate code path, biography comes from `Overview` | unchanged | code inspection, not exercised |

Only the Airsonic-Advanced row was verified on a running server. The other rows are inferred from the server sources, and I would appreciate a check by someone who runs those servers.

<details>
<summary>Screenshots (Airsonic-Advanced)</summary>

**Before**

<img width="1152" height="939" alt="before1" src="https://github.com/user-attachments/assets/283953dd-a6ee-4ee1-97cc-268b256bfa2e" />
<img width="1143" height="376" alt="before2" src="https://github.com/user-attachments/assets/d56b3219-baa3-4df4-84cb-8f03660cadca" />

**After**

<img width="1090" height="936" alt="after1" src="https://github.com/user-attachments/assets/67174eac-0b0d-4965-b25a-61702e8fb4da" />
<img width="1081" height="371" alt="after2" src="https://github.com/user-attachments/assets/37f59cbc-b7bd-41e4-96d0-4cc048b8a151" />

</details>

### Notes for review

- No fallback to `getArtistInfo` is kept on purpose. That endpoint does not fail on an ID3 id, it returns a plausible-looking biography of the wrong artist, so a fallback would silently reintroduce the bug instead of guarding against it.
- `getArtistInfo2` requires Subsonic API 1.11.0. The client already advertises `v=1.13.0`, so no version bump is needed.
- The new schema is written against actual server responses rather than copied from the old one: `albumCount` arrives as a number from Airsonic although the previous schema declared it a string, `coverArt` is missing on some entries, and gonic omits `similarArtist` entirely when the list is empty. These schemas are compile-time types only — the ts-rest client returns the raw body without parsing — so the mismatch surfaced as inaccurate types rather than a runtime error. `String(artist.id)` is needed because the shared `id` schema is `number | string` while `RelatedArtist.id` is `string`.

### Testing

Tested on Airsonic-Advanced (REST API 1.15.0) only — that is the one server I have:

- the same ID3 artist id returns an unrelated artist from `getArtistInfo` and the correct artist from `getArtistInfo2`;
- running the app from source, the biography and the "Related Artists" list now both match the artist on the page;
- `pnpm typecheck` and `eslint src/` are clean.

Not tested on Navidrome, gonic, LMS, Ampache or Jellyfin.
