### PR TITLE
fix(subsonic): load artist favorite songs via getStarred

### DIFF
--- a/src/renderer/api/subsonic/subsonic-controller.get-favorite-songs.test.mjs
+++ b/src/renderer/api/subsonic/subsonic-controller.get-favorite-songs.test.mjs
@@ -1,0 +1,80 @@
+/**
+ * Regression for jeffvli/feishin#2415 — Subsonic artist Favorite Songs.
+ *
+ * Without favorite:true, getFavoriteSongs album-scrapes via getArtist+getAlbum and
+ * can omit starred tracks that getStarred still returns. Run:
+ *   node src/renderer/api/subsonic/subsonic-controller.get-favorite-songs.test.mjs
+ */
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const controllerSrc = readFileSync(join(__dirname, 'subsonic-controller.ts'), 'utf8');
+
+// --- Source contract: favorites branch must request the getStarred path ---
+const favoritesBlock = controllerSrc.split("else if user selects 'favorites'")[1]?.slice(0, 600);
+assert.ok(favoritesBlock, 'favorites branch missing');
+assert.match(
+    favoritesBlock,
+    /favorite:\s*true/,
+    'getFavoriteSongs favorites branch must pass favorite:true so getSongList uses getStarred',
+);
+assert.match(favoritesBlock, /artistIds:\s*\[\s*query\.artistId\s*\]/);
+
+// --- Behavioral model of the two getSongList strategies ---
+function albumScrapeFavoriteSongs({ artistAlbumsSongs, starredSongIds }) {
+    // Old path: only songs present on getArtist albums, then filter userFavorite
+    return artistAlbumsSongs.filter((s) => starredSongIds.has(s.id) || s.userFavorite);
+}
+
+function getStarredFavoriteSongs({ artistId, starredSongs }) {
+    // New path: getStarred universe, filter by albumArtists (mirrors getSongList favorite:true)
+    return starredSongs.filter((song) => song.albumArtists?.some((aa) => aa.id === artistId));
+}
+
+const artistId = 'artist-1';
+const onAlbum = {
+    albumArtists: [{ id: artistId }],
+    id: 'song-on-album',
+    userFavorite: true,
+};
+const starredMissingFromAlbums = {
+    albumArtists: [{ id: artistId }],
+    id: 'song-starred-missing',
+    userFavorite: true,
+};
+const otherArtistStar = {
+    albumArtists: [{ id: 'artist-2' }],
+    id: 'song-other',
+    userFavorite: true,
+};
+
+const starredSongs = [onAlbum, starredMissingFromAlbums, otherArtistStar];
+const artistAlbumsSongs = [onAlbum]; // album scrape never saw song-starred-missing
+const starredSongIds = new Set(starredSongs.map((s) => s.id));
+
+const oldResult = albumScrapeFavoriteSongs({
+    artistAlbumsSongs: artistAlbumsSongs.map((s) => ({
+        ...s,
+        userFavorite: starredSongIds.has(s.id),
+    })),
+    starredSongIds,
+});
+const newResult = getStarredFavoriteSongs({ artistId, starredSongs });
+
+assert.deepEqual(
+    oldResult.map((s) => s.id),
+    ['song-on-album'],
+    'precondition: album-scrape omits starred track not on artist albums',
+);
+assert.deepEqual(
+    newResult.map((s) => s.id).sort(),
+    ['song-on-album', 'song-starred-missing'],
+    'getStarred+artist filter must include starred track missing from album scrape',
+);
+assert.ok(!newResult.some((s) => s.id === 'song-other'));
+
+console.log('ok - subsonic getFavoriteSongs #2415');

--- a/src/renderer/api/subsonic/subsonic-controller.ts
+++ b/src/renderer/api/subsonic/subsonic-controller.ts
@@ -1005,10 +1005,13 @@ export const SubsonicController: InternalControllerEndpoint = {
         }
 
         // else if user selects 'favorites'
+        // Use getStarred (via favorite:true) instead of album-scraping so starred
+        // tracks missing from getArtist album lists are not omitted (#2415).
         const res = await SubsonicController.getSongList({
             apiClientProps,
             query: {
                 artistIds: [query.artistId],
+                favorite: true,
                 sortBy: SongListSort.FAVORITED,
                 sortOrder: SortOrder.DESC,
                 startIndex: 0,


### PR DESCRIPTION
## Summary

On the Subsonic adapter, artist page **Favorite Songs** called `getSongList` with `artistIds` only. That path album-scrapes via `getArtist` + `getAlbum`, then client-filters `userFavorite`. Starred tracks that are not present on the albums returned by `getArtist` are omitted (Navidrome-native is unaffected because it uses a different list API).

`getSongList` already supports `favorite: true` → `getStarred` plus an `albumArtists`/`artistIds` filter. The favorites branch now passes `favorite: true` (keeping `artistIds`) so starred songs for that artist come from `getStarred`.

## Test

```bash
node src/renderer/api/subsonic/subsonic-controller.get-favorite-songs.test.mjs
```

Fixes #2415