### PR TITLE
fix(library): correct genre track count sort label on Subsonic

### DIFF
--- a/src/renderer/features/shared/components/list-sort-by-dropdown.tsx
+++ b/src/renderer/features/shared/components/list-sort-by-dropdown.tsx
@@ -867,7 +867,7 @@ const GENRE_LIST_FILTERS: Partial<
         },
         {
             defaultOrder: SortOrder.ASC,
-            name: i18n.t('filter.albumCount'),
+            name: i18n.t('filter.songCount'),
             value: GenreListSort.SONG_COUNT,
         },
     ],


### PR DESCRIPTION
## Problem

On Subsonic servers the genre sort menu lists "Albums count" twice. The first one sorts by album count, the second one actually sorts by track count.

### Screenshots

| Before | After |
| :---: | :---: |
| <img width="276" height="238" alt="before" src="https://github.com/user-attachments/assets/e994984b-bbe4-4af8-85ed-75bc85176895" /> | <img width="271" height="239" alt="after" src="https://github.com/user-attachments/assets/14fda8c8-f416-4648-bffa-ea71068bb7cf" /> |

## Cause

In `GENRE_LIST_FILTERS` the Subsonic block pairs the album count label with `GenreListSort.SONG_COUNT`:

```ts
{
    defaultOrder: SortOrder.ASC,
    name: i18n.t('filter.albumCount'),
    value: GenreListSort.SONG_COUNT,
},
```

It came in with da445b81 (`feat(genre): support sorting by track/album count`, closing #2126). The Navidrome block a few lines above uses `filter.songCount` for the same value, so the wrong label only appears on Subsonic compatible servers.

## Fix

One line, switching the label to the key the Navidrome block already uses. No new i18n keys, so every locale is covered already.

## Testing

Ran from source against Airsonic-Advanced. The genre sort menu now lists "Albums count", "Name", "Song count", and "Song count" sorts by the Tracks column.

Not tested on Navidrome or Jellyfin.
