### PR TITLE
feat(library): unify smart playlist editing with the edit button

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -34,7 +34,6 @@
         "removeFromPlaylist": "Remove from $t(entity.playlist, {\"count\": 1})",
         "removeFromQueue": "Remove from queue",
         "setRating": "Set rating",
-        "toggleSmartPlaylistEditor": "Toggle $t(entity.smartPlaylist) editor",
         "viewPlaylists": "View $t(entity.playlist, {\"count\": 2})",
         "viewMore": "View more",
         "openApplicationDirectory": "Open application directory",

--- a/src/renderer/features/playlists/components/playlist-detail-song-list-content.tsx
+++ b/src/renderer/features/playlists/components/playlist-detail-song-list-content.tsx
@@ -302,9 +302,9 @@ const PlaylistDetailTrackViewContent = ({ data }: { data: PlaylistSongListRespon
 };
 
 const PlaylistDetailSongList = ({ data }: { data: PlaylistSongListResponse }) => {
-    const { displayMode, mode } = useListContext();
+    const { displayMode, isSmartPlaylist, mode } = useListContext();
 
-    if (mode !== 'edit' && displayMode === LibraryItem.ALBUM) {
+    if ((mode !== 'edit' || isSmartPlaylist) && displayMode === LibraryItem.ALBUM) {
         return <PlaylistDetailAlbumView data={data} />;
     }
 

--- a/src/renderer/features/playlists/components/playlist-detail-song-list-header-filters.tsx
+++ b/src/renderer/features/playlists/components/playlist-detail-song-list-header-filters.tsx
@@ -1,6 +1,6 @@
 import { openContextModal } from '@mantine/modals';
 import { useQuery } from '@tanstack/react-query';
-import { useCallback, useMemo } from 'react';
+import { ReactNode, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
@@ -48,6 +48,7 @@ import { LibraryItem, Song, SongListSort, SortOrder } from '/@/shared/types/doma
 import { ItemListKey } from '/@/shared/types/types';
 
 interface PlaylistDetailSongListHeaderFiltersProps {
+    editActions?: ReactNode;
     isSmartPlaylist?: boolean;
 }
 
@@ -115,6 +116,7 @@ const PlaylistSongListFiltersModal = () => {
 };
 
 export const PlaylistDetailSongListHeaderFilters = ({
+    editActions,
     isSmartPlaylist,
 }: PlaylistDetailSongListHeaderFiltersProps) => {
     const { t } = useTranslation();
@@ -156,7 +158,7 @@ export const PlaylistDetailSongListHeaderFilters = ({
 
     const { ref: containerRef, ...breakpoints } = useContainerQuery();
 
-    const isViewEditMode = !isSmartPlaylist && (breakpoints.isSm || isAlbumMode);
+    const isViewEditMode = breakpoints.isSm || isAlbumMode;
     const isEditMode = mode === 'edit';
 
     const [collapsed, setCollapsed] = useLocalStorage<boolean>({
@@ -202,7 +204,12 @@ export const PlaylistDetailSongListHeaderFilters = ({
                 <MoreButton onClick={handleMore} />
             </Group>
             <Group gap="sm" wrap="nowrap">
-                {isViewEditMode && <SaveAndReplaceButton mode={mode} songIds={tracks} />}
+                {isViewEditMode &&
+                    (isSmartPlaylist ? (
+                        editActions
+                    ) : (
+                        <SaveAndReplaceButton mode={mode} songIds={tracks} />
+                    ))}
                 {isViewEditMode && (
                     <Button
                         onClick={() => setMode?.(mode === 'edit' ? 'view' : 'edit')}

--- a/src/renderer/features/playlists/components/playlist-detail-song-list-header.tsx
+++ b/src/renderer/features/playlists/components/playlist-detail-song-list-header.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { useCallback, useMemo } from 'react';
+import { ReactNode, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useParams } from 'react-router';
 
@@ -40,10 +40,9 @@ import { ServerFeature } from '/@/shared/types/features-types';
 import { Play } from '/@/shared/types/types';
 
 interface PlaylistDetailSongListHeaderProps {
+    editActions?: ReactNode;
     isSmartPlaylist?: boolean;
-    onConvertToSmart?: () => void;
     onDelete?: () => void;
-    onToggleQueryBuilder?: () => void;
 }
 
 function ImageUploadOverlay({
@@ -102,6 +101,7 @@ function ImageUploadOverlay({
 }
 
 export const PlaylistDetailSongListHeader = ({
+    editActions,
     isSmartPlaylist,
 }: PlaylistDetailSongListHeaderProps) => {
     const { t } = useTranslation();
@@ -242,7 +242,10 @@ export const PlaylistDetailSongListHeader = ({
                 </LibraryHeader>
             )}
             <FilterBar>
-                <PlaylistDetailSongListHeaderFilters isSmartPlaylist={isSmartPlaylist} />
+                <PlaylistDetailSongListHeaderFilters
+                    editActions={editActions}
+                    isSmartPlaylist={isSmartPlaylist}
+                />
             </FilterBar>
         </Stack>
     );

--- a/src/renderer/features/playlists/components/playlist-detail-song-list-header.tsx
+++ b/src/renderer/features/playlists/components/playlist-detail-song-list-header.tsx
@@ -42,7 +42,6 @@ import { Play } from '/@/shared/types/types';
 interface PlaylistDetailSongListHeaderProps {
     editActions?: ReactNode;
     isSmartPlaylist?: boolean;
-    onDelete?: () => void;
 }
 
 function ImageUploadOverlay({

--- a/src/renderer/features/playlists/components/playlist-query-editor.tsx
+++ b/src/renderer/features/playlists/components/playlist-query-editor.tsx
@@ -1,14 +1,13 @@
 import type { UseSuspenseQueryResult } from '@tanstack/react-query';
 
-import { closeAllModals, openModal } from '@mantine/modals';
-import { useCallback, useMemo, useState } from 'react';
+import { openModal } from '@mantine/modals';
+import { forwardRef, useCallback, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import {
     PlaylistQueryBuilder,
     PlaylistQueryBuilderRef,
 } from '/@/renderer/features/playlists/components/playlist-query-builder';
-import { useUpdatePlaylist } from '/@/renderer/features/playlists/mutations/update-playlist-mutation';
 import { convertQueryGroupToNDQuery } from '/@/renderer/features/playlists/utils';
 import { JsonPreview } from '/@/renderer/features/shared/components/json-preview';
 import { Box } from '/@/shared/components/box/box';
@@ -17,7 +16,6 @@ import { Flex } from '/@/shared/components/flex/flex';
 import { Group } from '/@/shared/components/group/group';
 import { Icon } from '/@/shared/components/icon/icon';
 import { JsonInput } from '/@/shared/components/json-input/json-input';
-import { ConfirmModal } from '/@/shared/components/modal/modal';
 import { ScrollArea } from '/@/shared/components/scroll-area/scroll-area';
 import { SegmentedControl } from '/@/shared/components/segmented-control/segmented-control';
 import { Stack } from '/@/shared/components/stack/stack';
@@ -27,30 +25,20 @@ import { SongListSort } from '/@/shared/types/domain-types';
 
 export interface PlaylistQueryEditorProps {
     detailQuery: UseSuspenseQueryResult<any, Error>;
-    handleSave: (
-        filter: Record<string, any>,
-        extraFilters: {
-            limit?: number;
-            limitPercent?: number;
-            sortBy?: string[];
-            sortOrder?: string;
-        },
-    ) => void;
-    handleSaveAs: (
-        filter: Record<string, any>,
-        extraFilters: {
-            limit?: number;
-            limitPercent?: number;
-            sortBy?: string[];
-            sortOrder?: string;
-        },
-    ) => void;
-    isQueryBuilderExpanded: boolean;
-    onToggleExpand: () => void;
     playlistId: string;
-    queryBuilderRef: React.RefObject<null | PlaylistQueryBuilderRef>;
-    updatePlaylistMutation: ReturnType<typeof useUpdatePlaylist>;
 }
+
+export type PlaylistQueryEditorRef = {
+    getFiltersForSave: () => null | {
+        extraFilters: {
+            limit?: number;
+            limitPercent?: number;
+            sortBy?: string[];
+            sortOrder?: string;
+        };
+        filter: Record<string, any>;
+    };
+};
 
 type AppliedJsonState = {
     limit?: number;
@@ -95,239 +83,187 @@ const parseRulesJsonToSaveArgs = (
     };
 };
 
-export const PlaylistQueryEditor = ({
-    detailQuery,
-    handleSave,
-    handleSaveAs,
-    isQueryBuilderExpanded,
-    onToggleExpand,
-    playlistId,
-    queryBuilderRef,
-    updatePlaylistMutation,
-}: PlaylistQueryEditorProps) => {
-    const { t } = useTranslation();
+export const PlaylistQueryEditor = forwardRef<PlaylistQueryEditorRef, PlaylistQueryEditorProps>(
+    ({ detailQuery, playlistId }, ref) => {
+        const { t } = useTranslation();
+        const queryBuilderRef = useRef<PlaylistQueryBuilderRef>(null);
 
-    const [editorMode, setEditorMode] = useState<EditorMode>('builder');
-    const [jsonText, setJsonText] = useState('');
-    const [appliedJsonState, setAppliedJsonState] = useState<AppliedJsonState | null>(null);
+        const [editorMode, setEditorMode] = useState<EditorMode>('builder');
+        const [jsonText, setJsonText] = useState('');
+        const [appliedJsonState, setAppliedJsonState] = useState<AppliedJsonState | null>(null);
 
-    const getFiltersForSave = useCallback((): null | {
-        extraFilters: {
-            limit?: number;
-            limitPercent?: number;
-            sortBy?: string[];
-            sortOrder?: string;
-        };
-        filter: Record<string, any>;
-    } => {
-        if (editorMode === 'json') {
-            try {
-                const parsed = JSON.parse(jsonText) as Record<string, any>;
-                const { extraFilters, filter } = parseRulesJsonToSaveArgs(parsed);
-                return { extraFilters, filter };
-            } catch {
-                return null;
-            }
-        }
-        const filters = queryBuilderRef.current?.getFilters();
-        if (!filters) return null;
-        return {
-            extraFilters: filters.extraFilters,
-            filter: convertQueryGroupToNDQuery(filters.filters),
-        };
-    }, [editorMode, jsonText, queryBuilderRef]);
-
-    const openPreviewModal = useCallback(() => {
-        const payload = getFiltersForSave();
-        if (!payload) {
+        const getFiltersForSave = useCallback((): ReturnType<
+            PlaylistQueryEditorRef['getFiltersForSave']
+        > => {
             if (editorMode === 'json') {
-                toast.error({ message: t('error.invalidJson') });
-            }
-            return;
-        }
-        const previewValue = {
-            ...payload.filter,
-            ...(payload.extraFilters.limit != null && { limit: payload.extraFilters.limit }),
-            ...(payload.extraFilters.limitPercent != null && {
-                limitPercent: payload.extraFilters.limitPercent,
-            }),
-            ...(payload.extraFilters.sortBy?.[0] && { sort: payload.extraFilters.sortBy[0] }),
-        };
-        openModal({
-            children: <JsonPreview value={previewValue} />,
-            size: 'xl',
-            title: t('common.preview'),
-        });
-    }, [editorMode, getFiltersForSave, t]);
-
-    const openSaveAndReplaceModal = useCallback(() => {
-        if (!isQueryBuilderExpanded) return;
-        const payload = getFiltersForSave();
-        if (!payload) {
-            if (editorMode === 'json') {
-                toast.error({ message: t('error.invalidJson') });
-            }
-            return;
-        }
-        openModal({
-            children: (
-                <ConfirmModal
-                    onConfirm={() => {
-                        handleSave(payload.filter, payload.extraFilters);
-                        closeAllModals();
-                    }}
-                >
-                    <Text>{t('common.areYouSure')}</Text>
-                </ConfirmModal>
-            ),
-            title: t('common.saveAndReplace'),
-        });
-    }, [editorMode, getFiltersForSave, handleSave, isQueryBuilderExpanded, t]);
-
-    const parseSortBy = useCallback((): string[] => {
-        const sort = detailQuery?.data?.rules?.sort;
-        // Handle new syntax: comma-separated with +/- prefix
-        // e.g., "+album,-year" -> return as single string in array
-        if (typeof sort === 'string') {
-            // Check if it's new syntax (has +/- prefix or commas)
-            if (sort.includes(',') || sort.startsWith('+') || sort.startsWith('-')) {
-                return [sort];
-            }
-            // Old syntax: single field, convert to new format with default order
-            const order = detailQuery?.data?.rules?.order || 'asc';
-            const prefix = order === 'desc' ? '-' : '+';
-            return [`${prefix}${sort}`];
-        }
-        if (Array.isArray(sort)) {
-            // If array, check if first item has +/- prefix
-            if (
-                sort.length > 0 &&
-                typeof sort[0] === 'string' &&
-                (sort[0].startsWith('+') || sort[0].startsWith('-'))
-            ) {
-                return sort;
-            }
-            // Old array format, convert to new format
-            const order = detailQuery?.data?.rules?.order || 'asc';
-            const prefix = order === 'desc' ? '-' : '+';
-            return sort.map((s) => `${prefix}${s}`);
-        }
-        return ['+dateAdded'];
-    }, [detailQuery?.data?.rules?.order, detailQuery?.data?.rules?.sort]);
-
-    const parseSortOrder = useCallback((): 'asc' | 'desc' => {
-        const sort = detailQuery?.data?.rules?.sort;
-        if (typeof sort === 'string' && sort.startsWith('-')) {
-            return 'desc';
-        }
-        // Fall back to old order field or default
-        return detailQuery?.data?.rules?.order || 'asc';
-    }, [detailQuery?.data?.rules?.order, detailQuery?.data?.rules?.sort]);
-
-    const appliedQuery = appliedJsonState?.query;
-    const detailQueryRules = detailQuery?.data?.rules;
-    const effectiveQuery = useMemo(
-        () =>
-            appliedQuery ??
-            (detailQueryRules?.all
-                ? { all: detailQueryRules.all }
-                : detailQueryRules?.any
-                  ? { any: detailQueryRules.any }
-                  : detailQueryRules),
-        [appliedQuery, detailQueryRules],
-    );
-    const effectiveLimit = appliedJsonState?.limit ?? detailQuery?.data?.rules?.limit;
-    const effectiveLimitPercent =
-        appliedJsonState?.limitPercent ?? detailQuery?.data?.rules?.limitPercent;
-
-    const appliedSort = appliedJsonState?.sort;
-    const effectiveSortBy = useMemo(
-        () => (appliedSort ? [appliedSort] : parseSortBy()) as SongListSort | SongListSort[],
-        [appliedSort, parseSortBy],
-    );
-    const effectiveSortOrder = appliedJsonState?.sort
-        ? appliedJsonState.sort.startsWith('-')
-            ? 'desc'
-            : 'asc'
-        : parseSortOrder();
-
-    const handleEditorModeChange = useCallback(
-        (value: string) => {
-            const nextMode = value as EditorMode;
-            if (nextMode === 'json') {
-                const filters = queryBuilderRef.current?.getFilters();
-                if (filters) {
-                    setJsonText(JSON.stringify(serializeFiltersToRulesJson(filters), null, 2));
-                } else {
-                    const fallback: Record<string, any> = effectiveQuery
-                        ? { ...effectiveQuery }
-                        : { all: [] };
-                    if (effectiveLimit != null) fallback.limit = effectiveLimit;
-                    if (effectiveLimitPercent != null)
-                        fallback.limitPercent = effectiveLimitPercent;
-                    if (effectiveSortBy?.[0]) fallback.sort = effectiveSortBy[0];
-                    if (!fallback.sort) fallback.sort = '+dateAdded';
-                    setJsonText(JSON.stringify(fallback, null, 2));
+                try {
+                    const parsed = JSON.parse(jsonText) as Record<string, any>;
+                    const { extraFilters, filter } = parseRulesJsonToSaveArgs(parsed);
+                    return { extraFilters, filter };
+                } catch {
+                    toast.error({ message: t('error.invalidJson') });
+                    return null;
                 }
-                setEditorMode('json');
-            } else {
-                if (editorMode === 'json') {
-                    try {
-                        const parsed = JSON.parse(jsonText) as Record<string, any>;
-                        const rootKey = parsed.all ? 'all' : 'any';
-                        if (!parsed[rootKey] || !Array.isArray(parsed[rootKey])) {
-                            throw new Error('Invalid rules structure');
-                        }
-                        setAppliedJsonState({
-                            limit: parsed.limit,
-                            limitPercent: parsed.limitPercent,
-                            query: { [rootKey]: parsed[rootKey] },
-                            sort: parsed.sort,
-                        });
-                    } catch {
-                        toast.error({
-                            message: t('error.invalidJson'),
-                        });
-                        return;
+            }
+            const filters = queryBuilderRef.current?.getFilters();
+            if (!filters) return null;
+            return {
+                extraFilters: filters.extraFilters,
+                filter: convertQueryGroupToNDQuery(filters.filters),
+            };
+        }, [editorMode, jsonText, t]);
+
+        useImperativeHandle(ref, () => ({ getFiltersForSave }), [getFiltersForSave]);
+
+        const openPreviewModal = useCallback(() => {
+            const payload = getFiltersForSave();
+            if (!payload) return;
+            const previewValue = {
+                ...payload.filter,
+                ...(payload.extraFilters.limit != null && { limit: payload.extraFilters.limit }),
+                ...(payload.extraFilters.limitPercent != null && {
+                    limitPercent: payload.extraFilters.limitPercent,
+                }),
+                ...(payload.extraFilters.sortBy?.[0] && { sort: payload.extraFilters.sortBy[0] }),
+            };
+            openModal({
+                children: <JsonPreview value={previewValue} />,
+                size: 'xl',
+                title: t('common.preview'),
+            });
+        }, [getFiltersForSave, t]);
+
+        const parseSortBy = useCallback((): string[] => {
+            const sort = detailQuery?.data?.rules?.sort;
+            // Handle new syntax: comma-separated with +/- prefix
+            // e.g., "+album,-year" -> return as single string in array
+            if (typeof sort === 'string') {
+                // Check if it's new syntax (has +/- prefix or commas)
+                if (sort.includes(',') || sort.startsWith('+') || sort.startsWith('-')) {
+                    return [sort];
+                }
+                // Old syntax: single field, convert to new format with default order
+                const order = detailQuery?.data?.rules?.order || 'asc';
+                const prefix = order === 'desc' ? '-' : '+';
+                return [`${prefix}${sort}`];
+            }
+            if (Array.isArray(sort)) {
+                // If array, check if first item has +/- prefix
+                if (
+                    sort.length > 0 &&
+                    typeof sort[0] === 'string' &&
+                    (sort[0].startsWith('+') || sort[0].startsWith('-'))
+                ) {
+                    return sort;
+                }
+                // Old array format, convert to new format
+                const order = detailQuery?.data?.rules?.order || 'asc';
+                const prefix = order === 'desc' ? '-' : '+';
+                return sort.map((s) => `${prefix}${s}`);
+            }
+            return ['+dateAdded'];
+        }, [detailQuery?.data?.rules?.order, detailQuery?.data?.rules?.sort]);
+
+        const parseSortOrder = useCallback((): 'asc' | 'desc' => {
+            const sort = detailQuery?.data?.rules?.sort;
+            if (typeof sort === 'string' && sort.startsWith('-')) {
+                return 'desc';
+            }
+            // Fall back to old order field or default
+            return detailQuery?.data?.rules?.order || 'asc';
+        }, [detailQuery?.data?.rules?.order, detailQuery?.data?.rules?.sort]);
+
+        const appliedQuery = appliedJsonState?.query;
+        const detailQueryRules = detailQuery?.data?.rules;
+        const effectiveQuery = useMemo(
+            () =>
+                appliedQuery ??
+                (detailQueryRules?.all
+                    ? { all: detailQueryRules.all }
+                    : detailQueryRules?.any
+                      ? { any: detailQueryRules.any }
+                      : detailQueryRules),
+            [appliedQuery, detailQueryRules],
+        );
+        const effectiveLimit = appliedJsonState?.limit ?? detailQuery?.data?.rules?.limit;
+        const effectiveLimitPercent =
+            appliedJsonState?.limitPercent ?? detailQuery?.data?.rules?.limitPercent;
+
+        const appliedSort = appliedJsonState?.sort;
+        const effectiveSortBy = useMemo(
+            () => (appliedSort ? [appliedSort] : parseSortBy()) as SongListSort | SongListSort[],
+            [appliedSort, parseSortBy],
+        );
+        const effectiveSortOrder = appliedJsonState?.sort
+            ? appliedJsonState.sort.startsWith('-')
+                ? 'desc'
+                : 'asc'
+            : parseSortOrder();
+
+        const handleEditorModeChange = useCallback(
+            (value: string) => {
+                const nextMode = value as EditorMode;
+                if (nextMode === 'json') {
+                    const filters = queryBuilderRef.current?.getFilters();
+                    if (filters) {
+                        setJsonText(JSON.stringify(serializeFiltersToRulesJson(filters), null, 2));
+                    } else {
+                        const fallback: Record<string, any> = effectiveQuery
+                            ? { ...effectiveQuery }
+                            : { all: [] };
+                        if (effectiveLimit != null) fallback.limit = effectiveLimit;
+                        if (effectiveLimitPercent != null)
+                            fallback.limitPercent = effectiveLimitPercent;
+                        if (effectiveSortBy?.[0]) fallback.sort = effectiveSortBy[0];
+                        if (!fallback.sort) fallback.sort = '+dateAdded';
+                        setJsonText(JSON.stringify(fallback, null, 2));
                     }
-                }
-                setEditorMode('builder');
-            }
-        },
-        [
-            editorMode,
-            effectiveLimit,
-            effectiveLimitPercent,
-            effectiveQuery,
-            effectiveSortBy,
-            jsonText,
-            queryBuilderRef,
-            t,
-        ],
-    );
-
-    return (
-        <div
-            className="query-editor-container"
-            style={{ borderTop: '1px solid var(--theme-colors-border)' }}
-        >
-            <Stack gap={0} h="100%" mah="30dvh" p="sm" w="100%">
-                <Group justify="space-between" wrap="nowrap">
-                    <Group gap="sm" wrap="nowrap">
-                        <Button
-                            leftSection={
-                                <Icon
-                                    icon={isQueryBuilderExpanded ? 'arrowDownS' : 'arrowUpS'}
-                                    size="lg"
-                                />
+                    setEditorMode('json');
+                } else {
+                    if (editorMode === 'json') {
+                        try {
+                            const parsed = JSON.parse(jsonText) as Record<string, any>;
+                            const rootKey = parsed.all ? 'all' : 'any';
+                            if (!parsed[rootKey] || !Array.isArray(parsed[rootKey])) {
+                                throw new Error('Invalid rules structure');
                             }
-                            onClick={onToggleExpand}
-                            size="sm"
-                            variant="subtle"
-                        >
-                            {t('form.queryEditor.title')}
-                        </Button>
-                        {isQueryBuilderExpanded && (
+                            setAppliedJsonState({
+                                limit: parsed.limit,
+                                limitPercent: parsed.limitPercent,
+                                query: { [rootKey]: parsed[rootKey] },
+                                sort: parsed.sort,
+                            });
+                        } catch {
+                            toast.error({
+                                message: t('error.invalidJson'),
+                            });
+                            return;
+                        }
+                    }
+                    setEditorMode('builder');
+                }
+            },
+            [
+                editorMode,
+                effectiveLimit,
+                effectiveLimitPercent,
+                effectiveQuery,
+                effectiveSortBy,
+                jsonText,
+                queryBuilderRef,
+                t,
+            ],
+        );
+
+        return (
+            <div
+                className="query-editor-container"
+                style={{ borderTop: '1px solid var(--theme-colors-border)' }}
+            >
+                <Stack gap={0} h="100%" mah="30dvh" p="sm" w="100%">
+                    <Group justify="space-between" wrap="nowrap">
+                        <Group gap="sm" wrap="nowrap">
+                            <Text fw={500}>{t('form.queryEditor.title')}</Text>
                             <SegmentedControl
                                 data={[
                                     {
@@ -351,82 +287,53 @@ export const PlaylistQueryEditor = ({
                                 size="xs"
                                 value={editorMode}
                             />
-                        )}
-                    </Group>
-                    <Group gap="xs">
+                        </Group>
                         <Button onClick={openPreviewModal} size="sm" variant="subtle">
                             {t('common.preview')}
                         </Button>
-                        <Button
-                            disabled={!isQueryBuilderExpanded}
-                            leftSection={<Icon icon="save" />}
-                            loading={updatePlaylistMutation?.isPending}
-                            onClick={() => {
-                                if (!isQueryBuilderExpanded) return;
-                                const payload = getFiltersForSave();
-                                if (payload) {
-                                    handleSaveAs(payload.filter, payload.extraFilters);
-                                } else if (editorMode === 'json') {
-                                    toast.error({
-                                        message: t('error.invalidJson'),
-                                    });
-                                }
-                            }}
-                            size="sm"
-                            variant="subtle"
-                        >
-                            {t('common.saveAs')}
-                        </Button>
-                        <Button
-                            disabled={!isQueryBuilderExpanded}
-                            leftSection={<Icon color="error" icon="save" />}
-                            onClick={openSaveAndReplaceModal}
-                            size="sm"
-                            variant="subtle"
-                        >
-                            {t('common.saveAndReplace')}
-                        </Button>
                     </Group>
-                </Group>
-                <Box
-                    py="md"
-                    style={{
-                        display: isQueryBuilderExpanded ? 'flex' : 'none',
-                        flex: 1,
-                        minHeight: 0,
-                        overflow: 'hidden',
-                    }}
-                >
-                    {editorMode === 'builder' ? (
-                        <PlaylistQueryBuilder
-                            key={JSON.stringify(appliedJsonState ?? detailQuery?.data?.rules)}
-                            limit={effectiveLimit}
-                            limitPercent={effectiveLimitPercent}
-                            playlistId={playlistId}
-                            query={effectiveQuery}
-                            ref={queryBuilderRef}
-                            sortBy={effectiveSortBy}
-                            sortOrder={effectiveSortOrder}
-                        />
-                    ) : (
-                        <ScrollArea style={{ flex: 1, minHeight: 0 }}>
-                            <JsonInput
-                                autosize
-                                minRows={8}
-                                onChange={(value) => setJsonText(value)}
-                                placeholder='{ "all": [], "limit": 100, "sort": "+dateAdded" }'
-                                size="lg"
-                                spellCheck={false}
-                                style={{
-                                    flex: 1,
-                                    minHeight: 0,
-                                }}
-                                value={jsonText}
+                    <Box
+                        py="md"
+                        style={{
+                            display: 'flex',
+                            flex: 1,
+                            minHeight: 0,
+                            overflow: 'hidden',
+                        }}
+                    >
+                        {editorMode === 'builder' ? (
+                            <PlaylistQueryBuilder
+                                key={JSON.stringify(appliedJsonState ?? detailQuery?.data?.rules)}
+                                limit={effectiveLimit}
+                                limitPercent={effectiveLimitPercent}
+                                playlistId={playlistId}
+                                query={effectiveQuery}
+                                ref={queryBuilderRef}
+                                sortBy={effectiveSortBy}
+                                sortOrder={effectiveSortOrder}
                             />
-                        </ScrollArea>
-                    )}
-                </Box>
-            </Stack>
-        </div>
-    );
-};
+                        ) : (
+                            <ScrollArea style={{ flex: 1, minHeight: 0 }}>
+                                <JsonInput
+                                    autosize
+                                    minRows={8}
+                                    onChange={(value) => setJsonText(value)}
+                                    placeholder='{ "all": [], "limit": 100, "sort": "+dateAdded" }'
+                                    size="lg"
+                                    spellCheck={false}
+                                    style={{
+                                        flex: 1,
+                                        minHeight: 0,
+                                    }}
+                                    value={jsonText}
+                                />
+                            </ScrollArea>
+                        )}
+                    </Box>
+                </Stack>
+            </div>
+        );
+    },
+);
+
+PlaylistQueryEditor.displayName = 'PlaylistQueryEditor';

--- a/src/renderer/features/playlists/routes/playlist-detail-song-list-route.tsx
+++ b/src/renderer/features/playlists/routes/playlist-detail-song-list-route.tsx
@@ -9,8 +9,10 @@ import { playlistsQueries } from '/@/renderer/features/playlists/api/playlists-a
 import { ClientSideSongFilters } from '/@/renderer/features/playlists/components/client-side-song-filters';
 import { PlaylistDetailSongListContent } from '/@/renderer/features/playlists/components/playlist-detail-song-list-content';
 import { PlaylistDetailSongListHeader } from '/@/renderer/features/playlists/components/playlist-detail-song-list-header';
-import { PlaylistQueryBuilderRef } from '/@/renderer/features/playlists/components/playlist-query-builder';
-import { PlaylistQueryEditor } from '/@/renderer/features/playlists/components/playlist-query-editor';
+import {
+    PlaylistQueryEditor,
+    PlaylistQueryEditorRef,
+} from '/@/renderer/features/playlists/components/playlist-query-editor';
 import { SaveAsPlaylistForm } from '/@/renderer/features/playlists/components/save-as-playlist-form';
 import { usePlaylistSongListFilters } from '/@/renderer/features/playlists/hooks/use-playlist-song-list-filters';
 import { useDeletePlaylist } from '/@/renderer/features/playlists/mutations/delete-playlist-mutation';
@@ -28,6 +30,7 @@ import {
 import { ActionIcon } from '/@/shared/components/action-icon/action-icon';
 import { Button } from '/@/shared/components/button/button';
 import { Group } from '/@/shared/components/group/group';
+import { Icon } from '/@/shared/components/icon/icon';
 import { ConfirmModal } from '/@/shared/components/modal/modal';
 import { ScrollArea } from '/@/shared/components/scroll-area/scroll-area';
 import { Spinner } from '/@/shared/components/spinner/spinner';
@@ -80,6 +83,8 @@ const PlaylistDetailSongListRoute = () => {
     });
     const deletePlaylistMutation = useDeletePlaylist({});
     const updatePlaylistMutation = useUpdatePlaylist({});
+    const [mode, setMode] = useState<'edit' | 'view'>('view');
+    const queryEditorRef = useRef<PlaylistQueryEditorRef>(null);
 
     const handleSave = (
         filter: Record<string, any>,
@@ -120,6 +125,7 @@ const PlaylistDetailSongListRoute = () => {
             {
                 onSuccess: () => {
                     toast.success({ message: 'Playlist has been saved' });
+                    setMode('view');
                 },
             },
         );
@@ -174,6 +180,25 @@ const PlaylistDetailSongListRoute = () => {
         });
     };
 
+    const openSaveAndReplaceModal = () => {
+        const payload = queryEditorRef.current?.getFiltersForSave();
+        if (!payload) return;
+
+        openModal({
+            children: (
+                <ConfirmModal
+                    onConfirm={() => {
+                        handleSave(payload.filter, payload.extraFilters);
+                        closeAllModals();
+                    }}
+                >
+                    <Text>{t('common.areYouSure')}</Text>
+                </ConfirmModal>
+            ),
+            title: t('common.saveAndReplace'),
+        });
+    };
+
     const openDeletePlaylistModal = () => {
         openModal({
             children: (
@@ -211,19 +236,6 @@ const PlaylistDetailSongListRoute = () => {
         detailQuery?.data?.rules && server?.type === ServerType.NAVIDROME,
     );
 
-    const [showQueryBuilder, setShowQueryBuilder] = useState(false);
-    const [isQueryBuilderExpanded, setIsQueryBuilderExpanded] = useState(false);
-    const queryBuilderRef = useRef<PlaylistQueryBuilderRef>(null);
-
-    const handleToggleExpand = () => {
-        setIsQueryBuilderExpanded((prev) => !prev);
-    };
-
-    const handleToggleShowQueryBuilder = () => {
-        setShowQueryBuilder((prev) => !prev);
-        setIsQueryBuilderExpanded(true);
-    };
-
     const playlistTarget = usePlaylistTarget();
     const displayMode: LibraryItem.ALBUM | LibraryItem.SONG =
         playlistTarget === PlaylistTarget.ALBUM ? LibraryItem.ALBUM : LibraryItem.SONG;
@@ -232,7 +244,6 @@ const PlaylistDetailSongListRoute = () => {
 
     const [itemCount, setItemCount] = useState<number | undefined>(undefined);
     const [listData, setListData] = useState<unknown[]>([]);
-    const [mode, setMode] = useState<'edit' | 'view'>('view');
     const [isSidebarOpen, setIsSidebarOpen] = usePageSidebar(listKey);
 
     const providerValue = useMemo(() => {
@@ -264,19 +275,40 @@ const PlaylistDetailSongListRoute = () => {
         setIsSidebarOpen,
     ]);
 
+    const isEditingSmartPlaylist = isSmartPlaylist && mode === 'edit';
+
+    const editActions = isEditingSmartPlaylist && (
+        <>
+            <Button
+                leftSection={<Icon icon="save" />}
+                onClick={() => {
+                    const payload = queryEditorRef.current?.getFiltersForSave();
+                    if (payload) handleSaveAs(payload.filter, payload.extraFilters);
+                }}
+                size="sm"
+                variant="subtle"
+            >
+                {t('common.saveAs')}
+            </Button>
+            <Button
+                leftSection={<Icon color="error" icon="save" />}
+                loading={updatePlaylistMutation.isPending}
+                onClick={openSaveAndReplaceModal}
+                size="sm"
+                variant="subtle"
+            >
+                {t('common.saveAndReplace')}
+            </Button>
+        </>
+    );
+
     return (
         <AnimatedPage key={`playlist-detail-songList-${playlistId}`}>
             <ListContext.Provider value={providerValue}>
                 <PlaylistDetailSongListHeader
+                    editActions={editActions}
                     isSmartPlaylist={!!isSmartPlaylist}
-                    onConvertToSmart={() => {
-                        if (!isSmartPlaylist) {
-                            setShowQueryBuilder(true);
-                            setIsQueryBuilderExpanded(true);
-                        }
-                    }}
                     onDelete={() => openDeletePlaylistModal()}
-                    onToggleQueryBuilder={handleToggleShowQueryBuilder}
                 />
 
                 <ListWithSidebarContainer>
@@ -289,16 +321,11 @@ const PlaylistDetailSongListRoute = () => {
                         <PlaylistDetailSongListContent />
                     </Suspense>
                 </ListWithSidebarContainer>
-                {(isSmartPlaylist || showQueryBuilder) && (
+                {isEditingSmartPlaylist && (
                     <PlaylistQueryEditor
                         detailQuery={detailQuery}
-                        handleSave={handleSave}
-                        handleSaveAs={handleSaveAs}
-                        isQueryBuilderExpanded={isQueryBuilderExpanded}
-                        onToggleExpand={handleToggleExpand}
                         playlistId={playlistId}
-                        queryBuilderRef={queryBuilderRef}
-                        updatePlaylistMutation={updatePlaylistMutation}
+                        ref={queryEditorRef}
                     />
                 )}
             </ListContext.Provider>
@@ -307,9 +334,11 @@ const PlaylistDetailSongListRoute = () => {
 };
 
 const PlaylistDetailSongListRouteWithBoundary = () => {
+    const { playlistId } = useParams() as { playlistId: string };
+
     return (
         <PageErrorBoundary>
-            <PlaylistDetailSongListRoute />
+            <PlaylistDetailSongListRoute key={playlistId} />
         </PageErrorBoundary>
     );
 };

--- a/src/renderer/features/playlists/routes/playlist-detail-song-list-route.tsx
+++ b/src/renderer/features/playlists/routes/playlist-detail-song-list-route.tsx
@@ -15,7 +15,6 @@ import {
 } from '/@/renderer/features/playlists/components/playlist-query-editor';
 import { SaveAsPlaylistForm } from '/@/renderer/features/playlists/components/save-as-playlist-form';
 import { usePlaylistSongListFilters } from '/@/renderer/features/playlists/hooks/use-playlist-song-list-filters';
-import { useDeletePlaylist } from '/@/renderer/features/playlists/mutations/delete-playlist-mutation';
 import { useUpdatePlaylist } from '/@/renderer/features/playlists/mutations/update-playlist-mutation';
 import { AnimatedPage } from '/@/renderer/features/shared/components/animated-page';
 import { ListWithSidebarContainer } from '/@/renderer/features/shared/components/list-with-sidebar-container';
@@ -81,7 +80,6 @@ const PlaylistDetailSongListRoute = () => {
     const detailQuery = useSuspenseQuery({
         ...playlistsQueries.detail({ query: { id: playlistId }, serverId: server?.id }),
     });
-    const deletePlaylistMutation = useDeletePlaylist({});
     const updatePlaylistMutation = useUpdatePlaylist({});
     const [mode, setMode] = useState<'edit' | 'view'>('view');
     const queryEditorRef = useRef<PlaylistQueryEditorRef>(null);
@@ -199,39 +197,6 @@ const PlaylistDetailSongListRoute = () => {
         });
     };
 
-    const openDeletePlaylistModal = () => {
-        openModal({
-            children: (
-                <ConfirmModal
-                    onConfirm={() => {
-                        if (!detailQuery?.data) return;
-                        deletePlaylistMutation?.mutate(
-                            {
-                                apiClientProps: { serverId: detailQuery.data._serverId },
-                                query: { id: detailQuery.data.id },
-                            },
-                            {
-                                onError: (err) => {
-                                    toast.error({
-                                        message: err.message,
-                                        title: t('error.genericError'),
-                                    });
-                                },
-                                onSuccess: () => {
-                                    navigate(AppRoute.PLAYLISTS, { replace: true });
-                                },
-                            },
-                        );
-                        closeAllModals();
-                    }}
-                >
-                    <Text>Are you sure you want to delete this playlist?</Text>
-                </ConfirmModal>
-            ),
-            title: t('form.deletePlaylist.title'),
-        });
-    };
-
     const isSmartPlaylist = Boolean(
         detailQuery?.data?.rules && server?.type === ServerType.NAVIDROME,
     );
@@ -308,7 +273,6 @@ const PlaylistDetailSongListRoute = () => {
                 <PlaylistDetailSongListHeader
                     editActions={editActions}
                     isSmartPlaylist={!!isSmartPlaylist}
-                    onDelete={() => openDeletePlaylistModal()}
                 />
 
                 <ListWithSidebarContainer>


### PR DESCRIPTION
Smart playlists are now edited the same way as standard playlists: the EDIT button in the filter bar opens the query editor below the list, and Cancel closes it. The always-visible "Query editor" panel at the bottom of smart playlists is gone saving space.

* Save As and Save and replace sit next to Cancel in the filter bar, in the same position as the standard playlist's Save and replace. Preview stays in the panel.
* Save and replace returns to view mode on success, matching standard playlists.
* The detail route is keyed by playlist id, so edit mode no longer leaks when navigating between playlists.
* A smart playlist in album view keeps the album list while editing rules.

I also removed the never-wired convert/toggle/delete props and handler on the detail route and header, and an unused `toggleSmartPlaylistEditor` locale key. The Save and replace button now shows the update spinner instead of Save As.

This addresses https://github.com/jeffvli/feishin/issues/2021.

Here's the new view without the panel:
<img width="1397" height="1128" alt="no_panel" src="https://github.com/user-attachments/assets/147fd36f-6c98-4856-9099-eaa06c856e90" />

And this is what you see when you hit "EDIT":
<img width="1445" height="1106" alt="editing" src="https://github.com/user-attachments/assets/10f2df82-52fc-4319-885c-7685010530d2" />
