### PR TITLE
fix: redundant menu divider

### DIFF
--- a/src/renderer/features/titlebar/components/app-menu.tsx
+++ b/src/renderer/features/titlebar/components/app-menu.tsx
@@ -290,13 +290,13 @@ export const AppMenu = () => {
             type: 'custom',
         },
         {
-            id: 'divider-5',
-            type: 'divider',
-        },
-        {
             condition: settings.sideQueueType === 'sideQueue',
             id: 'layout-toggle-group',
             items: [
+                {
+                    id: 'divider-5',
+                    type: 'divider',
+                },
                 {
                     component: (
                         <Group gap="xs" grow pb="xs" pt="sm" px="xs" w="100%">


### PR DESCRIPTION
Hide the redundant trailing app menu divider when the side play queue style is set to detached.

| Before | After |
| :---: | :---: |
| <img width="320" alt="Before" src="https://github.com/user-attachments/assets/5dd1f779-1f49-46ee-8f49-99a4a57b5bb3" /> | <img width="320" alt="After" src="https://github.com/user-attachments/assets/e7077720-e9ad-4415-8b32-b5f146fd72dd" /> |
