### PR TITLE
fix(api): preserve Jellyfin single album songs

### DIFF
--- a/src/renderer/api/jellyfin/jellyfin-controller.ts
+++ b/src/renderer/api/jellyfin/jellyfin-controller.ts
@@ -546,11 +546,10 @@ export const JellyfinController: InternalControllerEndpoint = {
             throw new Error('Failed to get album detail');
         }
 
-        // Workaround for Jellyfin bug that returns items that share the same album name
-        const albumIdSet = new Set([query.id]);
-        const songs = songsRes.body.Items.filter((item) => albumIdSet.has(item.AlbumId!));
-
-        return jfNormalize.album({ ...res.body, Songs: songs }, apiClientProps.server);
+        return jfNormalize.album(
+            { ...res.body, Songs: songsRes.body.Items },
+            apiClientProps.server,
+        );
     },
     getAlbumList: async (args) => {
         const { apiClientProps, query } = args;


### PR DESCRIPTION
## Summary

Preserves the songs returned for a Jellyfin album detail request.

## Problem

The stale `AlbumId` filter removes tracks from some singles even though the request is already scoped by `ParentId`.

## Fix

Pass the parent-scoped response to album normalization unchanged.

Fixes #2076

## Testing

- `pnpm lint:staged`
- `pnpm typecheck`
