### PR TITLE
fixed subtitle overflow for title-artist columns

### DIFF
--- a/src/renderer/components/item-list/item-table-list/columns/title-artist-column.module.css
+++ b/src/renderer/components/item-list/item-table-list/columns/title-artist-column.module.css
@@ -37,6 +37,8 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+
+    --text-text-wrap: nowrap;
 }
 
 a.title {

--- a/src/renderer/components/item-list/item-table-list/columns/title-artist-column.module.css
+++ b/src/renderer/components/item-list/item-table-list/columns/title-artist-column.module.css
@@ -9,7 +9,7 @@
 
 .text-container {
     display: grid;
-    grid-template-rows: 1fr 1fr;
+    grid-template-rows: auto auto;
     gap: var(--theme-spacing-xs);
     min-width: 0;
 }
@@ -31,14 +31,22 @@
 }
 
 .title {
-    display: inline-block;
+    display: -webkit-inline-box;
     width: 100%;
     max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;
+    white-space: normal;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+}
 
-    --text-text-wrap: nowrap;
+.title.compact {
+    -webkit-line-clamp: 1;
+}
+
+.title.large {
+    -webkit-line-clamp: 3;
 }
 
 a.title {

--- a/src/renderer/components/item-list/item-table-list/columns/title-artist-column.module.css
+++ b/src/renderer/components/item-list/item-table-list/columns/title-artist-column.module.css
@@ -36,9 +36,9 @@
     max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: normal;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
+    white-space: normal;
 }
 
 .title.compact {

--- a/src/renderer/components/item-list/item-table-list/columns/title-artist-column.tsx
+++ b/src/renderer/components/item-list/item-table-list/columns/title-artist-column.tsx
@@ -121,6 +121,8 @@ export const QueueSongTitleArtistColumn = (props: ItemTableListInnerColumn) => {
                     <Text
                         className={clsx({
                             [styles.active]: isActive,
+                            [styles.compact]: props.size === 'compact',
+                            [styles.large]: props.size === 'large',
                             [styles.title]: true,
                         })}
                         isNoSelect

--- a/src/renderer/components/item-list/item-table-list/columns/title-column.module.css
+++ b/src/renderer/components/item-list/item-table-list/columns/title-column.module.css
@@ -4,7 +4,7 @@
     max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
-    -webkit-line-clamp: 2;
+    -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
 }
 
@@ -17,7 +17,7 @@ a.name-container {
 }
 
 .name-container.large {
-    -webkit-line-clamp: 3;
+    -webkit-line-clamp: 4;
 }
 
 .active {

--- a/src/renderer/components/item-list/item-table-list/columns/title-combined-column.module.css
+++ b/src/renderer/components/item-list/item-table-list/columns/title-combined-column.module.css
@@ -12,7 +12,7 @@
 
 .text-container {
     display: grid;
-    grid-template-rows: 1fr 1fr;
+    grid-template-rows: auto auto;
     gap: var(--theme-spacing-xs);
     min-width: 0;
 }
@@ -34,15 +34,23 @@
 }
 
 .title {
-    display: inline-block;
+    display: -webkit-inline-box;
     width: 100%;
     min-width: 0;
     max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;
+    white-space: normal;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+}
 
-    --text-text-wrap: nowrap;
+.title.compact {
+    -webkit-line-clamp: 1;
+}
+
+.title.large {
+    -webkit-line-clamp: 3;
 }
 
 a.title {

--- a/src/renderer/components/item-list/item-table-list/columns/title-combined-column.module.css
+++ b/src/renderer/components/item-list/item-table-list/columns/title-combined-column.module.css
@@ -40,9 +40,9 @@
     max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: normal;
-    -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    white-space: normal;
 }
 
 .title.compact {

--- a/src/renderer/components/item-list/item-table-list/columns/title-combined-column.tsx
+++ b/src/renderer/components/item-list/item-table-list/columns/title-combined-column.tsx
@@ -316,6 +316,8 @@ export const QueueSongTitleCombinedColumn = (props: ItemTableListInnerColumn) =>
                     <Text
                         className={clsx({
                             [styles.active]: isActive,
+                            [styles.compact]: props.size === 'compact',
+                            [styles.large]: props.size === 'large',
                             [styles.title]: true,
                         })}
                         isNoSelect


### PR DESCRIPTION
fixed missing nowrap line for title-artist columns (present in title-combined columns) which caused overflow if subtitle went out of range (#2319)
before:
<img width="1457" height="306" alt="image" src="https://github.com/user-attachments/assets/bef131aa-9a95-43bb-94bd-5635217bef1d" />

after:
<img width="1470" height="299" alt="image" src="https://github.com/user-attachments/assets/4185739f-4400-4637-b0ca-9f81ad9e53e2" />

