### PR TITLE
fix: prevent macOS menu bar disappearance

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -453,7 +453,10 @@ const hideMainWindowToTray = () => {
 };
 
 export const showMainWindow = () => {
-    if (!mainWindow || mainWindow.isDestroyed()) return;
+    if (!mainWindow || mainWindow.isDestroyed()) {
+        void createWindow(false);
+        return;
+    }
 
     if (mainWindow.isMinimized()) {
         mainWindow.restore();
@@ -821,16 +824,6 @@ async function createWindow(first = true): Promise<void> {
         mainWindow = null;
     });
 
-    if (isMacOS()) {
-        mainWindow.on('show', () => {
-            rebuildMainMenu();
-        });
-
-        mainWindow.on('hide', () => {
-            rebuildMainMenu();
-        });
-    }
-
     mainWindow.on('close', (event) => {
         if (mainWindow) {
             const bounds = mainWindow.getNormalBounds();
@@ -867,7 +860,7 @@ async function createWindow(first = true): Promise<void> {
         app.setAppUserModelId('org.jeffvli.feishin');
     }
 
-    menuBuilder = new MenuBuilder(mainWindow);
+    menuBuilder = new MenuBuilder(mainWindow, showMainWindow);
     rebuildMainMenu();
 
     // Open URLs in the user's browser

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -2,7 +2,6 @@ import { BrowserWindow, Menu, MenuItemConstructorOptions, shell } from 'electron
 
 import packageJson from '../../package.json';
 
-import { store } from '/@/main/features/core/settings';
 import { PlayerRepeat, PlayerStatus } from '/@/shared/types/types';
 
 export type MenuPlaybackState = {
@@ -78,9 +77,11 @@ export default class MenuBuilder {
     applicationMenu: Menu | null = null;
     developmentEnvironmentSetup = false;
     mainWindow: BrowserWindow;
+    showMainWindow: () => void;
 
-    constructor(mainWindow: BrowserWindow) {
+    constructor(mainWindow: BrowserWindow, showMainWindow: () => void) {
         this.mainWindow = mainWindow;
+        this.showMainWindow = showMainWindow;
     }
 
     buildDarwinTemplate({
@@ -176,26 +177,12 @@ export default class MenuBuilder {
         };
         const subMenuWindow: MenuItemConstructorOptions = {
             role: 'windowMenu',
-            submenu:
-                store.get('window_exit_to_tray') && !this.mainWindow.isVisible()
-                    ? [
-                          {
-                              type: 'separator',
-                          },
-                          {
-                              accelerator: 'CmdOrCtrl+0',
-                              click: () => {
-                                  if (this.mainWindow.isMinimized()) {
-                                      this.mainWindow.restore();
-                                  }
-                                  this.mainWindow.setSkipTaskbar(false);
-                                  this.mainWindow.show();
-                                  this.mainWindow.focus();
-                              },
-                              label: 'Feishin',
-                          },
-                      ]
-                    : undefined,
+            submenu: [
+                {
+                    click: this.showMainWindow,
+                    label: 'Show Feishin',
+                },
+            ],
         };
         const subMenuPlayback: MenuItemConstructorOptions = {
             label: 'Playback',


### PR DESCRIPTION
Fix the macOS menu bar disappearing after display wake or unlock.

#2269 introduced the Window-menu lifecycle handling that triggered the regression.

Keep “Show Feishin” in the native Window menu and recreate the main window when it was closed.