### PR TITLE
feat(player): report play queue window to Jellyfin sessions

### DIFF
--- a/src/renderer/api/jellyfin/jellyfin-controller.ts
+++ b/src/renderer/api/jellyfin/jellyfin-controller.ts
@@ -61,9 +61,7 @@ const getNowPlayingQueueWindow = (): undefined | { Id: string }[] => {
 
         const window = playOrder
             .slice(index, index + QUEUE_REPORT_WINDOW)
-            .map((uniqueId) => songs[uniqueId]?.id)
-            .filter((id): id is string => Boolean(id))
-            .map((id) => ({ Id: id }));
+            .flatMap((uniqueId) => (songs[uniqueId] ? [{ Id: songs[uniqueId].id }] : []));
 
         return window.length > 1 ? window : undefined;
     } catch {

--- a/src/renderer/api/jellyfin/jellyfin-controller.ts
+++ b/src/renderer/api/jellyfin/jellyfin-controller.ts
@@ -7,6 +7,7 @@ import { z } from 'zod';
 
 import { createAuthHeader, jfApiClient } from '/@/renderer/api/jellyfin/jellyfin-api';
 import { useRadioStore } from '/@/renderer/features/radio/store/radio-store';
+import { isShuffleEnabled, usePlayerStoreBase } from '/@/renderer/store/player.store';
 import { getServerUrl } from '/@/renderer/utils/normalize-server-url';
 import { jfNormalize } from '/@/shared/api/jellyfin/jellyfin-normalize';
 import { JFSongListSort, JFSortOrder, jfType } from '/@/shared/api/jellyfin/jellyfin-types';
@@ -40,6 +41,35 @@ import {
     UploadPlaylistImageResponse,
 } from '/@/shared/types/domain-types';
 import { ServerFeature } from '/@/shared/types/features-types';
+
+// Jellyfin can receive the client's play queue with playback reports, which lets
+// server-side consumers (session UI, prefetch plugins) see the upcoming tracks.
+// Only a window from the current track onward is reported - full queues degrade
+// the /Sessions endpoint (jellyfin/jellyfin#13377).
+const QUEUE_REPORT_WINDOW = 20;
+
+const getNowPlayingQueueWindow = (): undefined | { Id: string }[] => {
+    try {
+        const state = usePlayerStoreBase.getState();
+        const { default: order, shuffled, songs } = state.queue;
+        const playOrder = isShuffleEnabled(state) ? shuffled.map((idx) => order[idx]) : order;
+        const index = state.player.index;
+
+        if (index < 0 || index >= playOrder.length) {
+            return undefined;
+        }
+
+        const window = playOrder
+            .slice(index, index + QUEUE_REPORT_WINDOW)
+            .map((uniqueId) => songs[uniqueId]?.id)
+            .filter((id): id is string => Boolean(id))
+            .map((id) => ({ Id: id }));
+
+        return window.length > 1 ? window : undefined;
+    } catch {
+        return undefined;
+    }
+};
 
 const getJellyfinImageRequest = ({
     apiClientProps: { server },
@@ -1772,6 +1802,7 @@ export const JellyfinController: InternalControllerEndpoint = {
         const { apiClientProps, query } = args;
 
         const position = query.position && Math.round(query.position);
+        const nowPlayingQueue = getNowPlayingQueueWindow();
 
         if (query.submission) {
             // Checked by jellyfin-plugin-lastfm for whether or not to send the "finished" scrobble (uses PositionTicks)
@@ -1790,6 +1821,7 @@ export const JellyfinController: InternalControllerEndpoint = {
             jfApiClient(apiClientProps).scrobblePlaying({
                 body: {
                     ItemId: query.id,
+                    NowPlayingQueue: nowPlayingQueue,
                     PositionTicks: position,
                 },
             });
@@ -1816,6 +1848,7 @@ export const JellyfinController: InternalControllerEndpoint = {
                     EventName: query.event,
                     IsPaused: false,
                     ItemId: query.id,
+                    NowPlayingQueue: nowPlayingQueue,
                     PositionTicks: position,
                 },
             });
@@ -1837,6 +1870,7 @@ export const JellyfinController: InternalControllerEndpoint = {
         jfApiClient(apiClientProps).scrobbleProgress({
             body: {
                 ItemId: query.id,
+                NowPlayingQueue: nowPlayingQueue,
                 PositionTicks: position,
             },
         });

--- a/src/shared/api/jellyfin/jellyfin-types.ts
+++ b/src/shared/api/jellyfin/jellyfin-types.ts
@@ -722,9 +722,6 @@ const scrobbleParameters = z.object({
     EventName: z.string().optional(),
     IsPaused: z.boolean().optional(),
     ItemId: z.string(),
-    // Windowed play-order queue (current + upcoming) so server-side consumers
-    // (session UI, prefetch plugins) can see what plays next; full queues degrade
-    // the /Sessions endpoint (jellyfin/jellyfin#13377), hence the window
     NowPlayingQueue: z
         .array(
             z.object({

--- a/src/shared/api/jellyfin/jellyfin-types.ts
+++ b/src/shared/api/jellyfin/jellyfin-types.ts
@@ -722,6 +722,17 @@ const scrobbleParameters = z.object({
     EventName: z.string().optional(),
     IsPaused: z.boolean().optional(),
     ItemId: z.string(),
+    // Windowed play-order queue (current + upcoming) so server-side consumers
+    // (session UI, prefetch plugins) can see what plays next; full queues degrade
+    // the /Sessions endpoint (jellyfin/jellyfin#13377), hence the window
+    NowPlayingQueue: z
+        .array(
+            z.object({
+                Id: z.string(),
+                PlaylistItemId: z.string().optional(),
+            }),
+        )
+        .optional(),
     PositionTicks: z.number().optional(),
 });
 


### PR DESCRIPTION
## Summary

Jellyfin sessions currently receive only `ItemId` + `PositionTicks` with playback reports, so the server never learns what the client will play next. jellyfin-web reports its queue (`NowPlayingQueue`), and server-side consumers rely on that: the dashboard's now-playing view shows upcoming tracks, and session-based tooling (e.g. prefetch/cache-warming plugins for spun-down media disks) reads the queue to warm the next tracks before the track change.

This PR attaches a `NowPlayingQueue` to the Jellyfin `start`, `unpause`, and progress reports.

## Implementation notes

- **Windowed, not the full queue:** only the current track plus up to 19 upcoming tracks are reported. Large reported queues are a known server-side problem (jellyfin/jellyfin#13377, `/Sessions` degradation with multi-thousand-item queues, which genre/mix queues easily produce). A window sidesteps that entirely while still telling the server everything it can act on; the window slides forward with each report.
- **Play order, not display order:** with shuffle active, the window follows `queue.shuffled` via the existing `isShuffleEnabled` helper, so the reported "next" tracks are the ones that will actually play.
- Jellyfin-only: the field is added to the Jellyfin scrobble parameters; Navidrome/Subsonic paths are untouched.
- Defensive: any store access problem degrades to reporting no queue (same behavior as today).

## Testing

Verified against Jellyfin 10.11.11: sessions now show a 20-item `NowPlayingQueue` with the current track first (`/Sessions` inspected directly), the dashboard lists the upcoming tracks, and a queue-reading prefetch plugin correctly warms the next tracks of a Feishin genre-mix queue. `pnpm typecheck` and `lint:staged` pass.
