### PR TITLE
fix: dedupe fetching art by album id for Navidrome users

### DIFF
--- a/src/shared/api/navidrome/navidrome-normalize.ts
+++ b/src/shared/api/navidrome/navidrome-normalize.ts
@@ -263,7 +263,7 @@ const normalizeSong = (
             songCount: null,
         })),
         id,
-        imageId: id,
+        imageId: item.albumId || id,
         imageUrl: null,
         lastPlayedAt: normalizePlayDate(item),
         lyrics: item.lyrics ? item.lyrics : null,


### PR DESCRIPTION
We fetch cover art for songs by song ID, meaning we fire off [album length] number of requests when loading an album, or if we have the same album in a playlist, we wait to load art over and over again for every song on the album. But since we have the album ID in question available to request by, we can deduplicate the requests to just the album; if no album, we fall back to song ID.