### PR TITLE
Fix macOS menu bar disappearing on screen wake

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,4 +1,10 @@
-import { BrowserWindow, Menu, MenuItemConstructorOptions, shell } from 'electron';
+import {
+    BrowserWindow,
+    Menu,
+    MenuItemConstructorOptions,
+    shell,
+    systemPreferences,
+} from 'electron';
 
 import packageJson from '../../package.json';
 
@@ -81,6 +87,21 @@ export default class MenuBuilder {
 
     constructor(mainWindow: BrowserWindow) {
         this.mainWindow = mainWindow;
+
+        if (process.platform === 'darwin') {
+            const subscription = systemPreferences.subscribeWorkspaceNotification(
+                'NSWorkspaceScreensDidWakeNotification',
+                () => {
+                    if (this.applicationMenu) {
+                        Menu.setApplicationMenu(this.applicationMenu);
+                    }
+                },
+            );
+
+            this.mainWindow.once('closed', () => {
+                systemPreferences.unsubscribeWorkspaceNotification(subscription);
+            });
+        }
     }
 
     buildDarwinTemplate({


### PR DESCRIPTION
On macOS, when the display wakes from sleep while the window is unfocused (e.g. on a secondary display), the menu bar can visually disappear.

Resolved by subscribing to `NSWorkspaceScreensDidWakeNotification` via `systemPreferences` to re-apply the application menu whenever the screen wakes, with proper cleanup when the window is closed.