### PR TITLE
feat: add album link to Discord RPC

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -905,7 +905,7 @@
         "discordDisplayType": "{{discord}} presence display type",
         "discordIdleStatus_description": "When enabled, update status while player is idle",
         "discordIdleStatus": "Show rich presence idle status",
-        "discordLinkType_description": "Adds external links to {{lastfm}} or {{musicbrainz}} to the song and artist fields in {{discord}} rich presence. {{musicbrainz}} is the most accurate but requires tags and doesn't provide artist links while {{lastfm}} should always provide a link. Makes no extra network requests",
+        "discordLinkType_description": "Adds {{lastfm}} or {{musicbrainz}} links to {{discord}} rich presence. {{musicbrainz}} is the most accurate but requires tags and doesn't provide artist links while {{lastfm}} should always provide a link. Makes no extra network requests",
         "discordLinkType_mbz_lastfm": "{{musicbrainz}} with {{lastfm}} fallback",
         "discordLinkType_none": "$t(common.none)",
         "discordLinkType": "{{discord}} presence links",

--- a/src/renderer/features/discord-rpc/use-discord-rpc.ts
+++ b/src/renderer/features/discord-rpc/use-discord-rpc.ts
@@ -210,20 +210,23 @@ export const useDiscordRpc = () => {
             if (
                 (discordSettings.linkType == DiscordLinkType.LAST_FM ||
                     discordSettings.linkType == DiscordLinkType.MBZ_LAST_FM) &&
-                song?.artistName
+                song.artistName
             ) {
                 activity.stateUrl =
                     'https://www.last.fm/music/' + encodeURIComponent(song.artists[0].name);
 
-                const detailsUrl =
+                const albumUrl =
                     'https://www.last.fm/music/' +
                     encodeURIComponent(song.albumArtists[0].name) +
                     '/' +
-                    encodeURIComponent(song.album || '_') +
-                    '/' +
-                    encodeURIComponent(song.name);
+                    encodeURIComponent(song.album || '_');
+                const detailsUrl = albumUrl + '/' + encodeURIComponent(song.name);
 
                 // The details URL has a max length, only set it if it doesn't exceed it
+                if (albumUrl.length <= MAX_URL_LENGTH) {
+                    activity.largeImageUrl = albumUrl;
+                }
+
                 if (detailsUrl.length <= MAX_URL_LENGTH) {
                     activity.detailsUrl = detailsUrl;
                 }
@@ -238,6 +241,10 @@ export const useDiscordRpc = () => {
                 } else if (song?.mbzRecordingId) {
                     activity.detailsUrl =
                         'https://musicbrainz.org/recording/' + song.mbzRecordingId;
+                }
+
+                if (song.mbzAlbumId) {
+                    activity.largeImageUrl = 'https://musicbrainz.org/release/' + song.mbzAlbumId;
                 }
             }
 

--- a/src/renderer/features/player/hooks/use-mpris.ts
+++ b/src/renderer/features/player/hooks/use-mpris.ts
@@ -92,6 +92,7 @@ export const useMPRIS = () => {
             imageUrl: null,
             lastPlayedAt: null,
             lyrics: null,
+            mbzAlbumId: null,
             mbzRecordingId: null,
             mbzTrackId: null,
             name: title,

--- a/src/shared/api/jellyfin/jellyfin-normalize.ts
+++ b/src/shared/api/jellyfin/jellyfin-normalize.ts
@@ -191,6 +191,7 @@ const normalizeSong = (
         imageUrl: null,
         lastPlayedAt: null,
         lyrics: null,
+        mbzAlbumId: item.ProviderIds?.MusicBrainzAlbum || null,
         mbzRecordingId: null,
         mbzTrackId: item.ProviderIds?.MusicBrainzTrack || null,
         name: item.Name,

--- a/src/shared/api/navidrome/navidrome-normalize.ts
+++ b/src/shared/api/navidrome/navidrome-normalize.ts
@@ -267,6 +267,7 @@ const normalizeSong = (
         imageUrl: null,
         lastPlayedAt: normalizePlayDate(item),
         lyrics: item.lyrics ? item.lyrics : null,
+        mbzAlbumId: item.mbzAlbumId || null,
         mbzRecordingId: item.mbzReleaseTrackId || null,
         mbzTrackId: item.mbzReleaseTrackId || null,
         name: item.title,

--- a/src/shared/api/subsonic/subsonic-normalize.ts
+++ b/src/shared/api/subsonic/subsonic-normalize.ts
@@ -226,6 +226,7 @@ const normalizeSong = (
         imageUrl: null,
         lastPlayedAt: null,
         lyrics: null,
+        mbzAlbumId: null,
         mbzRecordingId: item.musicBrainzId || null,
         mbzTrackId: null,
         name: item.title,

--- a/src/shared/types/domain-types.ts
+++ b/src/shared/types/domain-types.ts
@@ -400,6 +400,7 @@ export type Song = {
     imageUrl: null | string;
     lastPlayedAt: null | string;
     lyrics: null | string;
+    mbzAlbumId: null | string;
     mbzRecordingId: null | string;
     mbzTrackId: null | string;
     name: string;


### PR DESCRIPTION
Adds Last.fm and MusicBrainz links to album names and cover art in Discord Rich Presence.

MusicBrainz album IDs are now preserved for Navidrome and Jellyfin songs.