### PR TITLE
fix(player): stop radio before playing from the queue panel

### DIFF
--- a/src/renderer/store/player.store.ts
+++ b/src/renderer/store/player.store.ts
@@ -1134,6 +1134,10 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                 mediaPlay: (id?: string) => {
                     let playIndex: number | undefined;
 
+                    if (useRadioPlayerStore.getState().currentStreamUrl) {
+                        useRadioPlayerStore.getState().actions.stop();
+                    }
+
                     set((state) => {
                         if (id) {
                             const queue = state.getQueue();
@@ -1180,6 +1184,10 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                 mediaPlayByIndex: (index: number) => {
                     let playIndex: number | undefined;
                     let songId: string | undefined;
+
+                    if (useRadioPlayerStore.getState().currentStreamUrl) {
+                        useRadioPlayerStore.getState().actions.stop();
+                    }
 
                     set((state) => {
                         const queue = state.getQueue();


### PR DESCRIPTION
## Problem

While a radio stream is playing, selecting a track in the queue panel
and pressing Play does nothing — the track is silently
ignored. Switching back to track playback via a playlist or the track
list in the center panel works fine.

## Root cause

#2039 (f3c0b68a) stopped the active radio stream before starting track
playback, but only in `addToQueueByType`'s `Play.NOW`/`Play.SHUFFLE`
branches — the paths used when playing from a playlist/track list.

The queue panel's row-play action goes through `mediaPlay`/
`mediaPlayByIndex` instead, which update `player.index`/`player.status`
but never touch the radio store. While `isRadioActive` stays true,
`audio-players.tsx` keeps `RadioWebPlayer` mounted instead of the
normal player, and `RadioWebPlayer` only reacts to `currentStreamUrl` —
so the index/status change from the queue is silently ignored.

## Fix

Apply the same radio-stop call from #2039 to `mediaPlay` and
`mediaPlayByIndex` in `player.store.ts`.

## Test plan

- [ ] Play an internet radio station
- [ ] Select a track in the queue panel (right sidebar) and press Play
- [ ] Confirm the track starts playing and the radio stream stops
- [ ] Repeat via double-click on a queue row