### PR TITLE
fix(player): reset seek timestamp on song play

### DIFF
--- a/src/renderer/features/player/hooks/use-update-current-song.ts
+++ b/src/renderer/features/player/hooks/use-update-current-song.ts
@@ -5,7 +5,11 @@ import { useCallback } from 'react';
 import { api } from '/@/renderer/api';
 import { queryKeys } from '/@/renderer/api/query-keys';
 import { usePlayerEvents } from '/@/renderer/features/player/audio-player/hooks/use-player-events';
-import { updateQueueSong } from '/@/renderer/store/player.store';
+import {
+    uniqueSeekToTimestamp,
+    updateQueueSong,
+    usePlayerStoreBase,
+} from '/@/renderer/store/player.store';
 import { logger } from '/@/renderer/utils/logger';
 import { QueueSong, SongDetailQuery } from '/@/shared/types/domain-types';
 
@@ -59,6 +63,12 @@ export const useUpdateCurrentSong = () => {
         [queryClient],
     );
 
+    const resetSeekToTimestamp = useCallback(() => {
+        usePlayerStoreBase.setState((state) => {
+            state.player.seekToTimestamp = uniqueSeekToTimestamp(0);
+        });
+    }, []);
+
     usePlayerEvents(
         {
             onCurrentSongChange: (properties, prev) => {
@@ -68,10 +78,12 @@ export const useUpdateCurrentSong = () => {
                     properties.song?._uniqueId !== prev.song?._uniqueId
                 ) {
                     handleSongChange(properties);
+                    // Prevents issues with lingering seekToTimestamp on song autonext
+                    resetSeekToTimestamp();
                 }
             },
         },
-        [handleSongChange],
+        [handleSongChange, resetSeekToTimestamp],
     );
 };
 

--- a/src/renderer/store/player.store.ts
+++ b/src/renderer/store/player.store.ts
@@ -167,6 +167,11 @@ export function mapShuffledToQueueIndex(shuffledIndex: number, shuffled: number[
     return shuffledIndex;
 }
 
+// We need to use a unique id so that the equalityFn can work if attempting to set the same timestamp
+export function uniqueSeekToTimestamp(timestamp: number) {
+    return `${timestamp}-${nanoid()}`;
+}
+
 // Helper function to add new indexes to shuffled array after current position
 function addIndexesToShuffled(
     shuffled: number[],
@@ -525,7 +530,6 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                                 state.player.status = PlayerStatus.PLAYING;
                                 state.player.playerNum = 1;
                                 setTimestampStore(0);
-                                state.player.seekToTimestamp = uniqueSeekToTimestamp(0);
                                 state.queue.default = newUniqueIds;
 
                                 if (state.player.shuffle === PlayerShuffle.TRACK) {
@@ -585,7 +589,6 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                                 state.player.status = PlayerStatus.PLAYING;
                                 state.player.playerNum = 1;
                                 setTimestampStore(0);
-                                state.player.seekToTimestamp = uniqueSeekToTimestamp(0);
                                 state.queue.default = shuffledIds;
 
                                 // Always maintain shuffled array when using Play.SHUFFLE
@@ -709,7 +712,6 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                                 }
                                 state.player.status = PlayerStatus.PLAYING;
                                 setTimestampStore(0);
-                                state.player.seekToTimestamp = uniqueSeekToTimestamp(0);
                             }
                         });
 
@@ -1069,7 +1071,6 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                             state.player.index = nextIndex;
                             state.player.playerNum = 1;
                             setTimestampStore(0);
-                            state.player.seekToTimestamp = uniqueSeekToTimestamp(0);
 
                             if (isStopped) {
                                 state.player.status = PlayerStatus.PLAYING;
@@ -1123,7 +1124,6 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                         state.player.index = nextIndex;
                         state.player.playerNum = 1;
                         setTimestampStore(0);
-                        state.player.seekToTimestamp = uniqueSeekToTimestamp(0);
 
                         if (isStopped) {
                             state.player.status = PlayerStatus.PLAYING;
@@ -1178,7 +1178,6 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                                     playIndex = queueIndex;
                                 }
                                 setTimestampStore(0);
-                                state.player.seekToTimestamp = uniqueSeekToTimestamp(0);
                             }
                         }
 
