### PR TITLE
fix(player): correctly restore resume timestamp on app launch

### DIFF
--- a/src/renderer/features/player/audio-player/web-player.tsx
+++ b/src/renderer/features/player/audio-player/web-player.tsx
@@ -127,16 +127,16 @@ export function WebPlayer() {
                 return;
             }
 
+            if (usePlayerStoreBase.getState().player.status !== PlayerStatus.PLAYING) {
+                return;
+            }
+
             if (num === 1) {
                 setTimestamp(e.playedSeconds);
             }
 
             if (repeat === PlayerRepeat.ONE) {
                 handleRepeatOne(1, e.playedSeconds, getDuration(playerRef.current.player1().ref));
-                return;
-            }
-
-            if (usePlayerStoreBase.getState().player.status !== PlayerStatus.PLAYING) {
                 return;
             }
 
@@ -190,16 +190,16 @@ export function WebPlayer() {
                 return;
             }
 
+            if (usePlayerStoreBase.getState().player.status !== PlayerStatus.PLAYING) {
+                return;
+            }
+
             if (num === 2) {
                 setTimestamp(e.playedSeconds);
             }
 
             if (repeat === PlayerRepeat.ONE) {
                 handleRepeatOne(2, e.playedSeconds, getDuration(playerRef.current.player2().ref));
-                return;
-            }
-
-            if (usePlayerStoreBase.getState().player.status !== PlayerStatus.PLAYING) {
                 return;
             }
 

--- a/src/renderer/store/player.store.ts
+++ b/src/renderer/store/player.store.ts
@@ -1334,8 +1334,8 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                     const reset = options?.reset !== false;
                     set((state) => {
                         state.player.status = PlayerStatus.STOPPED;
-                        setTimestampStore(0);
                         if (reset) {
+                            setTimestampStore(0);
                             state.player.seekToTimestamp = uniqueSeekToTimestamp(0);
                         }
                     });


### PR DESCRIPTION
Feishin stores the player timestamp in a persistent way, and is capable of rehydrating it, but there are bugs that prevent this. With MPV it resets to zero on quit; the web player does seem to persist correctly but on mount the rendering displays zero. This rendering error does correct itself when playback begins but it's a bit disconcerting. The fixes:

Web player: storing the timestamp when not playing can overwrite the rehydrated timestamp with zero (particularly on mount)
MPV player: When the app quits there is a [media stop with reset false](https://github.com/jeffvli/feishin/blob/aa761b17ef4b122f2dfa49712c3b6945b2f4360c/src/renderer/features/player/audio-player/hooks/use-main-player-listener.tsx#L115). The stop handler was checking for this to avoid a _seek_ to zero, but still setting the store to zero. This should also mean a scrobble on quit sends the correct timestamp.

I use macOS desktop and Jellyfin 10.11.11, I've verified playback resume on both web and MPV. Claude verified the web player on linux using my Jellyfin server. I haven't tested this anywhere else.