### PR TITLE
fix delay in web audio playback by enforcing song preload (#2353)

### DIFF
--- a/src/renderer/features/player/audio-player/engine/web-player-engine.tsx
+++ b/src/renderer/features/player/audio-player/engine/web-player-engine.tsx
@@ -320,7 +320,10 @@ export const WebPlayerEngine = (props: WebPlayerEngineProps) => {
         <div id="web-player-engine" style={{ display: 'none' }}>
             <ReactPlayerComponent
                 config={{
-                    file: { attributes: { crossOrigin: 'anonymous' }, forceAudio: true },
+                    file: {
+                        attributes: { crossOrigin: 'anonymous', preload: 'auto' },
+                        forceAudio: true,
+                    },
                 }}
                 controls={false}
                 height={0}
@@ -346,7 +349,10 @@ export const WebPlayerEngine = (props: WebPlayerEngineProps) => {
             />
             <ReactPlayerComponent
                 config={{
-                    file: { attributes: { crossOrigin: 'anonymous' }, forceAudio: true },
+                    file: {
+                        attributes: { crossOrigin: 'anonymous', preload: 'auto' },
+                        forceAudio: true,
+                    },
                 }}
                 controls={false}
                 height={0}


### PR DESCRIPTION
## Diagnosis

1. Navidrome logs show the file being streamed successfully (`format=raw`, `transcoding=false`, no errors), and a `Now Playing` scrobble is registered normally.
2. On Feishin's devtools, the request to `/rest/stream.view` returns `206 Partial Content` with the full file in one response , but playback doesn't start until ~20-25s after the request begins.
3. Downloading the exact same stream URL with `curl` completes in 3s (almost 10 times faster)
4. DevTools "Timing" breakdown for the request isolated exactly where the time was going:
   - Queueing: 0.23ms
   - Stalled: 0.4ms
   - Waiting for server (TTFB): 207ms
   - **Content Download: ~1.2 min**

   This confirmed the delay is not server latency or network throttling, it's specifically how the response body is being read on the client.
5. Inspected `web-player-engine.tsx` and saw that both players are `react-player` instances configured with `file: { forceAudio: true }`, which renders a plain native `<audio>` element with `url={src}` pointing straight at the Subsonic stream URL. No `preload` attribute is set on the element.

## Root cause

Chromium applies conservative/throttled progressive buffering to native `<audio>` elements when no explicit `preload` hint is given (also, the element lives in a `display: none` container, so the browser may use aggressive resource optimizations). For large files this results in the effective download speed being far below the actual available bandwidth.

Adding `preload: 'auto'` to the `file.attributes` config passed to both `ReactPlayerComponent` instances in `web-player-engine.tsx` resolves the issue. I built the macOS app and confirmed locally, with this fix, the playback starts immediately on the previously affected tracks.

## Solution

The same song is loaded in 0.6 seconds. It still has a slight delay because it waits until the next song in the queue is also loaded, I think it has to do with the crossfader feature and maybe it could be optimized further.

<img width="2032" height="1162" alt="image" src="https://github.com/user-attachments/assets/c45a465b-15b4-451b-ad7a-3fa65072b93b" />