@@ -1226,7 +1225,6 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                             state.player.index = index;
                         }
                         setTimestampStore(0);
-                        state.player.seekToTimestamp = uniqueSeekToTimestamp(0);
 
                         state.player.status = PlayerStatus.PLAYING;
                     });
@@ -1279,7 +1277,6 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                         state.player.index = previousIndex;
                         state.player.playerNum = 1;
                         setTimestampStore(0);
-                        state.player.seekToTimestamp = uniqueSeekToTimestamp(0);
                         if (resumeFromStopped) {
                             state.player.status = PlayerStatus.PLAYING;
                         }
@@ -2380,9 +2377,4 @@ function toQueueSong(item: Song): QueueSong {
         ...item,
         _uniqueId: nanoid(),
     };
-}
-
-// We need to use a unique id so that the equalityFn can work if attempting to set the same timestamp
-function uniqueSeekToTimestamp(timestamp: number) {
-    return `${timestamp}-${nanoid()}`;
 }

--- a/src/renderer/store/player.store.ts
+++ b/src/renderer/store/player.store.ts
@@ -525,6 +525,7 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                                 state.player.status = PlayerStatus.PLAYING;
                                 state.player.playerNum = 1;
                                 setTimestampStore(0);
+                                state.player.seekToTimestamp = uniqueSeekToTimestamp(0);
                                 state.queue.default = newUniqueIds;
 
                                 if (state.player.shuffle === PlayerShuffle.TRACK) {
@@ -584,6 +585,7 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                                 state.player.status = PlayerStatus.PLAYING;
                                 state.player.playerNum = 1;
                                 setTimestampStore(0);
+                                state.player.seekToTimestamp = uniqueSeekToTimestamp(0);
                                 state.queue.default = shuffledIds;
 
                                 // Always maintain shuffled array when using Play.SHUFFLE
@@ -707,6 +709,7 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                                 }
                                 state.player.status = PlayerStatus.PLAYING;
                                 setTimestampStore(0);
+                                state.player.seekToTimestamp = uniqueSeekToTimestamp(0);
                             }
                         });
 
@@ -1066,6 +1069,7 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                             state.player.index = nextIndex;
                             state.player.playerNum = 1;
                             setTimestampStore(0);
+                            state.player.seekToTimestamp = uniqueSeekToTimestamp(0);
 
                             if (isStopped) {
                                 state.player.status = PlayerStatus.PLAYING;
@@ -1119,6 +1123,7 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                         state.player.index = nextIndex;
                         state.player.playerNum = 1;
                         setTimestampStore(0);
+                        state.player.seekToTimestamp = uniqueSeekToTimestamp(0);
 
                         if (isStopped) {
                             state.player.status = PlayerStatus.PLAYING;
@@ -1173,6 +1178,7 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                                     playIndex = queueIndex;
                                 }
                                 setTimestampStore(0);
+                                state.player.seekToTimestamp = uniqueSeekToTimestamp(0);
                             }
                         }
 
@@ -1220,6 +1226,7 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                             state.player.index = index;
                         }
                         setTimestampStore(0);
+                        state.player.seekToTimestamp = uniqueSeekToTimestamp(0);
 
                         state.player.status = PlayerStatus.PLAYING;
                     });
@@ -1272,6 +1279,7 @@ export const usePlayerStoreBase = createWithEqualityFn<PlayerState>()(
                         state.player.index = previousIndex;
                         state.player.playerNum = 1;
                         setTimestampStore(0);
+                        state.player.seekToTimestamp = uniqueSeekToTimestamp(0);
                         if (resumeFromStopped) {
                             state.player.status = PlayerStatus.PLAYING;
                         }


### PR DESCRIPTION
Due to autonext being handled differently than manual next, for whatever reason if you go back to a previous song and autonext progresses back to the song, it will resume to the old timestamp due to state.player.seekToTimestamp not being updated when changing songs most of the time.

an example scenario of this bug would be
1. You are 90 seconds into song 30. 
2. You click song 29. 
3. Let it play until autonext. 
4. Instead starting at the beginning of song 30, it starts 90 seconds in.

This is somewhat of a band-aid fix since the underlying issue is with autonext since it does not happen with manual next.