### PR TITLE
bandaid fix for bug with autonext timestamps

### DIFF
--- a/src/renderer/store/player.store.ts
+++ b/src/renderer/store/player.store.ts
@@ -525,6 +525,7 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                                 state.player.status = PlayerStatus.PLAYING;
                                 state.player.playerNum = 1;
                                 setTimestampStore(0);
+                                state.player.seekToTimestamp = uniqueSeekToTimestamp(0);
                                 state.queue.default = newUniqueIds;
 
                                 if (state.player.shuffle === PlayerShuffle.TRACK) {
@@ -584,6 +585,7 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                                 state.player.status = PlayerStatus.PLAYING;
                                 state.player.playerNum = 1;
                                 setTimestampStore(0);
+                                state.player.seekToTimestamp = uniqueSeekToTimestamp(0);
                                 state.queue.default = shuffledIds;
 
                                 // Always maintain shuffled array when using Play.SHUFFLE
@@ -707,6 +709,7 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                                 }
                                 state.player.status = PlayerStatus.PLAYING;
                                 setTimestampStore(0);
+                                state.player.seekToTimestamp = uniqueSeekToTimestamp(0);
                             }
                         });
 
@@ -1066,6 +1069,7 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                             state.player.index = nextIndex;
                             state.player.playerNum = 1;
                             setTimestampStore(0);
+                            state.player.seekToTimestamp = uniqueSeekToTimestamp(0);
 
                             if (isStopped) {
                                 state.player.status = PlayerStatus.PLAYING;
@@ -1119,6 +1123,7 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                         state.player.index = nextIndex;
                         state.player.playerNum = 1;
                         setTimestampStore(0);
+                        state.player.seekToTimestamp = uniqueSeekToTimestamp(0);
 
                         if (isStopped) {
                             state.player.status = PlayerStatus.PLAYING;
@@ -1173,6 +1178,7 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                                     playIndex = queueIndex;
                                 }
                                 setTimestampStore(0);
+                                state.player.seekToTimestamp = uniqueSeekToTimestamp(0);
                             }
                         }
 
@@ -1220,6 +1226,7 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                             state.player.index = index;
                         }
                         setTimestampStore(0);
+                        state.player.seekToTimestamp = uniqueSeekToTimestamp(0);
 
                         state.player.status = PlayerStatus.PLAYING;
                     });
@@ -1272,6 +1279,7 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                         state.player.index = previousIndex;
                         state.player.playerNum = 1;
                         setTimestampStore(0);
+                        state.player.seekToTimestamp = uniqueSeekToTimestamp(0);
                         if (resumeFromStopped) {
                             state.player.status = PlayerStatus.PLAYING;
                         }


### PR DESCRIPTION
Due to autonext being handled differently than manual next, for whatever reason if you go back to a previous song and autonext progresses back to the song, it will resume to the old timestamp due to state.player.seekToTimestamp not being updated when changing songs most of the time.

an example scenario of this bug would be
1. You are 90 seconds into song 30. 
2. You click song 29. 
3. Let it play until autonext. 
4. Instead starting at the beginning of song 30, it starts 90 seconds in.