### PR TITLE
fix: prevent stale MPV commands during runtime player switches

### DIFF
--- a/src/main/features/core/player/index.ts
+++ b/src/main/features/core/player/index.ts
@@ -23,6 +23,10 @@ declare module 'node-mpv';
 // }
 
 let mpvInstance: MpvAPI | null = null;
+// Set while a create is in flight. `mpvInstance` is null across that await, so callers that
+// only check it would otherwise conclude mpv is absent and spawn a throwaway instance
+// alongside the one being started.
+let mpvCreatePromise: null | Promise<MpvAPI> = null;
 let currentPlayerData: null | PlayerData = null;
 const socketPath = isWindows() ? `\\\\.\\pipe\\mpvserver-${pid}` : `/tmp/node-mpv-${pid}.sock`;
 
@@ -342,7 +346,12 @@ ipcMain.handle(
                 });
             mpvInstance = null;
 
-            mpvInstance = await createMpv(data);
+            mpvCreatePromise = createMpv(data);
+            try {
+                mpvInstance = await mpvCreatePromise;
+            } finally {
+                mpvCreatePromise = null;
+            }
             mpvLog({ action: 'Restarted mpv', toast: 'success' });
             setAudioPlayerFallback(false);
         } catch (err: any | NodeMpvError) {
@@ -360,7 +369,12 @@ ipcMain.handle(
                 action: `Attempting to initialize mpv with parameters: ${JSON.stringify(data)}`,
                 level: 'debug',
             });
