### PR TITLE
feat: exclude other artist from artist play

### DIFF
--- a/src/renderer/features/artists/components/album-artist-detail-header.tsx
+++ b/src/renderer/features/artists/components/album-artist-detail-header.tsx
@@ -171,21 +171,20 @@ export const AlbumArtistDetailHeader = forwardRef<HTMLDivElement, AlbumArtistDet
                 const albumIds = flatSortedAlbums.map((album) => album.id);
                 if (albumIds.length === 0) return;
 
-                const isSongByArtist =
-                    (artistId?: string) =>
-                    (song: Song): boolean => {
-                        return (
-                            song.albumArtists.some((artist) => artist.id === artistId) ||
-                            song.artists.some((artist) => artist.id === artistId)
-                        );
-                    };
+                const filter = (song: Song) => {
+                    if (song.albumArtists.some((artist) => artist.id === albumArtistId)) {
+                        return true;
+                    }
+
+                    return song.artists.some((artist) => artist.id === albumArtistId);
+                };
 
                 addToQueueByFetch(
                     server.id,
                     albumIds,
                     LibraryItem.ALBUM,
                     type || playButtonBehavior,
-                    isSongByArtist(albumArtistId),
+                    { filter },
                 );
             },
             [

--- a/src/renderer/features/artists/components/album-artist-detail-header.tsx
+++ b/src/renderer/features/artists/components/album-artist-detail-header.tsx
@@ -1,21 +1,17 @@
-import { useQueryClient, useSuspenseQuery, UseSuspenseQueryResult } from '@tanstack/react-query';
+import { useSuspenseQuery, UseSuspenseQueryResult } from '@tanstack/react-query';
 import { forwardRef, Fragment, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
 import styles from './album-artist-detail-header.module.css';
 
-import { queryKeys } from '/@/renderer/api/query-keys';
 import { useItemImageUrl } from '/@/renderer/components/item-image/item-image';
 import { artistsQueries } from '/@/renderer/features/artists/api/artists-api';
 import { getArtistAlbumsGrouped } from '/@/renderer/features/artists/hooks/use-artist-albums-grouped';
 import { useDeleteArtistImage } from '/@/renderer/features/artists/mutations/delete-artist-image-mutation';
 import { useUploadArtistImage } from '/@/renderer/features/artists/mutations/upload-artist-image-mutation';
 import { ContextMenuController } from '/@/renderer/features/context-menu/context-menu-controller';
-import {
-    fetchSongsByItemType,
-    usePlayer,
-} from '/@/renderer/features/player/context/player-context';
+import { usePlayer } from '/@/renderer/features/player/context/player-context';
 import {
     LibraryHeader,
     LibraryHeaderMenu,
@@ -37,6 +33,7 @@ import {
     AlbumListResponse,
     LibraryItem,
     ServerType,
+    Song,
 } from '/@/shared/types/domain-types';
 import { ServerFeature } from '/@/shared/types/features-types';
 import { Play } from '/@/shared/types/types';
@@ -110,7 +107,6 @@ export const AlbumArtistDetailHeader = forwardRef<HTMLDivElement, AlbumArtistDet
         const server = useCurrentServer();
         const showRatings = useShowRatings();
         const showFavorites = useShowFavorites();
-        const queryClient = useQueryClient();
         const { t } = useTranslation();
         const detailQuery = useSuspenseQuery(
             artistsQueries.albumArtistDetail({
@@ -145,7 +141,7 @@ export const AlbumArtistDetailHeader = forwardRef<HTMLDivElement, AlbumArtistDet
             },
         ];
 
-        const { addToQueueByData } = usePlayer();
+        const { addToQueueByFetch } = usePlayer();
         const playButtonBehavior = usePlayButtonBehavior();
         const setFavorite = useSetFavorite();
         const setRating = useSetRating();
@@ -158,7 +154,7 @@ export const AlbumArtistDetailHeader = forwardRef<HTMLDivElement, AlbumArtistDet
         const artistReleaseTypeItems = useArtistReleaseTypeItems();
 
         const handlePlay = useCallback(
-            async (type?: Play) => {
+            (type?: Play) => {
                 if (!server?.id || !routeId) return;
 
                 const albums = albumsQuery.data?.items || [];
@@ -175,28 +171,25 @@ export const AlbumArtistDetailHeader = forwardRef<HTMLDivElement, AlbumArtistDet
                 const albumIds = flatSortedAlbums.map((album) => album.id);
                 if (albumIds.length === 0) return;
 
-                const songs = await queryClient.fetchQuery({
-                    gcTime: 0,
-                    queryFn: () => {
-                        return fetchSongsByItemType(queryClient, server.id, {
-                            id: albumIds,
-                            itemType: LibraryItem.ALBUM,
-                        });
-                    },
-                    queryKey: queryKeys.player.fetch(),
-                    staleTime: 0,
-                });
+                const isSongByArtist =
+                    (artistId?: string) =>
+                    (song: Song): boolean => {
+                        return (
+                            song.albumArtists.some((artist) => artist.id === artistId) ||
+                            song.artists.some((artist) => artist.id === artistId)
+                        );
+                    };
 
-                const filteredArtistSongs = songs.filter((song) => {
-                    if (song.albumArtists.some((artist) => artist.id === albumArtistId))
-                        return true;
-
-                    return song.artists.some((artist) => artist.id === albumArtistId);
-                });
-
-                addToQueueByData(filteredArtistSongs, type || playButtonBehavior);
+                addToQueueByFetch(
+                    server.id,
+                    albumIds,
+                    LibraryItem.ALBUM,
+                    type || playButtonBehavior,
+                    isSongByArtist(albumArtistId),
+                );
             },
             [
+                addToQueueByFetch,
                 playButtonBehavior,
                 routeId,
                 server.id,
@@ -206,8 +199,6 @@ export const AlbumArtistDetailHeader = forwardRef<HTMLDivElement, AlbumArtistDet
                 groupingType,
                 artistReleaseTypeItems,
                 t,
-                queryClient,
-                addToQueueByData,
                 albumArtistId,
             ],
         );

--- a/src/renderer/features/artists/components/album-artist-detail-header.tsx
+++ b/src/renderer/features/artists/components/album-artist-detail-header.tsx
@@ -1,17 +1,21 @@
-import { useSuspenseQuery, UseSuspenseQueryResult } from '@tanstack/react-query';
+import { useQueryClient, useSuspenseQuery, UseSuspenseQueryResult } from '@tanstack/react-query';
 import { forwardRef, Fragment, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
 import styles from './album-artist-detail-header.module.css';
 
+import { queryKeys } from '/@/renderer/api/query-keys';
 import { useItemImageUrl } from '/@/renderer/components/item-image/item-image';
 import { artistsQueries } from '/@/renderer/features/artists/api/artists-api';
 import { getArtistAlbumsGrouped } from '/@/renderer/features/artists/hooks/use-artist-albums-grouped';
 import { useDeleteArtistImage } from '/@/renderer/features/artists/mutations/delete-artist-image-mutation';
 import { useUploadArtistImage } from '/@/renderer/features/artists/mutations/upload-artist-image-mutation';
 import { ContextMenuController } from '/@/renderer/features/context-menu/context-menu-controller';
-import { usePlayer } from '/@/renderer/features/player/context/player-context';
+import {
+    fetchSongsByItemType,
+    usePlayer,
+} from '/@/renderer/features/player/context/player-context';
 import {
     LibraryHeader,
     LibraryHeaderMenu,
@@ -106,6 +110,7 @@ export const AlbumArtistDetailHeader = forwardRef<HTMLDivElement, AlbumArtistDet
         const server = useCurrentServer();
         const showRatings = useShowRatings();
         const showFavorites = useShowFavorites();
+        const queryClient = useQueryClient();
         const { t } = useTranslation();
         const detailQuery = useSuspenseQuery(
             artistsQueries.albumArtistDetail({
@@ -140,7 +145,7 @@ export const AlbumArtistDetailHeader = forwardRef<HTMLDivElement, AlbumArtistDet
             },
         ];
 
-        const { addToQueueByFetch } = usePlayer();
+        const { addToQueueByData } = usePlayer();
         const playButtonBehavior = usePlayButtonBehavior();
         const setFavorite = useSetFavorite();
         const setRating = useSetRating();
@@ -153,7 +158,7 @@ export const AlbumArtistDetailHeader = forwardRef<HTMLDivElement, AlbumArtistDet
         const artistReleaseTypeItems = useArtistReleaseTypeItems();
 
         const handlePlay = useCallback(
-            (type?: Play) => {
+            async (type?: Play) => {
                 if (!server?.id || !routeId) return;
 
                 const albums = albumsQuery.data?.items || [];
@@ -169,15 +174,29 @@ export const AlbumArtistDetailHeader = forwardRef<HTMLDivElement, AlbumArtistDet
 
                 const albumIds = flatSortedAlbums.map((album) => album.id);
                 if (albumIds.length === 0) return;
-                addToQueueByFetch(
-                    server.id,
-                    albumIds,
-                    LibraryItem.ALBUM,
-                    type || playButtonBehavior,
-                );
+
+                const songs = await queryClient.fetchQuery({
+                    gcTime: 0,
+                    queryFn: () => {
+                        return fetchSongsByItemType(queryClient, server.id, {
+                            id: albumIds,
+                            itemType: LibraryItem.ALBUM,
+                        });
+                    },
+                    queryKey: queryKeys.player.fetch(),
+                    staleTime: 0,
+                });
+
+                const filteredArtistSongs = songs.filter((song) => {
+                    if (song.albumArtists.some((artist) => artist.id === albumArtistId))
+                        return true;
+
+                    return song.artists.some((artist) => artist.id === albumArtistId);
+                });
+
+                addToQueueByData(filteredArtistSongs, type || playButtonBehavior);
             },
             [
-                addToQueueByFetch,
                 playButtonBehavior,
                 routeId,
                 server.id,
@@ -187,6 +206,9 @@ export const AlbumArtistDetailHeader = forwardRef<HTMLDivElement, AlbumArtistDet
                 groupingType,
                 artistReleaseTypeItems,
                 t,
+                queryClient,
+                addToQueueByData,
+                albumArtistId,
             ],
         );
 

--- a/src/renderer/features/player/context/player-context.tsx
+++ b/src/renderer/features/player/context/player-context.tsx
@@ -18,6 +18,7 @@ import {
 import { playlistsQueries } from '/@/renderer/features/playlists/api/playlists-api';
 import { songsQueries } from '/@/renderer/features/songs/api/songs-api';
 import {
+    AddToQueueOptions,
     AddToQueueType,
     usePlayerActions,
     useSettingsStore,
@@ -54,6 +55,7 @@ export interface PlayerContext {
         id: string[],
         itemType: LibraryItem,
         type: AddToQueueType,
+        options?: AddToQueueOptions,
         additionalFilter?: (song: Song) => boolean,
     ) => void;
     addToQueueByListQuery: (
@@ -318,7 +320,7 @@ export const PlayerProvider = ({ children }: { children: React.ReactNode }) => {
             id: string[],
             itemType: LibraryItem,
             type: AddToQueueType,
-            additionalFilter?: (song: Song) => boolean,
+            options?: AddToQueueOptions,
         ) => {
             let toastId: null | string = null;
             const fetchId = nanoid();
@@ -378,8 +380,8 @@ export const PlayerProvider = ({ children }: { children: React.ReactNode }) => {
                 const filters = useSettingsStore.getState().playback.filters;
                 let filteredSongs = filterSongsByPlayerFilters(sortedSongs, filters);
 
-                if (additionalFilter) {
-                    filteredSongs = filteredSongs.filter(additionalFilter);
+                if (options?.filter) {
+                    filteredSongs = filteredSongs.filter(options.filter);
                 }
 
                 // Songs from multiple playlists are merged together, so there is no single

--- a/src/renderer/features/player/context/player-context.tsx
+++ b/src/renderer/features/player/context/player-context.tsx
@@ -54,6 +54,7 @@ export interface PlayerContext {
         id: string[],
         itemType: LibraryItem,
         type: AddToQueueType,
+        additionalFilter?: (song: Song) => boolean,
     ) => void;
     addToQueueByListQuery: (
         serverId: string,
@@ -312,7 +313,13 @@ export const PlayerProvider = ({ children }: { children: React.ReactNode }) => {
     );
 
     const addToQueueByFetch = useCallback(
-        async (serverId: string, id: string[], itemType: LibraryItem, type: AddToQueueType) => {
+        async (
+            serverId: string,
+            id: string[],
+            itemType: LibraryItem,
+            type: AddToQueueType,
+            additionalFilter?: (song: Song) => boolean,
+        ) => {
             let toastId: null | string = null;
             const fetchId = nanoid();
 
@@ -370,6 +377,10 @@ export const PlayerProvider = ({ children }: { children: React.ReactNode }) => {
 
                 const filters = useSettingsStore.getState().playback.filters;
                 let filteredSongs = filterSongsByPlayerFilters(sortedSongs, filters);
+
+                if (additionalFilter) {
+                    filteredSongs = filteredSongs.filter(additionalFilter);
+                }
 
                 // Songs from multiple playlists are merged together, so there is no single
                 // playlist to attribute them to: skip tagging (and URL inference) entirely.

--- a/src/renderer/features/player/context/player-context.tsx
+++ b/src/renderer/features/player/context/player-context.tsx
@@ -56,7 +56,6 @@ export interface PlayerContext {
         itemType: LibraryItem,
         type: AddToQueueType,
         options?: AddToQueueOptions,
-        additionalFilter?: (song: Song) => boolean,
     ) => void;
     addToQueueByListQuery: (
         serverId: string,

--- a/src/renderer/store/player.store.ts
+++ b/src/renderer/store/player.store.ts
@@ -1837,6 +1837,10 @@ export type AddToQueueByUniqueId = {
     uniqueId: string;
 };
 
+export type AddToQueueOptions = {
+    filter?: (song: Song) => boolean;
+};
+
 export type AddToQueueType = AddToQueueByPlayType | AddToQueueByUniqueId;
 
 export async function addToQueueByData(type: AddToQueueType, data: Song[]) {


### PR DESCRIPTION
## Summary

When clicking play on an artist page, it shuffles all albums available. The problem is that the artist could have a single song present in a large album from another artist, filling the queue with songs that aren't from the artist you want to play.

This PR adds a filter in the album play button that excludes any song that doesn't match these conditions:
1. The album artist is present in the song's album artists list.
2. The album artist is present in the song's artist list.

Any other case is treated as unrelated and therefore excluded from the queue.

Closes #2023 