### PR TITLE
feat(ui): add playlists section to home page

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -647,7 +647,8 @@
             "newlyAdded": "Newly added releases",
             "recentlyPlayed": "Recently played",
             "recentlyReleased": "Recently released",
-            "title": "$t(common.home)"
+            "title": "$t(common.home)",
+            "playlists": "Playlists"
         },
         "itemDetail": {
             "tagConfiguration": "Tag configuration",

--- a/src/renderer/features/home/components/playlist-infinite-carousel.tsx
+++ b/src/renderer/features/home/components/playlist-infinite-carousel.tsx
@@ -1,0 +1,157 @@
+import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
+import { Suspense, useCallback, useMemo } from 'react';
+
+import { api } from '/@/renderer/api';
+import { queryKeys } from '/@/renderer/api/query-keys';
+import {
+    GridCarousel,
+    GridCarouselSkeletonFallback,
+    useGridCarouselContainerQuery,
+} from '/@/renderer/components/grid-carousel/grid-carousel-v2';
+import { DataRow, MemoizedItemCard } from '/@/renderer/components/item-card/item-card';
+import { useDefaultItemListControls } from '/@/renderer/components/item-list/helpers/item-list-controls';
+import { useGridRows } from '/@/renderer/components/item-list/helpers/use-grid-rows';
+import { useCurrentServerId } from '/@/renderer/store';
+import {
+    LibraryItem,
+    Playlist,
+    PlaylistListQuery,
+    PlaylistListResponse,
+    PlaylistListSort,
+    SortOrder,
+} from '/@/shared/types/domain-types';
+import { ItemListKey } from '/@/shared/types/types';
+
+interface PlaylistCarouselProps {
+    containerQuery?: ReturnType<typeof useGridCarouselContainerQuery>;
+    enableRefresh?: boolean;
+    query?: Partial<Omit<PlaylistListQuery, 'startIndex'>>;
+    title: React.ReactNode | string;
+}
+
+const BasePlaylistInfiniteCarousel = (props: PlaylistCarouselProps & { rows: DataRow[] }) => {
+    const { containerQuery, enableRefresh, query: additionalQuery, title } = props;
+    const {
+        data: playlists,
+        fetchNextPage,
+        hasNextPage,
+        isFetchingNextPage,
+        refetch,
+    } = usePlaylistListInfinite(PlaylistListSort.UPDATED_AT, SortOrder.DESC, 20, additionalQuery);
+
+    const controls = useDefaultItemListControls();
+
+    const cards = useMemo(() => {
+        const allItems = playlists?.pages.flatMap((page: PlaylistListResponse) => page.items) || [];
+
+        return allItems.map((playlist: Playlist) => ({
+            content: (
+                <MemoizedItemCard
+                    controls={controls}
+                    data={playlist}
+                    enableDrag={false}
+                    enableExpansion={false}
+                    imageFetchPriority="low"
+                    itemType={LibraryItem.PLAYLIST}
+                    rows={props.rows}
+                    type="poster"
+                    withControls
+                />
+            ),
+            id: playlist.id,
+        }));
+    }, [playlists, controls, props.rows]);
+
+    const handleNextPage = useCallback(() => {}, []);
+
+    const handlePrevPage = useCallback(() => {}, []);
+
+    const handleRefresh = useCallback(() => {
+        refetch();
+    }, [refetch]);
+
+    const firstPageItems = playlists?.pages[0]?.items || [];
+
+    if (firstPageItems.length === 0) {
+        return null;
+    }
+
+    return (
+        <GridCarousel
+            cards={cards}
+            containerQuery={containerQuery}
+            enableRefresh={enableRefresh}
+            hasNextPage={hasNextPage}
+            isFetchingNextPage={isFetchingNextPage}
+            loadNextPage={fetchNextPage}
+            onNextPage={handleNextPage}
+            onPrevPage={handlePrevPage}
+            onRefresh={handleRefresh}
+            placeholderItemType={LibraryItem.PLAYLIST}
+            placeholderRows={props.rows}
+            title={title}
+        />
+    );
+};
+
+export const PlaylistInfiniteCarousel = (props: PlaylistCarouselProps) => {
+    const rows = useGridRows(LibraryItem.PLAYLIST, ItemListKey.PLAYLIST);
+
+    return (
+        <Suspense
+            fallback={
+                <GridCarouselSkeletonFallback
+                    containerQuery={props.containerQuery}
+                    placeholderItemType={LibraryItem.PLAYLIST}
+                    placeholderRows={rows}
+                    title={props.title}
+                />
+            }
+        >
+            <BasePlaylistInfiniteCarousel {...props} rows={rows} />
+        </Suspense>
+    );
+};
+
+function usePlaylistListInfinite(
+    sortBy: PlaylistListSort,
+    sortOrder: SortOrder,
+    itemLimit: number,
+    additionalQuery?: Partial<Omit<PlaylistListQuery, 'startIndex'>>,
+) {
+    const serverId = useCurrentServerId();
+
+    const defaultQueryKey = queryKeys.playlists.list(serverId, {
+        sortBy,
+        sortOrder,
+        ...additionalQuery,
+    });
+
+    const query = useSuspenseInfiniteQuery<PlaylistListResponse>({
+        getNextPageParam: (lastPage, _allPages, lastPageParam) => {
+            if (lastPage.items.length < itemLimit) {
+                return undefined;
+            }
+
+            const nextPageParam = Number(lastPageParam) + itemLimit;
+
+            return String(nextPageParam);
+        },
+        initialPageParam: '0',
+        queryFn: ({ pageParam, signal }) => {
+            return api.controller.getPlaylistList({
+                apiClientProps: { serverId, signal },
+                query: {
+                    limit: itemLimit,
+                    sortBy,
+                    sortOrder,
+                    startIndex: Number(pageParam),
+                    ...additionalQuery,
+                },
+            });
+        },
+        queryKey: defaultQueryKey,
+    });
+
+    return query;
+}

--- a/src/renderer/features/home/routes/home-route.tsx
+++ b/src/renderer/features/home/routes/home-route.tsx
@@ -7,6 +7,7 @@ import { AlbumInfiniteCarousel } from '/@/renderer/features/albums/components/al
 import { AlbumInfiniteFeatureCarousel } from '/@/renderer/features/home/components/album-infinite-feature-carousel';
 import { AlbumInfiniteSingleFeatureCarousel } from '/@/renderer/features/home/components/album-infinite-single-feature-carousel';
 import { FeaturedGenres } from '/@/renderer/features/home/components/featured-genres';
+import { PlaylistInfiniteCarousel } from '/@/renderer/features/home/components/playlist-infinite-carousel';
 import { AnimatedPage } from '/@/renderer/features/shared/components/animated-page';
 import { LibraryContainer } from '/@/renderer/features/shared/components/library-container';
 import { LibraryHeaderBar } from '/@/renderer/features/shared/components/library-header-bar';
@@ -52,6 +53,10 @@ const HomeRoute = () => {
             sortOrder: SortOrder.DESC,
             title: t('page.home.mostPlayed'),
         },
+        [HomeItem.PLAYLISTS]: {
+            enableRefresh: true,
+            title: t('page.home.playlists'),
+        },
         [HomeItem.RANDOM]: {
             enableRefresh: true,
             itemType: LibraryItem.ALBUM,
@@ -85,7 +90,7 @@ const HomeRoute = () => {
     const sortedItems = homeItems.filter((item) => !item.disabled);
 
     const sortedCarousel = sortedItems
-        .filter((item) => item.id !== HomeItem.GENRES)
+        .filter((item) => item.id !== HomeItem.GENRES && item.id !== HomeItem.PLAYLISTS)
         .map((item) => ({
             ...carousels[item.id],
             uniqueId: item.id,
@@ -122,6 +127,17 @@ const HomeRoute = () => {
                         {sortedItems.map((item) => {
                             if (item.id === HomeItem.GENRES) {
                                 return <FeaturedGenres key="featured-genres" />;
+                            }
+
+                            if (item.id === HomeItem.PLAYLISTS) {
+                                return (
+                                    <PlaylistInfiniteCarousel
+                                        containerQuery={containerQuery}
+                                        enableRefresh={carousels[item.id].enableRefresh}
+                                        key="home-playlists"
+                                        title={t('page.home.playlists')}
+                                    />
+                                );
                             }
 
                             const carousel = sortedCarousel.find((c) => c.uniqueId === item.id);

--- a/src/renderer/features/settings/components/general/home-settings.tsx
+++ b/src/renderer/features/settings/components/general/home-settings.tsx
@@ -11,6 +11,7 @@ import {
 const HOME_ITEMS: Array<[string, string]> = [
     [HomeItem.GENRES, 'page.home.genres'],
     [HomeItem.RANDOM, 'page.home.explore'],
+    [HomeItem.PLAYLISTS, 'page.home.playlists'],
     [HomeItem.RECENTLY_PLAYED, 'page.home.recentlyPlayed'],
     [HomeItem.RECENTLY_ADDED, 'page.home.newlyAdded'],
     [HomeItem.RECENTLY_RELEASED, 'page.home.recentlyReleased'],

--- a/src/renderer/store/settings.store.ts
+++ b/src/renderer/store/settings.store.ts
@@ -70,6 +70,7 @@ const deepMergeIntoState = <T extends Record<string, any>>(
 const HomeItemSchema = z.enum([
     'genres',
     'mostPlayed',
+    'playlists',
     'random',
     'recentlyAdded',
     'recentlyPlayed',
@@ -960,6 +961,7 @@ export enum GenreTarget {
 export enum HomeItem {
     GENRES = 'genres',
     MOST_PLAYED = 'mostPlayed',
+    PLAYLISTS = 'playlists',
     RANDOM = 'random',
     RECENTLY_ADDED = 'recentlyAdded',
     RECENTLY_PLAYED = 'recentlyPlayed',
@@ -1233,6 +1235,7 @@ const defaultHomeItemOrder: HomeItem[] = [
     HomeItem.RECENTLY_RELEASED,
     HomeItem.RECENTLY_PLAYED,
     HomeItem.MOST_PLAYED,
+    HomeItem.PLAYLISTS,
 ];
 
 const homeItems = defaultHomeItemOrder.map((id) => ({
@@ -2901,10 +2904,17 @@ export const useSettingsStore = createWithEqualityFn<SettingsSlice>()(
                     }
                 }
 
+                if (version < 34) {
+                    state.general.homeItems.push({
+                        disabled: false,
+                        id: HomeItem.PLAYLISTS,
+                    });
+                }
+
                 return persistedState;
             },
             name: 'store_settings',
-            version: 33,
+            version: 34,
         },
     ),
 );


### PR DESCRIPTION
Adds a configurable "Playlists" section to the home page that renders the user's playlists in a carousel, reusing the existing home carousel infrastructure. Sorted by recently-updated (descending), matching the "recently added playlists or recently updated playlists" ask in #2166.

- New `HomeItem.PLAYLISTS` value; appears in `Settings -> Home page configuration` for reorder/disable like the other sections
- New `PlaylistInfiniteCarousel` component in `src/renderer/features/home/components/playlist-infinite-carousel.tsx`, modeled directly on `AlbumInfiniteCarousel` (`GridCarousel` + `MemoizedItemCard` + the existing `getPlaylistList` controller, so it works for Jellyfin (paged) and Navidrome/Subsonic (full list) without server-specific code)
- Settings-store migration v33 -> v34 appends the section for existing installs (enabled by default), following the same precedent used when `GENRES` was introduced (v13). Fully reorderable/dismissible from Home page configuration
- i18n: `page.home.playlists` (en; other locales are Weblate-managed)

**Per-user visibility**

Nothing is exposed client-side beyond what the server already returns: the carousel renders `getPlaylistList` output verbatim, so private playlists are only visible to their owner and public/shared playlists to everyone, exactly as each server defines it.

Verified against a live Navidrome 0.63 instance with two accounts: the second account's home shows only the public playlists, and the owner's private playlists never appear (checked both the API response and the rendered UI).

## Testing

- `pnpm lint` (typecheck:web + eslint + stylelint) passes clean
- Manually verified against Navidrome 0.63.2 via the built Docker image: section renders on home, respects home-configuration order/disabled state, playlist cards navigate to the playlist detail page
- Multi-user visibility verified as described above