-            mpvInstance = await createMpv(data);
+            mpvCreatePromise = createMpv(data);
+            try {
+                mpvInstance = await mpvCreatePromise;
+            } finally {
+                mpvCreatePromise = null;
+            }
             setAudioPlayerFallback(false);
         } catch (err: any | NodeMpvError) {
             mpvLog({ action: 'Failed to initialize mpv, falling back to web player' }, err);
@@ -677,6 +691,15 @@ ipcMain.handle(
     'player-get-audio-devices',
     async (): Promise<{ label: string; value: string }[]> => {
         try {
+            // Wait out an in-flight startup so the real instance is reused instead of racing it.
+            if (mpvCreatePromise) {
+                try {
+                    await mpvCreatePromise;
+                } catch {
+                    // Startup failed; fall through to the temporary-instance path below.
+                }
+            }
+
             const instance = getMpvInstance();
             let tempInstance: MpvAPI | null = null;
             let mpvToUse: MpvAPI | null = null;

--- a/src/renderer/features/player/audio-player/engine/mpv-player-engine.tsx
+++ b/src/renderer/features/player/audio-player/engine/mpv-player-engine.tsx
@@ -10,6 +10,7 @@ import { AudioPlayer, PlayerOnProgressProps } from '/@/renderer/features/player/
 import { useRadioStore } from '/@/renderer/features/radio/hooks/use-radio-player';
 import { getMpvProperties } from '/@/renderer/features/settings/components/playback/mpv-properties';
 import {
+    setMpvInitialized,
     usePlaybackSettings,
     usePlayerActions,
     usePlayerSong,
@@ -67,6 +68,7 @@ export const MpvPlayerEngine = (props: MpvPlayerEngineProps) => {
     useEffect(() => {
         const handleMpvReload = () => {
             setIsInitialized(false);
+            setMpvInitialized(false);
             setReloadTrigger((prev) => prev + 1);
         };
 
@@ -89,6 +91,7 @@ export const MpvPlayerEngine = (props: MpvPlayerEngineProps) => {
     useEffect(() => {
         isMountedRef.current = true;
         setIsInitialized(false);
+        setMpvInitialized(false);
         let isCancelled = false;
 
         const initializeMpv = async () => {
@@ -162,6 +165,7 @@ export const MpvPlayerEngine = (props: MpvPlayerEngineProps) => {
 
             if (!isCancelled) {
                 setIsInitialized(true);
+                setMpvInitialized(true);
             }
         };
 
@@ -173,6 +177,7 @@ export const MpvPlayerEngine = (props: MpvPlayerEngineProps) => {
             // Quit mpv on unmount
             mpvPlayer?.quit();
             setIsInitialized(false);
+            setMpvInitialized(false);
             hasPopulatedQueueRef.current = false;
         };
         // Note: volume, speed, preservePitch, and transcode are intentionally not in dependencies.

--- a/src/renderer/features/player/audio-player/engine/mpv-player-engine.tsx
+++ b/src/renderer/features/player/audio-player/engine/mpv-player-engine.tsx
@@ -11,6 +11,7 @@ import { useRadioStore } from '/@/renderer/features/radio/hooks/use-radio-player
 import { getMpvProperties } from '/@/renderer/features/settings/components/playback/mpv-properties';
 import {
     setMpvInitialized,
+    useMpvInitialized,
     usePlaybackSettings,
     usePlayerActions,
     usePlayerSong,
@@ -53,7 +54,7 @@ export const MpvPlayerEngine = (props: MpvPlayerEngineProps) => {
     } = props;
 
     const [internalVolume, setInternalVolume] = useState(volume / 100 || 0);
-    const [isInitialized, setIsInitialized] = useState(false);
+    const isInitialized = useMpvInitialized();
     const currentSong = usePlayerSong();
 
     const progressIntervalRef = useRef<NodeJS.Timeout | null>(null);
@@ -67,7 +68,6 @@ export const MpvPlayerEngine = (props: MpvPlayerEngineProps) => {
 
     useEffect(() => {
         const handleMpvReload = () => {
-            setIsInitialized(false);
             setMpvInitialized(false);
             setReloadTrigger((prev) => prev + 1);
         };
@@ -90,7 +90,6 @@ export const MpvPlayerEngine = (props: MpvPlayerEngineProps) => {
     // Start the mpv instance on startup
     useEffect(() => {
         isMountedRef.current = true;
-        setIsInitialized(false);
         setMpvInitialized(false);
         let isCancelled = false;
 
@@ -164,7 +163,6 @@ export const MpvPlayerEngine = (props: MpvPlayerEngineProps) => {
             }
 
             if (!isCancelled) {
-                setIsInitialized(true);
                 setMpvInitialized(true);
             }
         };
@@ -176,7 +174,6 @@ export const MpvPlayerEngine = (props: MpvPlayerEngineProps) => {
             isMountedRef.current = false;
             // Quit mpv on unmount
             mpvPlayer?.quit();
-            setIsInitialized(false);
             setMpvInitialized(false);
             hasPopulatedQueueRef.current = false;
         };

--- a/src/renderer/features/player/audio-player/engine/mpv-player-engine.tsx
+++ b/src/renderer/features/player/audio-player/engine/mpv-player-engine.tsx
@@ -52,10 +52,10 @@ export const MpvPlayerEngine = (props: MpvPlayerEngineProps) => {
     } = props;
 
     const [internalVolume, setInternalVolume] = useState(volume / 100 || 0);
+    const [isInitialized, setIsInitialized] = useState(false);
     const currentSong = usePlayerSong();
 
     const progressIntervalRef = useRef<NodeJS.Timeout | null>(null);
-    const isInitializedRef = useRef<boolean>(false);
     const hasPopulatedQueueRef = useRef<boolean>(false);
     const isMountedRef = useRef<boolean>(true);
 
@@ -66,6 +66,7 @@ export const MpvPlayerEngine = (props: MpvPlayerEngineProps) => {
 
     useEffect(() => {
         const handleMpvReload = () => {
+            setIsInitialized(false);
             setReloadTrigger((prev) => prev + 1);
         };
 
@@ -87,6 +88,8 @@ export const MpvPlayerEngine = (props: MpvPlayerEngineProps) => {
     // Start the mpv instance on startup
     useEffect(() => {
         isMountedRef.current = true;
+        setIsInitialized(false);
+        let isCancelled = false;
 
         const initializeMpv = async () => {
             // Always quit mpv first to ensure clean state, especially during HMR remounts
@@ -107,7 +110,6 @@ export const MpvPlayerEngine = (props: MpvPlayerEngineProps) => {
             }
 
             // Reset initialization state
-            isInitializedRef.current = false;
             hasPopulatedQueueRef.current = false;
 
             // Initialize mpv with fresh state
@@ -158,16 +160,19 @@ export const MpvPlayerEngine = (props: MpvPlayerEngineProps) => {
                 }
             }
 
-            isInitializedRef.current = true;
+            if (!isCancelled) {
+                setIsInitialized(true);
+            }
         };
 
         initializeMpv();
 
         return () => {
+            isCancelled = true;
             isMountedRef.current = false;
             // Quit mpv on unmount
             mpvPlayer?.quit();
-            isInitializedRef.current = false;
+            setIsInitialized(false);
             hasPopulatedQueueRef.current = false;
         };
         // Note: volume, speed, preservePitch, and transcode are intentionally not in dependencies.
@@ -180,7 +185,7 @@ export const MpvPlayerEngine = (props: MpvPlayerEngineProps) => {
 
     // Update volume
     useEffect(() => {
-        if (!mpvPlayer) {
+        if (!mpvPlayer || !isInitialized) {
             return;
         }
 
@@ -189,20 +194,20 @@ export const MpvPlayerEngine = (props: MpvPlayerEngineProps) => {
             setInternalVolume(vol);
         });
         mpvPlayer.volume(volume);
-    }, [volume]);
+    }, [isInitialized, volume]);
 
     // Update mute status
     useEffect(() => {
-        if (!mpvPlayer) {
+        if (!mpvPlayer || !isInitialized) {
             return;
         }
 
         mpvPlayer.mute(isMuted);
-    }, [isMuted]);
+    }, [isInitialized, isMuted]);
 
     // Update speed/playback rate
     useEffect(() => {
-        if (!mpvPlayer) {
+        if (!mpvPlayer || !isInitialized) {
             return;
         }
 
@@ -211,11 +216,11 @@ export const MpvPlayerEngine = (props: MpvPlayerEngineProps) => {
         }
 
         mpvPlayer.setProperties({ speed });
-    }, [speed]);
+    }, [isInitialized, speed]);
 
     // Update pitch correction status
     useEffect(() => {
-        if (!mpvPlayer) {
+        if (!mpvPlayer || !isInitialized) {
             return;
         }
 
@@ -224,11 +229,11 @@ export const MpvPlayerEngine = (props: MpvPlayerEngineProps) => {
         } else {
             mpvPlayer.setProperties({ 'audio-pitch-correction': 'yes' });
         }
-    }, [preservePitch]);
+    }, [isInitialized, preservePitch]);
 
     // Handle play/pause status
     useEffect(() => {
-        if (!mpvPlayer) {
+        if (!mpvPlayer || !isInitialized) {
             return;
         }
 
@@ -237,7 +242,7 @@ export const MpvPlayerEngine = (props: MpvPlayerEngineProps) => {
         } else {
             mpvPlayer.pause();
         }
-    }, [playerStatus]);
+    }, [isInitialized, playerStatus]);
 
     const hasCurrentSong = !!currentSong?.id;
 

--- a/src/renderer/features/settings/components/playback/audio-settings.tsx
+++ b/src/renderer/features/settings/components/playback/audio-settings.tsx
@@ -9,7 +9,7 @@ import {
     SettingOption,
     SettingsSection,
 } from '/@/renderer/features/settings/components/settings-section';
-import { useCurrentServer, usePlayerStatus } from '/@/renderer/store';
+import { useCurrentServer, useMpvInitialized, usePlayerStatus } from '/@/renderer/store';
 import {
     usePlaybackSettings,
     usePlaybackType,
@@ -58,6 +58,7 @@ export const getDefaultAudioDevice = (
 
 export const useAudioDevices = (playbackType: PlayerType) => {
     const [audioDevices, setAudioDevices] = useState<AudioDeviceOption[]>([]);
+    const mpvInitialized = useMpvInitialized();
 
     useEffect(() => {
         const fetchAudioDevices = async () => {
@@ -81,7 +82,7 @@ export const useAudioDevices = (playbackType: PlayerType) => {
                             message: t('error.audioDeviceFetchError'),
                         }),
                     );
-            } else if (playbackType === PlayerType.LOCAL && mpvPlayer) {
+            } else if (playbackType === PlayerType.LOCAL && mpvPlayer && mpvInitialized) {
                 try {
                     const devices = await getMpvAudioDevices();
                     const uniqueDevices = devices.filter(
@@ -97,7 +98,7 @@ export const useAudioDevices = (playbackType: PlayerType) => {
         };
 
         fetchAudioDevices();
-    }, [playbackType]);
+    }, [mpvInitialized, playbackType]);
 
     return audioDevices;
 };

--- a/src/renderer/store/player.store.ts
+++ b/src/renderer/store/player.store.ts
@@ -87,6 +87,9 @@ interface GroupedQueue {
 
 interface State {
     hydrated: boolean;
+    // Runtime-only: true once the mpv engine has finished initializing.
+    // Top-level keys are not persisted (see partialize), same as `hydrated`.
+    mpvInitialized: boolean;
     player: {
         crossfadeDuration: number;
         crossfadeStyle: CrossfadeStyle;
@@ -335,6 +338,7 @@ function regenerateShuffledIndexesIfNeeded(state: {
 
 const initialState: State = {
     hydrated: false,
+    mpvInitialized: false,
     player: {
         crossfadeDuration: 5,
         crossfadeStyle: CrossfadeStyle.EQUAL_POWER,
@@ -2216,6 +2220,14 @@ export const usePlayerStatus = () => {
 
 export const usePlayerHydrated = () => {
     return usePlayerStoreBase((state) => state.hydrated);
+};
+
+export const useMpvInitialized = () => {
+    return usePlayerStoreBase((state) => state.mpvInitialized);
+};
+
+export const setMpvInitialized = (mpvInitialized: boolean) => {
+    usePlayerStoreBase.setState({ mpvInitialized });
 };
 
 export const usePlayerVolume = () => {


### PR DESCRIPTION
Represent MPV readiness as component state in `MpvPlayerEngine` and keep it false while the old process is being stopped and the new process and queue are initialized. Switching from the web player to MPV while playback is active can briefly control the previous MPV process before the replacement process and queue are ready.

Start a song with the web player, switch to MPV while it is playing, and verify only the selected song is audible, its timestamp advances from the correct position, seek controls work, and the MPV visualizer receives audio; Pause a song in the web player before switching to MPV and verify the fresh MPV queue remains paused until playback is explicitly resumed.

Closes #2362
